### PR TITLE
Incorporate another round of wizard remarks

### DIFF
--- a/llm-prompts/basic-integration/1.3-conclude.md
+++ b/llm-prompts/basic-integration/1.3-conclude.md
@@ -14,6 +14,8 @@ The wizard has completed a deep integration of your project. [Detailed summary o
 
 [table of events/descriptions/files]
 
+[description of changes to components, if any]
+
 ## Next steps
 
 We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:

--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -18,6 +18,7 @@ commandments:
   nextjs:
     # Initialization
     - For Next.js 15.3+, initialize PostHog in instrumentation-client.ts for the simplest setup
+    - PostHogProvider is no longer needed for Next.js 15.3+ - use the global posthog-js singleton instead by importing posthog from 'posthog-js'. Hooks that would normally require PostHogProvider will now work without it, simply by importing and using the hooks directly.
 
   nextjs-feature-flags:
     # Client-side feature flags

--- a/transformation-config/skills/integration/description.md
+++ b/transformation-config/skills/integration/description.md
@@ -19,6 +19,7 @@ The example project shows the target implementation pattern. Consult the documen
 - **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
 - **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
 - **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+- **You must read files before editing**: Otherwise the edit tool will fail
 
 ## Framework guidelines
 


### PR DESCRIPTION
Next.js and PostHogProvider regularly confuse the agent, but the solution is clear: don't use it at all, the singleton is good to go thanks to `instrumentation-client.ts`. This enhances the commandments to clarify this point, with a reminder not to bother with edits until a file has been read (surprising source of friction!).

Also adds a changes explainer to the setup report, which will be especially helpful if the wizard trims out a PostHogProvider.