### PR TITLE
fix: route /array/* to assets origin

### DIFF
--- a/basics/next-app-router/next.config.ts
+++ b/basics/next-app-router/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
         destination: "https://us-assets.i.posthog.com/static/:path*",
       },
       {
+        source: "/ingest/array/:path*",
+        destination: "https://us-assets.i.posthog.com/array/:path*",
+      },
+      {
         source: "/ingest/:path*",
         destination: "https://us.i.posthog.com/:path*",
       },

--- a/basics/next-pages-router/next.config.ts
+++ b/basics/next-pages-router/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
         destination: "https://us-assets.i.posthog.com/static/:path*",
       },
       {
+        source: "/ingest/array/:path*",
+        destination: "https://us-assets.i.posthog.com/array/:path*",
+      },
+      {
         source: "/ingest/:path*",
         destination: "https://us.i.posthog.com/:path*",
       },

--- a/basics/react-react-router-7-framework/vite.config.ts
+++ b/basics/react-react-router-7-framework/vite.config.ts
@@ -13,6 +13,16 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
+        '/ingest/static': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
+        '/ingest/array': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
         '/ingest': {
           target: env.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
           changeOrigin: true,

--- a/basics/react-tanstack-router-code-based/vite.config.ts
+++ b/basics/react-tanstack-router-code-based/vite.config.ts
@@ -17,6 +17,16 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
+        '/ingest/static': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
+        '/ingest/array': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
         '/ingest': {
           target: env.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
           changeOrigin: true,

--- a/basics/react-tanstack-router-file-based/vite.config.ts
+++ b/basics/react-tanstack-router-file-based/vite.config.ts
@@ -25,6 +25,16 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
+        '/ingest/static': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
+        '/ingest/array': {
+          target: 'https://us-assets.i.posthog.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ingest/, ''),
+        },
         '/ingest': {
           target: env.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
           changeOrigin: true,

--- a/basics/sveltekit/src/hooks.server.ts
+++ b/basics/sveltekit/src/hooks.server.ts
@@ -7,9 +7,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	// Reverse proxy for PostHog - route /ingest requests to PostHog servers
 	if (pathname.startsWith('/ingest')) {
-		const hostname = pathname.startsWith('/ingest/static/')
-			? 'us-assets.i.posthog.com'
-			: 'us.i.posthog.com';
+		const useAssetHost = pathname.startsWith('/ingest/static/') || pathname.startsWith('/ingest/array/')
+		const hostname = useAssetHost ? 'us-assets.i.posthog.com' : 'us.i.posthog.com';
 
 		const url = new URL(event.request.url);
 		url.protocol = 'https:';

--- a/basics/tanstack-start/vite.config.ts
+++ b/basics/tanstack-start/vite.config.ts
@@ -14,6 +14,18 @@ const config = defineConfig({
   ],
   server: {
     proxy: {
+      '/ingest/static': {
+        target: 'https://us-assets.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ingest/, ''),
+        secure: false,
+      },
+      '/ingest/array': {
+        target: 'https://us-assets.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ingest/, ''),
+        secure: false,
+      },
       '/ingest': {
         target: 'https://us.i.posthog.com',
         changeOrigin: true,

--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -3,6 +3,9 @@
 # Skills collect all commandments matching their tags
 
 commandments:
+  javascript:
+    - When a reverse proxy is configured, both /static/* AND /array/* must route to the assets origin (us-assets.i.posthog.com or eu-assets.i.posthog.com).
+
   react:
     # PostHog-specific
     - For feature flags, use useFeatureFlagEnabled() or useFeatureFlagPayload() hooks - they handle loading states and external sync automatically

--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -33,6 +33,7 @@ commandments:
     - Client-side hooks may return undefined initially while flags load - handle this loading state
 
   javascript_web:
+    - When a reverse proxy is configured, both /static/* AND /array/* must route to the assets origin (us-assets.i.posthog.com or eu-assets.i.posthog.com).
     - Remember that source code is available in the node_modules directory
     - Check package.json for type checking or build scripts to validate changes
     - posthog-js is the JavaScript SDK package name


### PR DESCRIPTION
related: https://github.com/PostHog/posthog.com/pull/16081

fixes /array/* path routing in context-mill example apps - was routing through the main API origin, which strips cache-control headers, causing browsers to cache stale SDK config for hours or days and breaking feature flags, session recording conditions, and sampling rates

also adds a javascript commandment so all client-side JS frameworks get the rule in one place. (note: javascript_web uses a separate tag so it gets its own copy)