### PR TITLE
fix: use projects-get MCP tool for env var setup in instrument skills

### DIFF
--- a/transformation-config/skills/omnibus/instrument-error-tracking/description.md
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/description.md
@@ -36,7 +36,10 @@ STEP 6: Upload source maps (frontend/mobile only).
   - Follow the platform-specific reference for upload configuration (build plugins, CI scripts, etc.).
 
 STEP 7: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 8: Verify and clean up.

--- a/transformation-config/skills/omnibus/instrument-feature-flags/description.md
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/description.md
@@ -32,7 +32,10 @@ STEP 5: Instrument the feature.
   - You must read a file immediately before attempting to write it.
 
 STEP 6: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/transformation-config/skills/omnibus/instrument-integration/description.md
+++ b/transformation-config/skills/omnibus/instrument-integration/description.md
@@ -30,7 +30,10 @@ STEP 5: Identify users.
   - If both frontend and backend exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to the server-side code.
 
 STEP 6: Set up environment variables.
-  - Store the PostHog API key and host in environment variables (e.g. `.env` or framework-specific env files).
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file (e.g. `.env.local` for Next.js, `.env` for others) using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 7: Verify and clean up.

--- a/transformation-config/skills/omnibus/instrument-llm-analytics/description.md
+++ b/transformation-config/skills/omnibus/instrument-llm-analytics/description.md
@@ -36,7 +36,10 @@ STEP 5: Link to users.
   - Associate LLM generations with identified users via distinct IDs when possible.
 
 STEP 6: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys then set_env_values to configure the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/transformation-config/skills/omnibus/instrument-logs/description.md
+++ b/transformation-config/skills/omnibus/instrument-logs/description.md
@@ -37,7 +37,11 @@ STEP 6: Add structured properties.
   - Prefer structured log formats with key-value properties over plain text messages.
 
 STEP 7: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys then set_env_values to configure the PostHog API key, host, and OpenTelemetry endpoint.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - For the OpenTelemetry endpoint, use `https://us.i.posthog.com/v1` (US) or `https://eu.i.posthog.com/v1` (EU).
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/transformation-config/skills/omnibus/instrument-product-analytics/description.md
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/description.md
@@ -45,7 +45,10 @@ STEP 8: Add error tracking.
   - Add PostHog exception capture error tracking to relevant files, particularly around critical user flows and API boundaries.
 
 STEP 9: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 10: Verify and clean up.


### PR DESCRIPTION
## Problem

The instrument skills reference a non-existent `env-file-tools` MCP server for setting up PostHog environment variables. This means the env var step silently fails for all users.

Meanwhile, the PostHog MCP server is already connected and authenticated via OAuth, and its `projects-get` tool returns the `api_token` for every project.

## Changes

Updated the env var setup step in all 6 omnibus instrument skill `description.md` files to:

1. Check if PostHog env vars already exist (skip if so)
2. Call `projects-get` from the PostHog MCP to retrieve the `api_token`
3. Handle multi-project orgs (ask user which project)
4. Gracefully fall back to asking the user if MCP isn't connected
5. Default to US/EU Cloud host URLs
6. Write values using framework-specific env var naming conventions

Mirrors https://github.com/PostHog/ai-plugin/pull/25 but applied upstream so the daily sync propagates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)