### PR TITLE
Opt-in continuations and preambles at config.yaml

### DIFF
--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -146,6 +146,7 @@ function expandSkillGroups(config, configDir) {
                 _template: template,
                 _sharedDocs: sharedDocs,
                 _examplePaths: [...baseExamplePaths, ...normalizeExamplePaths(variation.example_paths)],
+                _references: group.references || null,
                 _group: key,
             });
         }
@@ -490,10 +491,42 @@ async function generateSkill({
         const localReferences = fs.readdirSync(sourceReferencesDir, { withFileTypes: true })
             .filter(entry => entry.isFile() && entry.name.endsWith('.md'));
 
+        const refsConfig = skill._references || {};
+
+        // Build continuation map when opted in via config
+        const continuationMap = new Map();
+        if (refsConfig.continuations) {
+            const sequentialPattern = /^(\d+)-(.+)\.md$/;
+            const sequential = localReferences
+                .filter(entry => sequentialPattern.test(entry.name))
+                .sort((a, b) => {
+                    const aNum = parseInt(a.name.match(sequentialPattern)[1], 10);
+                    const bNum = parseInt(b.name.match(sequentialPattern)[1], 10);
+                    return aNum - bNum;
+                });
+
+            for (let i = 0; i < sequential.length - 1; i++) {
+                continuationMap.set(sequential[i].name, sequential[i + 1].name);
+            }
+        }
+
         for (const reference of localReferences) {
             const sourcePath = path.join(sourceReferencesDir, reference.name);
-            const content = fs.readFileSync(sourcePath, 'utf8');
+            let content = fs.readFileSync(sourcePath, 'utf8');
             const headingMatch = content.match(/^#\s+(.+)$/m);
+
+            // Inject preamble after the first heading if configured
+            if (refsConfig.preamble && headingMatch) {
+                const headingEnd = content.indexOf(headingMatch[0]) + headingMatch[0].length;
+                content = content.slice(0, headingEnd) + '\n\n' + refsConfig.preamble + content.slice(headingEnd);
+            }
+
+            // Auto-append continuation for sequential references
+            const nextFile = continuationMap.get(reference.name);
+            if (nextFile) {
+                content = content.replace(/\n+---\n+\*\*Upon completion, continue with:\*\*\s*\[.*?\]\(.*?\)\s*$/, '');
+                content += `\n\n---\n\n**Upon completion, continue with:** [${nextFile}](${nextFile})`;
+            }
 
             fs.writeFileSync(
                 path.join(referencesDir, reference.name),

--- a/transformation-config/skills/audit/config.yaml
+++ b/transformation-config/skills/audit/config.yaml
@@ -2,6 +2,9 @@ type: docs-only
 template: description.md
 description: Audit an existing PostHog integration for correctness and best practices
 tags: [best-practices]
+references:
+  continuations: true
+  preamble: "**Read ONLY this file.** Do not read any other reference file until this one tells you to."
 shared_docs:
   - https://posthog.com/docs/getting-started/identify-users.md
   - https://posthog.com/docs/product-analytics/best-practices.md

--- a/transformation-config/skills/audit/references/1-seed.md
+++ b/transformation-config/skills/audit/references/1-seed.md
@@ -1,7 +1,5 @@
 # Step 1 — Seed the ledger
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly one action: open `.posthog-audit-checks.json` at the project root with the seeded installation entries.
 
 ## TodoWrite
@@ -37,6 +35,3 @@ Status to report in this phase:
 
 - Seeding installation checks
 
----
-
-**Upon completion, continue with:** [2-manifests.md](2-manifests.md)

--- a/transformation-config/skills/audit/references/10-report.md
+++ b/transformation-config/skills/audit/references/10-report.md
@@ -1,7 +1,5 @@
 # Step 8 — Generate the audit report
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 The audit report is rendered **directly from `.posthog-audit-checks.json`** — that file is the source of truth.
 
 ## Action

--- a/transformation-config/skills/audit/references/2-manifests.md
+++ b/transformation-config/skills/audit/references/2-manifests.md
@@ -1,7 +1,5 @@
 # Step 2 — Scan manifests
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly one action: scan dependency manifests and resolve `sdk-installed` and `sdk-up-to-date`.
 
 ## TodoWrite
@@ -35,6 +33,3 @@ Status to report in this phase:
 - Scanning manifests
 - Resolved SDK install + version checks
 
----
-
-**Upon completion, continue with:** [3-init.md](3-init.md)

--- a/transformation-config/skills/audit/references/3-init.md
+++ b/transformation-config/skills/audit/references/3-init.md
@@ -1,7 +1,5 @@
 # Step 3 — Locate init sites
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly one action: find the PostHog init site for each runtime. No evaluation, no resolving — that happens in Step 5.
 
 ## TodoWrite
@@ -23,6 +21,3 @@ Status to report in this phase:
 
 - Locating init sites
 
----
-
-**Upon completion, continue with:** [4-config.md](4-config.md)

--- a/transformation-config/skills/audit/references/4-config.md
+++ b/transformation-config/skills/audit/references/4-config.md
@@ -1,7 +1,5 @@
 # Step 4 — Read the bounded config set
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly one action: read a fixed, short list of config files. This list is the complete remaining evidence base for the installation phase.
 
 ## TodoWrite
@@ -31,6 +29,3 @@ Status to report in this phase:
 
 - Reading bounded config set
 
----
-
-**Upon completion, continue with:** [5-resolve.md](5-resolve.md)

--- a/transformation-config/skills/audit/references/5-resolve.md
+++ b/transformation-config/skills/audit/references/5-resolve.md
@@ -1,7 +1,5 @@
 # Step 5 — Resolve `init-correct`
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly one action: evaluate `init-correct` against the evidence already in your reasoning, then `Write` the updated ledger.
 
 **No new Reads, Greps, Globs, or Bash searches in this step.** Every rule below is evaluated against the manifests (Step 2), init-site files (Step 3), and bounded config set (Step 4).
@@ -39,6 +37,3 @@ Status to report in this phase:
 - Resolving installation checks
 - Found [N] installation issues ([X] errors, [Y] warnings, [Z] suggestions)
 
----
-
-**Upon completion, continue with:** [6-identify-seed.md](6-identify-seed.md)

--- a/transformation-config/skills/audit/references/6-identify-seed.md
+++ b/transformation-config/skills/audit/references/6-identify-seed.md
@@ -1,7 +1,5 @@
 # Step 6 — Seed identification checks
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly two actions:
 
 1. `Read` the **PostHog best practices** skill's `description.md` to find which reference file covers identification (look for the file describing `identify()` / `distinct_id` / `reset()` / `group()` rules), then `Read` that file. It is the source of truth for identification rules — do not invent rules that aren't there.
@@ -31,6 +29,3 @@ When in doubt, include the entry — Step 7 will resolve N/A entries to `pass` w
 - Reading identification rules from best-practices
 - Seeding identification checks
 
----
-
-**Upon completion, continue with:** [7-identify.md](7-identify.md)

--- a/transformation-config/skills/audit/references/7-identify.md
+++ b/transformation-config/skills/audit/references/7-identify.md
@@ -1,7 +1,5 @@
 # Step 7 — Resolve identification checks
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 The identification entries are already seeded in `.posthog-audit-checks.json` from Step 6, with ids of the form `<file-stem>:<line>` pointing back into the best-practices skill. This step is pure scan + resolve — no new entries are added.
 
 ## Action
@@ -35,6 +33,3 @@ Run targeted Greps for `posthog.identify(`, `posthog.reset(`, `posthog.group(`, 
 - Checking cross-runtime distinct_id consistency
 - Found [N] identification issues ([X] errors, [Y] warnings, [Z] suggestions)
 
----
-
-**Upon completion, continue with:** [8-capture-seed.md](8-capture-seed.md)

--- a/transformation-config/skills/audit/references/8-capture-seed.md
+++ b/transformation-config/skills/audit/references/8-capture-seed.md
@@ -1,7 +1,5 @@
 # Step 8 — Seed capture / flags / errors / replay / experiments checks
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 This step has exactly two actions:
 
 1. `Read` the **PostHog best practices** skill's `description.md` to find every reference file it ships, then `Read` each one (one Read per file, no re-reads). Skip the file already read in Step 6.
@@ -33,6 +31,3 @@ When in doubt, include the entry — Step 9 will resolve N/A entries (e.g. flag 
 - Reading capture / flags / errors / replay / experiments rules from best-practices
 - Seeding capture checks
 
----
-
-**Upon completion, continue with:** [9-capture.md](9-capture.md)

--- a/transformation-config/skills/audit/references/9-capture.md
+++ b/transformation-config/skills/audit/references/9-capture.md
@@ -1,7 +1,5 @@
 # Step 9 — Resolve capture / flags / errors / replay / experiments checks
 
-**Read ONLY this file.** Do not read any other reference file until this one tells you to.
-
 The Phase 3 entries are already seeded in `.posthog-audit-checks.json` from Step 8, with ids of the form `<file-stem>:<line>` pointing back into the best-practices skill. This step is pure scan + resolve — no new entries are added.
 
 ## Action
@@ -38,6 +36,3 @@ Run **one** scan per area — a single Grep with the right patterns, then Read t
 - Scanning experiments (if applicable)
 - Found [N] usage issues ([X] errors, [Y] warnings, [Z] suggestions)
 
----
-
-**Upon completion, continue with:** [10-report.md](10-report.md)


### PR DESCRIPTION
Probably won't be the last time we need this sort of structure, so let's give config.yaml the power to opt-in continuations and insert preambles.