### PR TITLE
feat(logs): register React Native and JS web variants in wizard

### DIFF
--- a/transformation-config/skills/logs/config.yaml
+++ b/transformation-config/skills/logs/config.yaml
@@ -11,6 +11,12 @@ shared_docs:
   - https://posthog.com/docs/logs/link-session-replay.md
   - https://posthog.com/docs/logs/debug-logs-mcp.md
 variants:
+  - id: javascript
+    display_name: Web (JavaScript)
+    tags: [javascript_web, javascript]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/javascript.md
+
   - id: nextjs
     display_name: Next.js
     tags: [nextjs, javascript]

--- a/transformation-config/skills/logs/config.yaml
+++ b/transformation-config/skills/logs/config.yaml
@@ -47,6 +47,12 @@ variants:
     docs_urls:
       - https://posthog.com/docs/logs/installation/datadog.md
 
+  - id: react-native
+    display_name: React Native
+    tags: [react-native, javascript]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/react-native.md
+
   - id: other
     display_name: Other Languages
     tags: []


### PR DESCRIPTION
## Summary

Adds the two SDKs that ship first-class logs support to `transformation-config/skills/logs/config.yaml` so the installation wizard can pre-populate context for them:

- **React Native** — new in `posthog-react-native@4.44.0`. Install page: https://posthog.com/docs/logs/installation/react-native (shipping in [posthog.com#16679](https://github.com/PostHog/posthog.com/pull/16679), backed by [posthog-js#3480](https://github.com/PostHog/posthog-js/pull/3480)).
- **JavaScript Web** — already shipped in `posthog-js`. Install page: https://posthog.com/docs/logs/installation/javascript. Pre-existing gap in the wizard config; adding alongside RN.

Follow-up to @dustinbyrne's review on PostHog/posthog.com#16679.

Need to merge first: https://github.com/PostHog/posthog.com/pull/16679

## Test plan

- [ ] Wizard surfaces React Native and Web (JavaScript) as logs install options.
- [ ] Pre-populated docs match the linked install pages.
