### PR TITLE
chore: migrate context-mill to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@posthog/context-mill",
   "version": "1.2.0",
   "private": true,
+  "type": "module",
   "description": "PostHog Context Mill: assembling and packaging context for AI agents and LLMs",
   "scripts": {
     "build": "node scripts/build.js",
@@ -15,6 +16,9 @@
   "devDependencies": {
     "archiver": "^7.0.1",
     "vitest": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=20.11.0"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,13 +9,13 @@
  * - Individual skill ZIPs ({skill-id}.zip)
  */
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-const archiver = require('archiver');
-const { generateAllSkills, loadSkillsConfig, fetchDoc } = require('./lib/skill-generator');
-const { generateMarketplace } = require('./lib/marketplace-generator');
-const { REPO_URL } = require('./lib/constants');
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import archiver from 'archiver';
+import { generateAllSkills, loadSkillsConfig, fetchDoc } from './lib/skill-generator.js';
+import { generateMarketplace } from './lib/marketplace-generator.js';
+import { REPO_URL } from './lib/constants.js';
 
 const BUILD_VERSION = process.env.BUILD_VERSION || 'dev';
 
@@ -148,7 +148,7 @@ async function main() {
     console.log('Building resources...');
     console.log(`Version: ${BUILD_VERSION}\n`);
 
-    const repoRoot = path.join(__dirname, '..');
+    const repoRoot = path.join(import.meta.dirname, '..');
     const configDir = path.join(repoRoot, 'transformation-config');
     const distDir = path.join(repoRoot, 'dist');
     const skillsDir = path.join(distDir, 'skills');

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -15,22 +15,22 @@
  *   pnpm run dev:local-resources (and update wrangler --var flag)
  */
 
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
-const { spawn } = require('child_process');
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
 
 const PORT = process.env.PORT || 8765;
-const DIST_DIR = path.join(__dirname, '..', 'dist');
+const DIST_DIR = path.join(import.meta.dirname, '..', 'dist');
 const SKILLS_ZIP_PATH = path.join(DIST_DIR, 'skills-mcp-resources.zip');
 const SKILLS_DIR = path.join(DIST_DIR, 'skills');
 
 // Directories to watch for changes
 const WATCH_DIRS = [
-    path.join(__dirname, '..', 'llm-prompts'),
-    path.join(__dirname, '..', 'transformation-config'),
-    path.join(__dirname, '..', 'mcp-commands'),
-    path.join(__dirname, '..', 'basics'),
+    path.join(import.meta.dirname, '..', 'llm-prompts'),
+    path.join(import.meta.dirname, '..', 'transformation-config'),
+    path.join(import.meta.dirname, '..', 'mcp-commands'),
+    path.join(import.meta.dirname, '..', 'basics'),
 ];
 
 let isRebuilding = false;
@@ -53,7 +53,7 @@ function rebuild() {
 
     const buildProcess = spawn('npm', ['run', 'build'], {
         stdio: 'inherit',
-        cwd: path.join(__dirname, '..'),
+        cwd: path.join(import.meta.dirname, '..'),
         env: { ...process.env, SKILLS_BASE_URL: localSkillsUrl },
         shell: true
     });
@@ -83,11 +83,11 @@ function setupWatchers() {
 
     WATCH_DIRS.forEach(dir => {
         if (!fs.existsSync(dir)) {
-            console.log(`   ⚠️  ${path.relative(path.join(__dirname, '..'), dir)} (not found, skipping)`);
+            console.log(`   ⚠️  ${path.relative(path.join(import.meta.dirname, '..'), dir)} (not found, skipping)`);
             return;
         }
 
-        console.log(`   📁 ${path.relative(path.join(__dirname, '..'), dir)}`);
+        console.log(`   📁 ${path.relative(path.join(import.meta.dirname, '..'), dir)}`);
 
         // Watch recursively
         fs.watch(dir, { recursive: true }, (eventType, filename) => {
@@ -200,7 +200,7 @@ async function main() {
     await new Promise((resolve) => {
         const buildProcess = spawn('npm', ['run', 'build'], {
             stdio: 'inherit',
-            cwd: path.join(__dirname, '..'),
+            cwd: path.join(import.meta.dirname, '..'),
             env: { ...process.env, SKILLS_BASE_URL: localSkillsUrl },
             shell: true
         });

--- a/scripts/lib/constants.js
+++ b/scripts/lib/constants.js
@@ -2,8 +2,4 @@
  * Shared constants for build scripts
  */
 
-const REPO_URL = 'https://github.com/PostHog/context-mill';
-
-module.exports = {
-    REPO_URL,
-};
+export const REPO_URL = 'https://github.com/PostHog/context-mill';

--- a/scripts/lib/example-processor.js
+++ b/scripts/lib/example-processor.js
@@ -5,11 +5,11 @@
  * Reads configuration from transformation-config/skip-patterns.yaml
  */
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-const { composePlugins, ignoreLinePlugin, ignoreFilePlugin, ignoreBlockPlugin } = require('../plugins/index');
-const { REPO_URL } = require('./constants');
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { composePlugins, ignoreLinePlugin, ignoreFilePlugin, ignoreBlockPlugin } from '../plugins/index.js';
+import { REPO_URL } from './constants.js';
 
 /**
  * Load skip patterns from YAML config
@@ -182,7 +182,7 @@ function processExample({ examplePath, displayName, id, repoRoot, skipPatterns, 
  */
 const defaultPlugins = [ignoreFilePlugin, ignoreBlockPlugin, ignoreLinePlugin];
 
-module.exports = {
+export {
     loadSkipPatterns,
     mergeSkipPatterns,
     processExample,

--- a/scripts/lib/marketplace-generator.js
+++ b/scripts/lib/marketplace-generator.js
@@ -6,9 +6,9 @@
  * Configuration is driven by transformation-config/marketplace.yaml.
  */
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
 
 /**
  * Load marketplace config from YAML
@@ -253,4 +253,4 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
     return { marketplaceDir, pluginCount: allPluginNames.length, skillCount: allSkillEntries.length };
 }
 
-module.exports = { generateMarketplace };
+export { generateMarketplace };

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -8,11 +8,11 @@
  * - Commandments (based on tags)
  */
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-const matter = require('gray-matter');
-const { processExample, loadSkipPatterns, mergeSkipPatterns, defaultPlugins } = require('./example-processor');
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import matter from 'gray-matter';
+import { processExample, loadSkipPatterns, mergeSkipPatterns, defaultPlugins } from './example-processor.js';
 
 /**
  * Load YAML config file
@@ -670,7 +670,7 @@ async function generateAllSkills({
     }));
 }
 
-module.exports = {
+export {
     loadSkillsConfig,
     loadCommandments,
     loadSkillTemplate,

--- a/scripts/lib/tests/skill-config-loader.test.js
+++ b/scripts/lib/tests/skill-config-loader.test.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import yaml from 'js-yaml';
 
-const { loadSkillsConfig } = require('../skill-generator.js');
+import { loadSkillsConfig } from '../skill-generator.js';
 
 function createFixture(tree, baseDir) {
     for (const [name, content] of Object.entries(tree)) {

--- a/scripts/lib/tests/skill-generator-references-folder.test.js
+++ b/scripts/lib/tests/skill-generator-references-folder.test.js
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, mkdtempSync, rmSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-const { expandSkillGroups, generateSkill } = require('../skill-generator.js');
+import { expandSkillGroups, generateSkill } from '../skill-generator.js';
 
 function createFixture(tree, baseDir) {
     for (const [name, content] of Object.entries(tree)) {

--- a/scripts/lib/tests/skill-group-expander.test.js
+++ b/scripts/lib/tests/skill-group-expander.test.js
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-const { expandSkillGroups } = require('../skill-generator.js');
+import { expandSkillGroups } from '../skill-generator.js';
 
 function createFixture(tree, baseDir) {
     for (const [name, content] of Object.entries(tree)) {

--- a/scripts/lib/tests/skill-template-loader.test.js
+++ b/scripts/lib/tests/skill-template-loader.test.js
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-const { loadSkillTemplate } = require('../skill-generator.js');
+import { loadSkillTemplate } from '../skill-generator.js';
 
 function createFixture(tree, baseDir) {
     for (const [name, content] of Object.entries(tree)) {

--- a/scripts/plugins/ignore-block.js
+++ b/scripts/plugins/ignore-block.js
@@ -35,4 +35,4 @@ const ignoreBlockPlugin = {
     },
 };
 
-module.exports = ignoreBlockPlugin;
+export default ignoreBlockPlugin;

--- a/scripts/plugins/ignore-file.js
+++ b/scripts/plugins/ignore-file.js
@@ -21,4 +21,4 @@ const ignoreFilePlugin = {
     },
 };
 
-module.exports = ignoreFilePlugin;
+export default ignoreFilePlugin;

--- a/scripts/plugins/ignore-line.js
+++ b/scripts/plugins/ignore-line.js
@@ -34,4 +34,4 @@ const ignoreLinePlugin = {
     },
 };
 
-module.exports = ignoreLinePlugin;
+export default ignoreLinePlugin;

--- a/scripts/plugins/index.js
+++ b/scripts/plugins/index.js
@@ -2,9 +2,9 @@
  * Plugin system for content transformation
  */
 
-const ignoreLinePlugin = require('./ignore-line');
-const ignoreFilePlugin = require('./ignore-file');
-const ignoreBlockPlugin = require('./ignore-block');
+import ignoreLinePlugin from './ignore-line.js';
+import ignoreFilePlugin from './ignore-file.js';
+import ignoreBlockPlugin from './ignore-block.js';
 
 /**
  * Compose multiple plugins into a single transformation function
@@ -33,7 +33,7 @@ function composePlugins(plugins = []) {
     };
 }
 
-module.exports = {
+export {
     composePlugins,
     ignoreLinePlugin,
     ignoreFilePlugin,


### PR DESCRIPTION
2015 x2 - vincent moved the wizard to ESM, just moving over context mill + warlock

- Add "type": "module" to package.json
- Add engines field requiring Node >=20.11.0 (for import.meta.dirname)
- Convert all require()/module.exports to import/export across 15 files
- Replace __dirname with import.meta.dirname in build.js and dev-server.js
- Fix test files that mixed require() with ESM imports

All 42 tests pass. Full build (82 skills) completes successfully.

Generated-By: PostHog Code
Task-Id: 6d2d9459-9c69-4d58-9937-ca35bf9ecea4