### PR TITLE
Add Laravel and Rails feature skill docs

### DIFF
--- a/transformation-config/skills/error-tracking/config.yaml
+++ b/transformation-config/skills/error-tracking/config.yaml
@@ -60,6 +60,13 @@ variants:
     docs_urls:
       - https://posthog.com/docs/error-tracking/installation/php.md
 
+  - id: laravel
+    display_name: Laravel
+    tags: [laravel, php]
+    docs_urls:
+      - https://posthog.com/docs/error-tracking/installation/php.md
+      - https://posthog.com/docs/libraries/laravel.md
+
   - id: ruby
     display_name: Ruby
     tags: [ruby]
@@ -71,6 +78,7 @@ variants:
     tags: [ruby-on-rails, ruby]
     docs_urls:
       - https://posthog.com/docs/error-tracking/installation/ruby-on-rails.md
+      - https://posthog.com/docs/libraries/ruby-on-rails.md
 
   - id: go
     display_name: Go

--- a/transformation-config/skills/feature-flags/config.yaml
+++ b/transformation-config/skills/feature-flags/config.yaml
@@ -64,11 +64,25 @@ variants:
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/php.md
 
+  - id: laravel
+    display_name: Laravel
+    tags: [laravel, php]
+    docs_urls:
+      - https://posthog.com/docs/feature-flags/installation/php.md
+      - https://posthog.com/docs/libraries/laravel.md
+
   - id: ruby
     display_name: Ruby
     tags: [ruby]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/ruby.md
+
+  - id: ruby-on-rails
+    display_name: Ruby on Rails
+    tags: [ruby-on-rails, ruby]
+    docs_urls:
+      - https://posthog.com/docs/feature-flags/installation/ruby.md
+      - https://posthog.com/docs/libraries/ruby-on-rails.md
 
   - id: go
     display_name: Go

--- a/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
@@ -22,8 +22,10 @@ variants:
       - https://posthog.com/docs/libraries/django.md
       - https://posthog.com/docs/libraries/flask.md
       - https://posthog.com/docs/error-tracking/installation/php.md
+      - https://posthog.com/docs/libraries/laravel.md
       - https://posthog.com/docs/error-tracking/installation/ruby.md
       - https://posthog.com/docs/error-tracking/installation/ruby-on-rails.md
+      - https://posthog.com/docs/libraries/ruby-on-rails.md
       - https://posthog.com/docs/error-tracking/installation/go.md
       - https://posthog.com/docs/error-tracking/installation/angular.md
       - https://posthog.com/docs/error-tracking/installation/svelte.md

--- a/transformation-config/skills/omnibus/instrument-feature-flags/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/config.yaml
@@ -20,7 +20,9 @@ variants:
       - https://posthog.com/docs/libraries/django.md
       - https://posthog.com/docs/libraries/flask.md
       - https://posthog.com/docs/feature-flags/installation/php.md
+      - https://posthog.com/docs/libraries/laravel.md
       - https://posthog.com/docs/feature-flags/installation/ruby.md
+      - https://posthog.com/docs/libraries/ruby-on-rails.md
       - https://posthog.com/docs/feature-flags/installation/go.md
       - https://posthog.com/docs/feature-flags/installation/java.md
       - https://posthog.com/docs/feature-flags/installation/rust.md


### PR DESCRIPTION
## Problem

Laravel and Ruby on Rails apps only had generic PHP/Ruby skill coverage for feature flags and partial framework-specific coverage for error tracking, even though their framework docs include implementation details that agents need.

## Changes

- Added a Laravel variant to the feature flags skill config.
- Added a Laravel variant to the error tracking skill config.
- Added a Ruby on Rails variant to the feature flags skill config.
- Added the Ruby on Rails library docs to the Ruby on Rails error tracking skill config.
- Added Laravel and Ruby on Rails library docs to the omnibus feature flags and error tracking skill configs.

## Testing

- [x] `pnpm test:skills`
- [x] `pnpm build`
