### PR TITLE
Add Flutter docs coverage

### DIFF
--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -194,8 +194,8 @@ commandments:
   flutter:
     - posthog_flutter is the Flutter SDK package name; install it with `flutter pub add posthog_flutter` or add it to `pubspec.yaml`
     - For manual setup, call `WidgetsFlutterBinding.ensureInitialized()`, create a `PostHogConfig`, then await `Posthog().setup(config)` before `runApp()`
-    - For Android, set `minSdkVersion 23` and configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `android/app/src/main/AndroidManifest.xml` unless using manual setup with `AUTO_INIT=false`
-    - For iOS, set `platform :ios, '13.0'` in `ios/Podfile` and configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `ios/Runner/Info.plist` unless using manual setup
+    - For Android, ensure `minSdkVersion` is at least `23`. If the current value is lower than `23` or missing, update/add it as `minSdkVersion 23`; if it is already `23` or higher, leave it unchanged. Configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `android/app/src/main/AndroidManifest.xml` unless using manual setup with `AUTO_INIT=false`
+    - For iOS, ensure the minimum deployment target is at least iOS `13.0`. If the current `platform :ios` value is lower than `13.0` or missing, update/add it as `platform :ios, '13.0'`; if it is already `13.0` or higher, leave it unchanged. Configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `ios/Runner/Info.plist` unless using manual setup
     - For Session Replay or Surveys, disable auto-init with `com.posthog.posthog.AUTO_INIT=false` and initialize manually so the required options can be enabled
     - For Flutter Web, add the posthog-js web snippet to `web/index.html`; Flutter Web session replay also requires Canvas capture in project settings
     - Capture screen views with `PosthogObserver()` and named routes; unnamed routes will not produce useful `$screen` names

--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -191,6 +191,17 @@ commandments:
     - Access config via `Constants.expoConfig?.extra?.posthogProjectToken` in your posthog.ts config file
     - For expo-router, wrap PostHogProvider in app/_layout.tsx and manually track screens with `posthog.screen(pathname, params)` in a useEffect
 
+  flutter:
+    - posthog_flutter is the Flutter SDK package name; install it with `flutter pub add posthog_flutter` or add it to `pubspec.yaml`
+    - For manual setup, call `WidgetsFlutterBinding.ensureInitialized()`, create a `PostHogConfig`, then await `Posthog().setup(config)` before `runApp()`
+    - For Android, set `minSdkVersion 23` and configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `android/app/src/main/AndroidManifest.xml` unless using manual setup with `AUTO_INIT=false`
+    - For iOS, set `platform :ios, '13.0'` in `ios/Podfile` and configure `com.posthog.posthog.PROJECT_TOKEN` and `com.posthog.posthog.POSTHOG_HOST` in `ios/Runner/Info.plist` unless using manual setup
+    - For Session Replay or Surveys, disable auto-init with `com.posthog.posthog.AUTO_INIT=false` and initialize manually so the required options can be enabled
+    - For Flutter Web, add the posthog-js web snippet to `web/index.html`; Flutter Web session replay also requires Canvas capture in project settings
+    - Capture screen views with `PosthogObserver()` and named routes; unnamed routes will not produce useful `$screen` names
+    - Call `Posthog().identify(...)` after login and `Posthog().reset()` on logout; keep PII in user properties, not event properties
+    - Use `beforeSend` to redact or drop Dart-captured events, but remember it does not intercept native session replay, lifecycle, or system properties
+
   astro:
     - Always use the is:inline directive on PostHog script tags to prevent Astro from processing them and causing TypeScript errors
     - Use PUBLIC_ prefix for client-side environment variables in Astro (e.g., PUBLIC_POSTHOG_PROJECT_TOKEN)

--- a/transformation-config/skills/integration/config.yaml
+++ b/transformation-config/skills/integration/config.yaml
@@ -208,6 +208,15 @@ variants:
     tags: [swift, ios, macos, swiftui]
     docs_urls:
       - https://posthog.com/docs/libraries/ios.md
+
+  - id: flutter
+    type: docs-only
+    template: description-docs-only.md
+    display_name: Flutter
+    description: PostHog integration for Flutter applications using the posthog_flutter SDK
+    tags: [flutter, dart, mobile]
+    docs_urls:
+      - https://posthog.com/docs/libraries/flutter.md
   
   - id: react-native
     example_paths: basics/react-native

--- a/transformation-config/skills/integration/description-docs-only.md
+++ b/transformation-config/skills/integration/description-docs-only.md
@@ -1,0 +1,27 @@
+# PostHog integration for {display_name}
+
+This skill helps you add PostHog analytics to {display_name} applications using the official PostHog SDK documentation.
+
+## Instructions
+
+1. Detect the existing app structure and package manager. For Flutter, check `pubspec.yaml`, `pubspec.lock`, `android/`, `ios/`, `macos/`, and `web/`.
+2. Read the matching reference file below before changing code. It is the source of truth for SDK installation, initialization, capture, identify, feature flags, error tracking, session replay, surveys, and platform-specific setup.
+3. Install the SDK using the platform package manager. For Flutter, prefer `flutter pub add posthog_flutter` over manually editing `pubspec.yaml`.
+4. Initialize PostHog once, using environment/configuration values for the project token and host. Never hardcode secrets.
+5. Add identify calls at login/signup boundaries and reset on logout.
+6. Verify with the project's normal analyzer, tests, or build commands.
+
+## Reference files
+
+{references}
+
+## Key principles
+
+- **Environment/configuration values**: Always use environment variables or platform configuration files for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the docs**: Follow the framework reference's initialization and capture patterns exactly.
+- **Analytics contract**: Treat event names, property names, and feature flag keys as part of an analytics contract. Reuse existing names and patterns found in the project. When introducing new ones, make them clear, descriptive, and consistent with existing conventions.
+
+## Framework guidelines
+
+{commandments}

--- a/transformation-config/skills/omnibus/instrument-error-tracking/description.md
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/description.md
@@ -9,8 +9,8 @@ Supported platforms: React, Next.js, Web (JavaScript), Node.js, Python, PHP, Rub
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, pubspec.yaml, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, pubspec.lock) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 4.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-feature-flags/description.md
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/description.md
@@ -9,8 +9,8 @@ Supported platforms: React, Next.js, React Native, Web (JavaScript), Node.js, Py
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, pubspec.yaml, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, pubspec.lock) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 3.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-integration/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-integration/config.yaml
@@ -85,4 +85,5 @@ variants:
       # Mobile
       - https://posthog.com/docs/libraries/android.md
       - https://posthog.com/docs/libraries/ios.md
+      - https://posthog.com/docs/libraries/flutter.md
       - https://posthog.com/docs/libraries/react-native.md

--- a/transformation-config/skills/omnibus/instrument-integration/description.md
+++ b/transformation-config/skills/omnibus/instrument-integration/description.md
@@ -2,15 +2,15 @@
 
 Use this skill to add the PostHog SDK to an application. Use it when setting up PostHog for the first time, or reviewing PRs that need PostHog initialization. Covers SDK installation, provider setup, and basic configuration. Supports any framework or language.
 
-Supported frameworks: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, Swift, React Native, Expo, Node.js, and vanilla JavaScript.
+Supported frameworks: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, Swift, Flutter, React Native, Expo, Node.js, and vanilla JavaScript.
 
 ## Instructions
 
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, pubspec.yaml, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, pubspec.lock) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, do not modify its code. Inform the user and skip to verification.
 
 STEP 2: Research integration.

--- a/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
@@ -76,4 +76,5 @@ variants:
       # Mobile
       - https://posthog.com/docs/libraries/android.md
       - https://posthog.com/docs/libraries/ios.md
+      - https://posthog.com/docs/libraries/flutter.md
       - https://posthog.com/docs/libraries/react-native.md

--- a/transformation-config/skills/omnibus/instrument-product-analytics/description.md
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/description.md
@@ -2,15 +2,15 @@
 
 Use this skill to add product analytics events (capture calls) that track meaningful user actions in new or changed code. Use it after implementing features or reviewing PRs to ensure key user behaviors are captured. If PostHog is not yet installed, this skill also covers initial SDK setup. Supports any framework or language.
 
-Supported frameworks: Next.js, React Router, Nuxt, Vue, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, iOS, React Native, Expo, and more.
+Supported frameworks: Next.js, React Router, Nuxt, Vue, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, iOS, Flutter, React Native, Expo, and more.
 
 ## Instructions
 
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, pubspec.yaml, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, pubspec.lock) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, skip to STEP 5.
 
 STEP 2: Research integration. (Skip if PostHog is already set up.)


### PR DESCRIPTION
## Problem

Flutter was only covered in feature flags and error tracking docs, but not in the core integration/product analytics configs. Agents working on Flutter apps could miss the main `posthog_flutter` setup guidance unless they manually found the Flutter library docs.

## Changes

- Add a docs-only `integration-flutter` skill using the official Flutter library docs.
- Add Flutter library docs to the omnibus integration and product analytics skills.
- Add Flutter to supported-platform wording and platform detection hints (`pubspec.yaml` / `pubspec.lock`).
- Add Flutter-specific commandments for SDK installation, platform setup, manual initialization, screen tracking, identify/reset, session replay/surveys, and `beforeSend`.
- Keep this docs-only: no `basics/flutter` sample is added.

## Checklist

- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Changeset not required (chore/docs-only config update)
