### PR TITLE
Add iOS docs coverage

### DIFF
--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -179,6 +179,17 @@ commandments:
     - Check the latest release version of posthog-ios at `https://github.com/PostHog/posthog-ios/releases` before setting the `minimumVersion` in the SPM package reference — do not hardcode a stale version
     - If the project uses App Sandbox (macOS), add `ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES` to the target's build settings so PostHog can reach its servers — do NOT disable the sandbox entirely
 
+  ios:
+    - Install the PostHog iOS SDK as `PostHog` via Swift Package Manager or CocoaPods, using `https://github.com/PostHog/posthog-ios.git` for SPM
+    - Initialize `PostHogSDK.shared.setup(config)` exactly once and as early as possible, either in `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)` or in the SwiftUI `App` initializer
+    - For SwiftUI apps, prefer meaningful `.postHogScreenView(...)` modifiers for screen tracking because automatic SwiftUI screen names can be internal view identifiers
+    - Call `PostHogSDK.shared.identify(...)` after login and `PostHogSDK.shared.reset()` on logout; keep PII in user properties, not event properties
+    - Enable iOS error autocapture with `config.errorTrackingConfig.autoCapture = true` and upload dSYM files so crash reports are symbolicated
+    - Enable session replay with `config.sessionReplay = true` only after confirming project replay settings and privacy masking requirements; session replay is iOS-only, not macOS
+    - Use `config.setBeforeSend { event in ... }` to redact, drop, or sample custom events, while preserving PostHog internal events where possible
+    - For iOS logs, use posthog-ios 3.58.0 or later, set `config.logs` fields before `setup`, and capture logs manually with `PostHogSDK.shared.logger` or `captureLog`
+    - For widgets, app clips, share extensions, and other app extensions, configure `config.appGroupIdentifier` so the main app and extensions share analytics identity
+
   react-native:
     - posthog-react-native is the React Native SDK package name
     - Use react-native-config to load POSTHOG_PROJECT_TOKEN and POSTHOG_HOST from .env (variables are embedded at build time, not runtime)

--- a/transformation-config/skills/error-tracking/config.yaml
+++ b/transformation-config/skills/error-tracking/config.yaml
@@ -123,6 +123,12 @@ variants:
     docs_urls:
       - https://posthog.com/docs/error-tracking/installation/flutter.md
 
+  - id: ios
+    display_name: iOS
+    tags: [ios, swift]
+    docs_urls:
+      - https://posthog.com/docs/error-tracking/installation/ios.md
+
   - id: android
     display_name: Android
     tags: [android, java, kotlin]

--- a/transformation-config/skills/feature-flags/config.yaml
+++ b/transformation-config/skills/feature-flags/config.yaml
@@ -134,6 +134,7 @@ variants:
     tags: [ios, swift]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/ios.md
+      - https://posthog.com/docs/libraries/ios/usage.md
 
   - id: flutter
     display_name: Flutter

--- a/transformation-config/skills/integration/config.yaml
+++ b/transformation-config/skills/integration/config.yaml
@@ -208,6 +208,8 @@ variants:
     tags: [swift, ios, macos, swiftui]
     docs_urls:
       - https://posthog.com/docs/libraries/ios.md
+      - https://posthog.com/docs/libraries/ios/usage.md
+      - https://posthog.com/docs/libraries/ios/configuration.md
   
   - id: react-native
     example_paths: basics/react-native

--- a/transformation-config/skills/logs/config.yaml
+++ b/transformation-config/skills/logs/config.yaml
@@ -65,6 +65,12 @@ variants:
     docs_urls:
       - https://posthog.com/docs/logs/installation/android.md
 
+  - id: ios
+    display_name: iOS
+    tags: [ios, swift]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/ios.md
+
   - id: other
     display_name: Other Languages
     tags: []

--- a/transformation-config/skills/logs/description.md
+++ b/transformation-config/skills/logs/description.md
@@ -12,7 +12,8 @@ Consult the documentation for API details and framework-specific patterns.
 
 - **Environment variables**: Always use environment variables for PostHog keys and OpenTelemetry endpoints. Never hardcode them.
 - **Minimal changes**: Add log export alongside existing logging. Don't replace or restructure existing logging code.
-- **OpenTelemetry**: PostHog logs use the OpenTelemetry protocol. Configure an OTLP exporter pointed at PostHog's ingest endpoint.
+- **OpenTelemetry**: PostHog logs use the OpenTelemetry protocol. Configure an OTLP exporter pointed at PostHog's ingest endpoint unless the platform SDK provides native log capture.
+- **SDK-native logs**: For Android, React Native, and iOS, use the SDK logger/capture APIs from the platform reference instead of adding a separate OTLP exporter.
 - **Structured logging**: Prefer structured log formats with key-value properties over plain text messages.
 
 ## Framework guidelines

--- a/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
@@ -34,5 +34,6 @@ variants:
       - https://posthog.com/docs/error-tracking/installation/nuxt.md
       - https://posthog.com/docs/error-tracking/installation/react-native.md
       - https://posthog.com/docs/error-tracking/installation/flutter.md
+      - https://posthog.com/docs/error-tracking/installation/ios.md
       - https://posthog.com/docs/error-tracking/installation/android.md
       - https://posthog.com/docs/error-tracking/installation/hono.md

--- a/transformation-config/skills/omnibus/instrument-error-tracking/description.md
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/description.md
@@ -2,15 +2,15 @@
 
 Use this skill to add PostHog error tracking that captures and monitors exceptions in your application. Use it after implementing features or reviewing PRs to ensure errors are tracked with full stack traces and source maps. If PostHog is not yet installed, this skill also covers initial SDK setup. Supports any platform or language.
 
-Supported platforms: React, Next.js, Web (JavaScript), Node.js, Python, PHP, Ruby, Ruby on Rails, Go, Angular, Svelte, Nuxt, React Native, Flutter, Android, and Hono.
+Supported platforms: React, Next.js, Web (JavaScript), Node.js, Python, PHP, Ruby, Ruby on Rails, Go, Angular, Svelte, Nuxt, React Native, Flutter, iOS, Android, and Hono.
 
 ## Instructions
 
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, Podfile, Package.swift, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, Podfile.lock, Package.resolved) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 4.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-feature-flags/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/config.yaml
@@ -31,6 +31,7 @@ variants:
       - https://posthog.com/docs/feature-flags/installation/elixir.md
       - https://posthog.com/docs/feature-flags/installation/android.md
       - https://posthog.com/docs/feature-flags/installation/ios.md
+      - https://posthog.com/docs/libraries/ios/usage.md
       - https://posthog.com/docs/feature-flags/installation/flutter.md
       - https://posthog.com/docs/feature-flags/installation/api.md
       - https://posthog.com/docs/libraries/next-js.md

--- a/transformation-config/skills/omnibus/instrument-feature-flags/description.md
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/description.md
@@ -9,8 +9,8 @@ Supported platforms: React, Next.js, React Native, Web (JavaScript), Node.js, Py
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, Podfile, Package.swift, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, Podfile.lock, Package.resolved) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 3.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-integration/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-integration/config.yaml
@@ -85,4 +85,6 @@ variants:
       # Mobile
       - https://posthog.com/docs/libraries/android.md
       - https://posthog.com/docs/libraries/ios.md
+      - https://posthog.com/docs/libraries/ios/usage.md
+      - https://posthog.com/docs/libraries/ios/configuration.md
       - https://posthog.com/docs/libraries/react-native.md

--- a/transformation-config/skills/omnibus/instrument-integration/description.md
+++ b/transformation-config/skills/omnibus/instrument-integration/description.md
@@ -2,15 +2,15 @@
 
 Use this skill to add the PostHog SDK to an application. Use it when setting up PostHog for the first time, or reviewing PRs that need PostHog initialization. Covers SDK installation, provider setup, and basic configuration. Supports any framework or language.
 
-Supported frameworks: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, Swift, React Native, Expo, Node.js, and vanilla JavaScript.
+Supported frameworks: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, iOS, Swift, React Native, Expo, Node.js, and vanilla JavaScript.
 
 ## Instructions
 
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, Podfile, Package.swift, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, Podfile.lock, Package.resolved) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, do not modify its code. Inform the user and skip to verification.
 
 STEP 2: Research integration.

--- a/transformation-config/skills/omnibus/instrument-logs/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-logs/config.yaml
@@ -22,4 +22,7 @@ variants:
       - https://posthog.com/docs/logs/installation/go.md
       - https://posthog.com/docs/logs/installation/java.md
       - https://posthog.com/docs/logs/installation/datadog.md
+      - https://posthog.com/docs/logs/installation/android.md
+      - https://posthog.com/docs/logs/installation/react-native.md
+      - https://posthog.com/docs/logs/installation/ios.md
       - https://posthog.com/docs/logs/installation/other.md

--- a/transformation-config/skills/omnibus/instrument-logs/description.md
+++ b/transformation-config/skills/omnibus/instrument-logs/description.md
@@ -2,7 +2,7 @@
 
 Use this skill to add PostHog log capture for new or changed code. Use it after implementing features or reviewing PRs to ensure meaningful log events are captured with structured properties. If PostHog log export is not yet configured, this skill also covers initial OTLP exporter setup. Supports any platform or language.
 
-Supported platforms: Next.js, Node.js, Python, Go, Java, Datadog, and any language via OpenTelemetry.
+Supported platforms: Next.js, Node.js, Python, Go, Java, Datadog, Android, React Native, iOS, and any language via OpenTelemetry.
 
 ## Instructions
 
@@ -10,8 +10,9 @@ Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
   - Detect the language, framework, and existing logging setup.
-  - Look for log libraries (winston, pino, logging module, logrus, log4j, serilog, etc.).
-  - Look for lockfiles to determine the package manager.
+  - Look for dependency files and project files (package.json, Podfile, Package.swift, requirements.txt, go.mod, pom.xml, etc.).
+  - Look for log libraries (winston, pino, logging module, logrus, log4j, serilog, os_log, Logger, etc.).
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, Podfile.lock, Package.resolved, etc.) to determine the package manager.
   - Check for existing PostHog log export setup. If the OTLP exporter is already configured, skip to STEP 5 to add log capture for new code.
 
 STEP 2: Research log capture. (Skip if PostHog log export is already configured.)
@@ -25,6 +26,7 @@ STEP 3: Install dependencies. (Skip if PostHog log export is already configured.
 
 STEP 4: Configure the OTLP exporter. (Skip if PostHog log export is already configured.)
   - PostHog logs use the OpenTelemetry protocol. Set up an OTLP exporter pointed at PostHog's ingest endpoint.
+  - For SDK-native log support such as Android, React Native, and iOS, follow the platform reference instead of adding a separate OTLP exporter.
   - Follow the platform-specific reference for the exact configuration.
 
 STEP 5: Integrate with existing logging.
@@ -54,5 +56,6 @@ Each platform reference contains specific OTLP configuration, SDK setup, and int
 
 - **Environment variables**: Always use environment variables for PostHog keys and OpenTelemetry endpoints. Never hardcode them.
 - **Minimal changes**: Add log export alongside existing logging. Don't replace or restructure existing logging code.
-- **OpenTelemetry**: PostHog logs use the OpenTelemetry protocol. Configure an OTLP exporter pointed at PostHog's ingest endpoint.
+- **OpenTelemetry**: PostHog logs use the OpenTelemetry protocol. Configure an OTLP exporter pointed at PostHog's ingest endpoint unless the platform SDK provides native log capture.
+- **SDK-native logs**: For Android, React Native, and iOS, use the SDK logger/capture APIs from the platform reference instead of adding a separate OTLP exporter.
 - **Structured logging**: Prefer structured log formats with key-value properties over plain text messages.

--- a/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
@@ -76,4 +76,6 @@ variants:
       # Mobile
       - https://posthog.com/docs/libraries/android.md
       - https://posthog.com/docs/libraries/ios.md
+      - https://posthog.com/docs/libraries/ios/usage.md
+      - https://posthog.com/docs/libraries/ios/configuration.md
       - https://posthog.com/docs/libraries/react-native.md

--- a/transformation-config/skills/omnibus/instrument-product-analytics/description.md
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/description.md
@@ -9,8 +9,8 @@ Supported frameworks: Next.js, React Router, Nuxt, Vue, TanStack Start, SvelteKi
 Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
-  - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for dependency files (package.json, Podfile, Package.swift, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, Podfile.lock, Package.resolved) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, skip to STEP 5.
 
 STEP 2: Research integration. (Skip if PostHog is already set up.)


### PR DESCRIPTION
## Problem

iOS had core library coverage through the Swift integration skill, but several related configs were missing the newer iOS docs for usage, configuration, error tracking, and logs. Agents working on iOS apps could miss important PostHog iOS SDK guidance such as SwiftUI screen tracking, error autocapture/dSYMs, SDK-native logs, app groups, and platform-specific project detection.

## Changes

- Add iOS usage and configuration docs to Swift integration and omnibus integration/product analytics skills.
- Add an iOS error tracking skill and include iOS error tracking in the omnibus error tracking skill.
- Add an iOS logs skill and include iOS logs in the omnibus logs skill.
- Add iOS usage docs to feature flags skill coverage.
- Add iOS-specific commandments for SDK setup, screen views, identify/reset, error autocapture/dSYMs, session replay, SDK-native logs, beforeSend, and app groups.
- Add iOS project detection hints for `Podfile`, `Package.swift`, `Podfile.lock`, and `Package.resolved`.
- Clarify SDK-native logs guidance to include Android alongside React Native and iOS, and include Android logs in the omnibus logs references.
- Keep existing basics samples untouched.

## Checklist

- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Changeset not required (chore/docs-only config update)
