### PR TITLE
Use captureException SDK methods in error tracking examples

### DIFF
--- a/basics/angular/README.md
+++ b/basics/angular/README.md
@@ -146,11 +146,7 @@ posthogService.posthog.capture('burrito_considered', {
 ### Error tracking (pages/profile/profile.component.ts)
 
 ```typescript
-posthogService.posthog.capture('$exception', {
-  $exception_message: error.message,
-  $exception_type: error.name,
-  $exception_stack_trace_raw: error.stack,
-});
+posthogService.posthog.captureException(error);
 ```
 
 ## Angular-specific details

--- a/basics/angular/src/app/pages/profile/profile.component.ts
+++ b/basics/angular/src/app/pages/profile/profile.component.ts
@@ -75,11 +75,7 @@ export class ProfileComponent {
       throw new Error('Test error for PostHog error tracking');
     } catch (err) {
       const error = err as Error;
-      this.posthogService.posthog.capture('$exception', {
-        $exception_message: error.message,
-        $exception_type: error.name,
-        $exception_stack_trace_raw: error.stack,
-      });
+      this.posthogService.posthog.captureException(error);
       console.error('Captured error:', err);
       alert('Error captured and sent to PostHog!');
     }

--- a/basics/expo/README.md
+++ b/basics/expo/README.md
@@ -6,7 +6,7 @@ A React Native Expo app demonstrating PostHog product analytics integration with
 
 - **Product Analytics**: Full PostHog integration with event tracking
 - **Autocapture**: Touch events and screen tracking
-- **Error Tracking**: Manual exception capture with `$exception` events
+- **Error Tracking**: Manual exception capture with `captureException`
 - **User Authentication**: Demo login with PostHog user identification
 - **Session Persistence**: AsyncStorage for session management
 - **Modern React**: React 19 with React Compiler for automatic memoization
@@ -147,11 +147,7 @@ useEffect(() => {
 Manual exception capture:
 
 ```typescript
-posthog.capture('$exception', {
-  $exception_type: error.name,
-  $exception_message: error.message,
-  $exception_stack_trace_raw: error.stack,
-})
+posthog.captureException(error)
 ```
 
 ## Modern React Features

--- a/basics/expo/app/profile.tsx
+++ b/basics/expo/app/profile.tsx
@@ -32,7 +32,7 @@ export default function ProfileScreen() {
   /**
    * Triggers a test error and captures it in PostHog
    *
-   * This demonstrates manual exception capture using the $exception event.
+   * This demonstrates manual exception capture via captureException.
    * In production, you would typically set up automatic exception capture
    * or use the before_send callback for customization.
    *
@@ -44,21 +44,9 @@ export default function ProfileScreen() {
     } catch (err) {
       const error = err as Error
 
-      // Capture exception in PostHog
       // @see https://posthog.com/docs/error-tracking
-      posthog.capture('$exception', {
-        $exception_list: [
-          {
-            type: error.name,
-            value: error.message,
-            stacktrace: {
-              type: 'raw',
-              frames: error.stack ?? '',
-            },
-          },
-        ],
+      posthog.captureException(error, {
         $exception_source: 'react-native',
-        // Additional context
         username: user.username,
         screen: 'Profile',
       })

--- a/basics/expo/app/profile.tsx
+++ b/basics/expo/app/profile.tsx
@@ -46,7 +46,6 @@ export default function ProfileScreen() {
 
       // @see https://posthog.com/docs/error-tracking
       posthog.captureException(error, {
-        $exception_source: 'react-native',
         username: user.username,
         screen: 'Profile',
       })

--- a/basics/laravel/app/Services/PostHogService.php
+++ b/basics/laravel/app/Services/PostHogService.php
@@ -63,13 +63,8 @@ class PostHogService
 
         $eventId = uniqid('error_', true);
 
-        $this->capture($distinctId, '$exception', [
+        PostHog::captureException($exception, $distinctId, [
             'error_id' => $eventId,
-            'exception_type' => get_class($exception),
-            'exception_message' => $exception->getMessage(),
-            'exception_file' => $exception->getFile(),
-            'exception_line' => $exception->getLine(),
-            'stack_trace' => $exception->getTraceAsString(),
         ]);
 
         return $eventId;

--- a/basics/laravel/composer.json
+++ b/basics/laravel/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.2",
         "laravel/framework": "^11.0",
         "livewire/livewire": "^4.0",
-        "posthog/posthog-php": "^4.0"
+        "posthog/posthog-php": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/basics/laravel/composer.lock
+++ b/basics/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a71ae5efeb83bf3a1bb1d291cdf626f1",
+    "content-hash": "476aa681b3925049b59c4cb71b568fcd",
     "packages": [
         {
             "name": "brick/math",
@@ -2548,16 +2548,16 @@
         },
         {
             "name": "posthog/posthog-php",
-            "version": "4.0.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PostHog/posthog-php.git",
-                "reference": "9f5e54eaacff9315a021571bec5432cb451be012"
+                "reference": "e1ca536ff60071d844cf65290bf63806b81bc386"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PostHog/posthog-php/zipball/9f5e54eaacff9315a021571bec5432cb451be012",
-                "reference": "9f5e54eaacff9315a021571bec5432cb451be012",
+                "url": "https://api.github.com/repos/PostHog/posthog-php/zipball/e1ca536ff60071d844cf65290bf63806b81bc386",
+                "reference": "e1ca536ff60071d844cf65290bf63806b81bc386",
                 "shasum": ""
             },
             "require": {
@@ -2595,9 +2595,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PostHog/posthog-php/issues",
-                "source": "https://github.com/PostHog/posthog-php/tree/4.0.0"
+                "source": "https://github.com/PostHog/posthog-php/tree/4.2.0"
             },
-            "time": "2026-01-09T10:46:48+00:00"
+            "time": "2026-04-06T22:54:03+00:00"
         },
         {
             "name": "psr/clock",

--- a/basics/react-native/README.md
+++ b/basics/react-native/README.md
@@ -326,7 +326,7 @@ posthog.capture('burrito_considered', {
 
 ### Error tracking (screens/ProfileScreen.tsx)
 
-Capture exceptions using the `$exception` event:
+Capture exceptions using `captureException`:
 
 ```typescript
 import { usePostHog } from 'posthog-react-native'
@@ -336,11 +336,8 @@ const posthog = usePostHog()
 try {
   throw new Error('Test error for PostHog error tracking')
 } catch (err) {
-  posthog.capture('$exception', {
-    $exception_type: err.name,
-    $exception_message: err.message,
+  posthog.captureException(err, {
     $exception_source: 'ProfileScreen',
-    $exception_stack_trace_raw: err.stack,
   })
 }
 ```

--- a/basics/react-native/README.md
+++ b/basics/react-native/README.md
@@ -336,9 +336,7 @@ const posthog = usePostHog()
 try {
   throw new Error('Test error for PostHog error tracking')
 } catch (err) {
-  posthog.captureException(err, {
-    $exception_source: 'ProfileScreen',
-  })
+  posthog.captureException(err)
 }
 ```
 

--- a/basics/react-native/src/screens/ProfileScreen.tsx
+++ b/basics/react-native/src/screens/ProfileScreen.tsx
@@ -45,7 +45,7 @@ export default function ProfileScreen() {
   /**
    * Triggers a test error and captures it in PostHog
    *
-   * This demonstrates manual exception capture using the $exception event.
+   * This demonstrates manual exception capture via captureException.
    * In production, you would typically set up automatic exception capture
    * or use the before_send callback for customization.
    *
@@ -57,14 +57,8 @@ export default function ProfileScreen() {
     } catch (err) {
       const error = err as Error
 
-      // Capture exception in PostHog using the $exception event
-      // This follows PostHog's error tracking format
-      posthog.capture('$exception', {
-        $exception_type: error.name,
-        $exception_message: error.message,
+      posthog.captureException(error, {
         $exception_source: 'ProfileScreen.triggerTestError',
-        $exception_stack_trace_raw: error.stack,
-        // Additional context
         username: user.username,
         screen: 'Profile',
       })

--- a/basics/react-native/src/screens/ProfileScreen.tsx
+++ b/basics/react-native/src/screens/ProfileScreen.tsx
@@ -58,7 +58,6 @@ export default function ProfileScreen() {
       const error = err as Error
 
       posthog.captureException(error, {
-        $exception_source: 'ProfileScreen.triggerTestError',
         username: user.username,
         screen: 'Profile',
       })

--- a/basics/ruby/Gemfile
+++ b/basics/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'posthog-ruby', '~> 3.0'
+gem 'posthog-ruby', '~> 3.3'
 gem 'dotenv', '~> 3.0'

--- a/basics/ruby/todo.rb
+++ b/basics/ruby/todo.rb
@@ -252,19 +252,7 @@ rescue StandardError => e
   puts "ERROR: #{e.message}"
 
   # Manually capture handled errors
-  posthog&.capture(
-    distinct_id: get_user_id,
-    event: '$exception',
-    properties: {
-      '$exception_type' => e.class.name,
-      '$exception_message' => e.message,
-      '$exception_list' => [{
-        'type' => e.class.name,
-        'value' => e.message,
-        'stacktrace' => { 'frames' => (e.backtrace || []).first(10).map { |line| { 'filename' => line } } }
-      }]
-    }
-  )
+  posthog&.capture_exception(e, get_user_id)
 
   exit 1
 ensure


### PR DESCRIPTION
## Summary

Manoel flagged in Slack that some of our examples were capturing `$exception` events through the generic `capture` method with hand-built property bags. This PR switches each example to the SDK's first-class exception capture API so PostHog receives proper exception metadata (correct `$exception_list` shape, fingerprinting, etc).

## Changes per example

- **Angular** (`posthog-js`): use `posthog.captureException(error)`
- **Expo** & **React Native** (`posthog-react-native@4`): use `posthog.captureException(error, additionalProperties)`
- **Ruby** (`posthog-ruby`): use `posthog.capture_exception(e, distinct_id)`; bump `Gemfile` to `~> 3.3` (first 3.x to ship `capture_exception`)
- **Laravel** (`posthog-php`): delegate `PostHogService::captureException` to `PostHog::captureException`. The previous wrapper built properties without the `$` prefix (`exception_type`, `exception_message`, ...) so PostHog never parsed them as exception fields. Bumps `composer.json` to `^4.2` and updates `composer.lock` to 4.2.0 (first 4.x with `PostHog::captureException`).
- Updated each example README snippet to match.

## Test plan

- [x] `ng build` succeeds for the Angular example with the new code
- [x] `tsc --noEmit -p .` on Expo example reports no new errors (only pre-existing unrelated errors)
- [x] `tsc --noEmit -p .` on React Native example reports no new errors in `ProfileScreen.tsx`
- [x] Run Laravel + Ruby examples end-to-end against a real PostHog project (requires PHP/Ruby toolchains — not available in this sandbox; needs manual smoke test)
- [x] Confirm `$exception` events show up in PostHog Error Tracking with parsed stack frames

Tested these locally to make sure they work
<img width="1287" height="631" alt="Screenshot 2026-05-27 at 12 09 27 PM" src="https://github.com/user-attachments/assets/100eed56-4825-4a25-8f0e-d4ac2d499d23" />

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*