### PR TITLE
Add Go docs coverage

### DIFF
--- a/transformation-config/commandments.yaml
+++ b/transformation-config/commandments.yaml
@@ -72,6 +72,18 @@ commandments:
     - Register posthog_client.shutdown with atexit.register() to ensure all events are flushed on exit
     - The Python SDK has NO identify() method — use posthog_client.set(distinct_id=user_id, properties={...}) to set person properties, or use identify_context(user_id) within a context
 
+  go:
+    - posthog-go is the Go SDK package; install it with `go get github.com/posthog/posthog-go` and import `github.com/posthog/posthog-go`
+    - Create one PostHog client per process with `posthog.NewWithConfig(...)`; do not create a new client per request or job
+    - Always close the client during graceful shutdown with `client.Close()` so queued events flush before the process exits
+    - Configure the project token, endpoint, and optional personal API key from environment variables; never hardcode PostHog secrets
+    - Server-side captures must set `DistinctId` to a stable user ID that matches frontend identify calls; avoid anonymous or literal IDs for business events
+    - Use `posthog.NewProperties().Set(...)` for event properties and keep PII in person properties via `$set`, not in event properties
+    - For new feature flag code, prefer `client.EvaluateFlags(...)` once per user/request, then use the returned snapshot's `IsEnabled` or `GetFlag` methods
+    - When capturing events related to feature-gated code, attach the evaluated flag snapshot with `Flags`, optionally filtered with `OnlyAccessed()` or `Only(...)`
+    - Avoid deprecated feature flag helpers such as `IsFeatureEnabled`, `GetFeatureFlag`, `GetFeatureFlagPayload`, and `Capture.SendFeatureFlags` in new code
+    - For error tracking, use `posthog.NewDefaultException(...)` for direct captures or wrap `log/slog` with `posthog.NewSlogCaptureHandler(...)` for automatic warning-and-above exception capture
+
   dotnet:
     - posthog-dotnet package names are `PostHog` for general .NET apps and `PostHog.AspNetCore` for ASP.NET Core apps
     - Use environment variables, user secrets, or configuration providers for `ProjectToken`, `HostUrl`, and `PersonalApiKey`; never hardcode PostHog secrets

--- a/transformation-config/skills/integration/config.yaml
+++ b/transformation-config/skills/integration/config.yaml
@@ -201,6 +201,15 @@ variants:
     docs_urls:
       - https://posthog.com/docs/libraries/ruby.md
 
+  - id: go
+    type: docs-only
+    template: description-go-docs-only.md
+    display_name: Go
+    description: PostHog integration for Go applications using the posthog-go SDK
+    tags: [go]
+    docs_urls:
+      - https://posthog.com/docs/libraries/go.md
+
   - id: swift
     example_paths: basics/swift
     display_name: Swift (iOS/macOS)

--- a/transformation-config/skills/integration/description-go-docs-only.md
+++ b/transformation-config/skills/integration/description-go-docs-only.md
@@ -1,0 +1,27 @@
+# PostHog integration for {display_name}
+
+This skill helps you add PostHog analytics to {display_name} applications using the official PostHog Go SDK documentation.
+
+## Instructions
+
+1. Detect the existing Go app structure. Check `go.mod`, `go.sum`, `cmd/`, `internal/`, HTTP/router setup, worker entry points, and existing logging/error handling.
+2. Read the reference files below before changing code. They are the source of truth for SDK installation, initialization, event capture, identification, feature flags, group analytics, and error tracking.
+3. Install the SDK with `go get github.com/posthog/posthog-go` instead of manually editing `go.mod`.
+4. Initialize one PostHog client per process with configuration from environment variables. Close it during graceful shutdown so queued events flush.
+5. Add captures at meaningful request, job, or business-action boundaries. Use a stable `DistinctId` that matches the frontend/user identity.
+6. Verify with the project's normal Go commands, such as `go test ./...`, `go vet ./...`, or the repository's existing checks.
+
+## Reference files
+
+{references}
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the docs**: Follow the Go reference's initialization, capture, feature flag, and error tracking patterns exactly.
+- **Analytics contract**: Treat event names, property names, and feature flag keys as part of an analytics contract. Reuse existing names and patterns found in the project. When introducing new ones, make them clear, descriptive, and consistent with existing conventions.
+
+## Framework guidelines
+
+{commandments}

--- a/transformation-config/skills/omnibus/instrument-error-tracking/description.md
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/description.md
@@ -10,7 +10,7 @@ Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
   - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, go.sum) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 4.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-feature-flags/description.md
+++ b/transformation-config/skills/omnibus/instrument-feature-flags/description.md
@@ -10,7 +10,7 @@ Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
   - Look for dependency files (package.json, requirements.txt, go.mod, Gemfile, composer.json, etc.) to determine the language and framework.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, go.sum) to determine the package manager.
   - Check for existing PostHog setup (SDK initialization, env vars, etc.). If PostHog is already installed and initialized, skip to STEP 3.
 
 STEP 2: Research instrumentation. (Skip if PostHog is already set up.)

--- a/transformation-config/skills/omnibus/instrument-integration/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-integration/config.yaml
@@ -76,6 +76,8 @@ variants:
       - https://posthog.com/docs/references/posthog-python.md
       # .NET
       - https://posthog.com/docs/libraries/dotnet.md
+      # Go
+      - https://posthog.com/docs/libraries/go.md
       # PHP
       - https://posthog.com/docs/libraries/laravel.md
       - https://posthog.com/docs/libraries/php.md

--- a/transformation-config/skills/omnibus/instrument-integration/description.md
+++ b/transformation-config/skills/omnibus/instrument-integration/description.md
@@ -2,7 +2,7 @@
 
 Use this skill to add the PostHog SDK to an application. Use it when setting up PostHog for the first time, or reviewing PRs that need PostHog initialization. Covers SDK installation, provider setup, and basic configuration. Supports any framework or language.
 
-Supported frameworks: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, Swift, React Native, Expo, Node.js, and vanilla JavaScript.
+Supported frameworks and languages: Next.js, React, React Router, Vue, Nuxt, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Go, Android, Swift, React Native, Expo, Node.js, and vanilla JavaScript.
 
 ## Instructions
 
@@ -10,7 +10,7 @@ Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
   - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, go.sum) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, do not modify its code. Inform the user and skip to verification.
 
 STEP 2: Research integration.

--- a/transformation-config/skills/omnibus/instrument-logs/description.md
+++ b/transformation-config/skills/omnibus/instrument-logs/description.md
@@ -11,7 +11,7 @@ Follow these steps IN ORDER:
 STEP 1: Analyze the codebase and detect the platform.
   - Detect the language, framework, and existing logging setup.
   - Look for log libraries (winston, pino, logging module, logrus, log4j, serilog, etc.).
-  - Look for lockfiles to determine the package manager.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, go.sum, etc.) to determine the package manager.
   - Check for existing PostHog log export setup. If the OTLP exporter is already configured, skip to STEP 5 to add log capture for new code.
 
 STEP 2: Research log capture. (Skip if PostHog log export is already configured.)

--- a/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/config.yaml
@@ -67,6 +67,8 @@ variants:
       - https://posthog.com/docs/references/posthog-python.md
       # .NET
       - https://posthog.com/docs/libraries/dotnet.md
+      # Go
+      - https://posthog.com/docs/libraries/go.md
       # PHP
       - https://posthog.com/docs/libraries/laravel.md
       - https://posthog.com/docs/libraries/php.md

--- a/transformation-config/skills/omnibus/instrument-product-analytics/description.md
+++ b/transformation-config/skills/omnibus/instrument-product-analytics/description.md
@@ -2,7 +2,7 @@
 
 Use this skill to add product analytics events (capture calls) that track meaningful user actions in new or changed code. Use it after implementing features or reviewing PRs to ensure key user behaviors are captured. If PostHog is not yet installed, this skill also covers initial SDK setup. Supports any framework or language.
 
-Supported frameworks: Next.js, React Router, Nuxt, Vue, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Android, iOS, React Native, Expo, and more.
+Supported frameworks and languages: Next.js, React Router, Nuxt, Vue, TanStack Start, SvelteKit, Astro, Angular, Django, Flask, FastAPI, Laravel, PHP, Ruby on Rails, Go, Android, iOS, React Native, Expo, and more.
 
 ## Instructions
 
@@ -10,7 +10,7 @@ Follow these steps IN ORDER:
 
 STEP 1: Analyze the codebase and detect the platform.
   - Look for dependency files (package.json, requirements.txt, Gemfile, composer.json, go.mod, etc.) to determine the framework and language.
-  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb) to determine the package manager.
+  - Look for lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb, go.sum) to determine the package manager.
   - Check for existing PostHog setup. If PostHog is already installed and initialized, skip to STEP 5.
 
 STEP 2: Research integration. (Skip if PostHog is already set up.)


### PR DESCRIPTION
## Problem

Go had coverage in feature flags, error tracking, and logs, but it was missing the main Go SDK library docs from the core integration and product analytics skill configs. Agents working on Go applications could miss the current `posthog-go` setup and SDK guidance, especially around client lifecycle, stable distinct IDs, `EvaluateFlags`, and Go error tracking patterns.

## Changes

- Add a docs-only `integration-go` skill using the official Go library docs.
- Add the Go library docs to omnibus integration and product analytics skills.
- Add a Go-specific integration template with Go app detection and verification guidance.
- Add Go-specific commandments for SDK installation, one-client-per-process lifecycle, `client.Close()`, distinct IDs, properties/PII, feature flag snapshots, and error tracking with `NewDefaultException` / `SlogCaptureHandler`.
- Add `go.sum` to relevant omnibus platform/package detection hints.
- Keep existing Go feature flag installation docs unchanged per review feedback.
- Keep this docs-only: no basics sample is added.

## Checklist

- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Changeset not required (chore/docs-only config update)
