### PR TITLE
Fix Nuxt error tracking docs URLs

### DIFF
--- a/transformation-config/skills/error-tracking/config.yaml
+++ b/transformation-config/skills/error-tracking/config.yaml
@@ -109,7 +109,8 @@ variants:
     display_name: Nuxt
     tags: [nuxt, javascript]
     docs_urls:
-      - https://posthog.com/docs/error-tracking/installation/nuxt.md
+      - https://posthog.com/docs/error-tracking/installation/nuxt-3-7.md
+      - https://posthog.com/docs/error-tracking/installation/nuxt-3-6.md
 
   - id: react-native
     display_name: React Native

--- a/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
+++ b/transformation-config/skills/omnibus/instrument-error-tracking/config.yaml
@@ -31,7 +31,8 @@ variants:
       - https://posthog.com/docs/libraries/dotnet.md
       - https://posthog.com/docs/error-tracking/installation/angular.md
       - https://posthog.com/docs/error-tracking/installation/svelte.md
-      - https://posthog.com/docs/error-tracking/installation/nuxt.md
+      - https://posthog.com/docs/error-tracking/installation/nuxt-3-7.md
+      - https://posthog.com/docs/error-tracking/installation/nuxt-3-6.md
       - https://posthog.com/docs/error-tracking/installation/react-native.md
       - https://posthog.com/docs/error-tracking/installation/flutter.md
       - https://posthog.com/docs/error-tracking/installation/ios.md


### PR DESCRIPTION
## Problem

The build was failing because the Nuxt error-tracking docs URL returned 404:

`https://posthog.com/docs/error-tracking/installation/nuxt.md`

PostHog docs now split this content across Nuxt 3.7+ and Nuxt 3.6 pages.

## Changes

- Replaced the removed Nuxt error-tracking docs URL in the Nuxt-specific error-tracking skill config.
- Replaced the same removed URL in the omnibus error-tracking skill config.
- Included both current Nuxt docs pages:
  - `https://posthog.com/docs/error-tracking/installation/nuxt-3-7.md`
  - `https://posthog.com/docs/error-tracking/installation/nuxt-3-6.md`

## Checklist

- [x] `pnpm build`
- [x] `pnpm test`
- [x] `bash scripts/scan-prompt-injection.sh dist/skills`
- [x] `bash scripts/lint-env-naming.sh` (exits 0; prints existing PHP env-var warnings)
