### PR TITLE
feat: add a "Verify before merging" checklist to the integration report

### DIFF
--- a/context/skills/integration/references/4-conclude.md
+++ b/context/skills/integration/references/4-conclude.md
@@ -10,7 +10,7 @@ Search for a file called `.posthog-events.json` and read it for available events
 
 Do not spawn subagents.
 
-Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, along with a list of links for the dashboard and insights created. Follow this format:
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, a list of links for the dashboard and insights created, and a "Verify before merging" checklist (see below). Follow this format:
 
 <wizard-report>
 # PostHog post-wizard report
@@ -25,11 +25,26 @@ We've built some insights and a dashboard for you to keep an eye on user behavio
 
 [links]
 
+## Verify before merging
+
+[checklist]
+
 ### Agent skill
 
 We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
 
 </wizard-report>
+
+For the "Verify before merging" checklist, write GitHub-style checkboxes (`- [ ] ...`) covering what the developer (or their coding agent) still needs to do to take this from "wizard finished" to "merged". Include ONLY the items that actually apply to the integration you just performed — judge each against the code you changed in this run, and drop any that don't fit. Phrase each item as a concrete, checkable action. Candidate items, with the condition for including each:
+
+- Always: "Run a full production build (the wizard only verified the files it touched) and fix any lint or type errors introduced by the generated code."
+- Always: "Run the test suite — call sites that were rewritten or instrumented may need updated mocks or fixtures."
+- If you added environment variables: "Add the exact PostHog env var names you added to `.env.example` and any monorepo/bootstrap scripts so collaborators know what to set."
+- If this integration ships a minified production browser bundle (most SPA/SSR web frameworks — e.g. Next.js, Nuxt, SvelteKit, Astro, Vite-based apps): "Wire source-map upload (`posthog-cli sourcemap` or your bundler's upload step) into CI so production stack traces de-minify."
+- If LLM analytics was set up in this run: "Trigger the LLM call path(s) you instrumented and confirm `$ai_generation` events appear in PostHog AI Observability."
+- If the app has user auth and an `identify` call was added: "Confirm the returning-visitor path also calls `identify` — a handler that only identifies on fresh login can leave returning sessions on anonymous distinct IDs."
+
+Do not invent items beyond what applies. If only the two "Always" items apply, the checklist is just those two.
 
 Upon completion, remove .posthog-events.json.
 


### PR DESCRIPTION
## Problem

Part of PostHog/wizard#447. After the wizard integrates PostHog there's a gap between "done" and "merged" — verification + glue steps the developer still needs. This adds them as a checklist the agent writes into `posthog-setup-report.md`.

Companion to the wizard PR PostHog/wizard#595, which surfaces a copy-paste handoff prompt pointing at this checklist.

## Changes

`llm-prompts/basic-integration/1.3-conclude.md` now instructs the agent to write a `## Verify before merging` checklist into the report, choosing only items relevant to the run from a curated candidate list.

**Why this shape:**

- **The model picks the relevant items; the wizard doesn't compute them.** Rather than a deterministic, wizard-side per-integration map, the agent judges each candidate against the code it actually changed this run.
- **Curated candidate list + a "Do not invent items" guardrail** — judgment within bounds, so it doesn't hallucinate steps.
- **Strategy-agnostic wording** — e.g. the LLM item is *"trigger the LLM call path(s) you instrumented and confirm `$ai_generation`…"*, not assuming OpenTelemetry vs the `@posthog/ai` wrapper.
- **It lives in the report, not the wizard** — this is integration knowledge, so it belongs in context-mill, decoupled from the wizard release cycle.

## Test plan

Validated via real wizard runs (real OAuth + agent + PostHog project) against a Next.js 15 SaaS app:
- the checklist rendered with the run-relevant items and omitted the rest;
- across runs, `$ai_generation` appeared **only** when LLM analytics was set up in that run and was correctly absent otherwise;
- confirmed the edited skill flows through the context-mill build into the served bundle.

Opening per the repo's contribution invitation in the README. Co-authored with Claude Code (Opus 4.8); follows the PostHog [AI policy](https://github.com/PostHog/posthog/blob/master/AI_POLICY.md).

cc @PostHog/team-docs-wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
