### PR TITLE
build(deps): use the published @posthog/warlock npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.0",
-    "@posthog/warlock": "git+https://github.com/PostHog/warlock.git",
+    "@posthog/warlock": "^0.2.2",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.95.0
         version: 0.95.0
       '@posthog/warlock':
-        specifier: git+https://github.com/PostHog/warlock.git
-        version: git+https://github.com/PostHog/warlock.git#39957221e6225c4c8d00d26af522dab0dd3a951b
+        specifier: ^0.2.2
+        version: 0.2.2
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -195,9 +195,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@posthog/warlock@git+https://github.com/PostHog/warlock.git#39957221e6225c4c8d00d26af522dab0dd3a951b':
-    resolution: {commit: 39957221e6225c4c8d00d26af522dab0dd3a951b, repo: https://github.com/PostHog/warlock.git, type: git}
-    version: 0.0.0
+  '@posthog/warlock@0.2.2':
+    resolution: {integrity: sha512-fpN9eZJ7JvOFej6gfsW1DETJTyo7S2xuu5NQsnBYl8C/cYCmGc8Q0IPiVfBGkIifF1Cic0fzkytFusImxzv4ww==}
     engines: {node: ^20.20.0 || >=22.22.0}
 
   '@rollup/rollup-android-arm-eabi@4.56.0':
@@ -971,7 +970,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@posthog/warlock@git+https://github.com/PostHog/warlock.git#39957221e6225c4c8d00d26af522dab0dd3a951b':
+  '@posthog/warlock@0.2.2':
     dependencies:
       '@virustotal/yara-x': 1.15.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 onlyBuiltDependencies:
-  - "@posthog/warlock"
   - esbuild
 allowBuilds:
-  "@posthog/warlock": true
   esbuild: true


### PR DESCRIPTION
## What

Switches `@posthog/warlock` from the **git dependency** (`git+https://github.com/PostHog/warlock.git`) to the **published npm package** [`^0.2.2`](https://www.npmjs.com/package/@posthog/warlock), and drops the warlock build-script approvals that the git install needed.

## Why now

The CI workflows install pnpm with `version: latest`. That just rolled over to **pnpm v11**, which tightened supply-chain safety: it blocks install/build scripts for **git-hosted** dependencies unless they're explicitly allow-listed in a specific git-spec format. The warlock is pulled from git and runs a build step on install, so v11's gate broke `pnpm install` **repo-wide** (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`).

The published tarball ships **pre-built** (`main: dist/index.js`) with **no install script**, and its only dependency (`@virustotal/yara-x`) is a prebuilt WASM package with no install script either. So installing from the registry runs no build step at all, and v11 has nothing to gate. This fixes the failure at the root instead of pinning pnpm or hand-maintaining a SHA-pinned allowlist.

## Changes

- `package.json` — warlock dep `git+...` → `^0.2.2`.
- `pnpm-workspace.yaml` — removed the now-unnecessary `@posthog/warlock` entries from `onlyBuiltDependencies` and `allowBuilds` (kept `esbuild`).
- `pnpm-lock.yaml` — regenerated; warlock now resolves to `0.2.2` from the registry, no git refs remain.

## Verification (local, pnpm v10)

- `pnpm install` resolves `0.2.2` from the registry, lockfile has zero `warlock.git` refs.
- Package imports `{ scan, triageMatches, CATEGORIES }` — exactly what `scripts/scan-warlock.js` uses.
- WASM scanner runs and returns `{ matched, matches: [{ rule, metadata, matchedStrings }] }`, the shape `scan-warlock.js` consumes (confirmed against a real shipped rule).
- `npm test` passes (58/58).
- CI's `node scripts/scan-warlock.js dist/skills` step (in `build.yml`) is the end-to-end integration check.

## Heads-up for the reviewer

- warlock `0.2.2` declares `engines: node ^20.20.0 || >=22.22.0`, slightly newer than this repo's `>=20.11.0`. CI uses `node-version: lts/*`, which satisfies it, but if anyone runs an older Node locally they may see an engines warning.
- Independent of the in-flight CLI overhaul PR (#178); this targets `main` directly so it can land and unblock CI for everyone.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*