### PR TITLE
feat(logs): add Flutter variant to logs skills

### DIFF
--- a/context/skills/logs/config.yaml
+++ b/context/skills/logs/config.yaml
@@ -71,6 +71,12 @@ variants:
     docs_urls:
       - https://posthog.com/docs/logs/installation/ios.md
 
+  - id: flutter
+    display_name: Flutter
+    tags: [flutter, dart]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/flutter.md
+
   - id: other
     display_name: Other Languages
     tags: []

--- a/context/skills/omnibus/instrument-logs/config.yaml
+++ b/context/skills/omnibus/instrument-logs/config.yaml
@@ -25,4 +25,5 @@ variants:
       - https://posthog.com/docs/logs/installation/android.md
       - https://posthog.com/docs/logs/installation/react-native.md
       - https://posthog.com/docs/logs/installation/ios.md
+      - https://posthog.com/docs/logs/installation/flutter.md
       - https://posthog.com/docs/logs/installation/other.md


### PR DESCRIPTION
## Problem

The logs skills cover all platforms except Flutter. iOS, Android, and React Native are present in both the wizard variant list and the omnibus \`instrument-logs\` skill, but Flutter is missing — so the AI wizard / coding-agents can't surface PostHog logs setup for Flutter apps.

## Changes

- Add a \`flutter\` variant to \`context/skills/logs/config.yaml\` (after \`ios\`), pointing at \`https://posthog.com/docs/logs/installation/flutter.md\`.
- Add the Flutter installation doc URL to the omnibus \`instrument-logs\` \`all\` variant.

This completes mobile parity: react-native, android, ios, flutter.

## Notes

Depends on the posthog.com Flutter logs installation page landing: PostHog/posthog.com#17529. Kept as a draft until that page is live so the manifest doesn't 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)