### PR TITLE
Remove obsolete warlock private-git-dependency CI steps

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,22 +39,6 @@ jobs:
         with:
           version: latest
 
-      # TODO: Remove these two steps once @posthog/warlock is published to npm.
-      # They exist because warlock is currently installed as a private git dependency,
-      # so the CI runner needs credentials to clone it.
-      - name: Generate token for private dependencies
-        id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        with:
-          app-id: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_APP_ID }}
-          private-key: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_PRIVATE_KEY }}
-          repositories: warlock
-
-      - name: Configure git auth for private deps
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://x-access-token:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
       run: pnpm build
 
     - name: Scan skills with Warlock
+      # Fork PRs don't get repo secrets, so Warlock can't reach the LLM gateway to
+      # triage matches and reports every hit (incl. false positives) as a threat.
+      # On forks we let the scan run and annotate, but don't fail the build — the
+      # full triaged scan still gates trusted runs (push-to-main, release).
+      continue-on-error: ${{ github.event.pull_request.head.repo.fork == true }}
       env:
         CONTEXT_MILL_WARLOCK_POSTHOG_PERSONAL_KEY: ${{ secrets.CONTEXT_MILL_WARLOCK_POSTHOG_PERSONAL_KEY }}
       run: node scripts/scan-warlock.js dist/skills

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,22 +27,6 @@ jobs:
       with:
         version: latest
 
-    # TODO: Remove these two steps once @posthog/warlock is published to npm.
-    # They exist because warlock is currently installed as a private git dependency,
-    # so the CI runner needs credentials to clone it.
-    - name: Generate token for private dependencies
-      id: app-token
-      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-      with:
-        app-id: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_APP_ID }}
-        private-key: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_PRIVATE_KEY }}
-        repositories: warlock
-
-    - name: Configure git auth for private deps
-      env:
-        APP_TOKEN: ${{ steps.app-token.outputs.token }}
-      run: git config --global url."https://x-access-token:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
-
     - name: Install dependencies
       run: pnpm install
 


### PR DESCRIPTION
## What

Makes CI pass on forked PRs, in two parts:

1. **Removes** the now-obsolete `Generate token for private dependencies` and `Configure git auth for private deps` steps (plus their stale `TODO` comment) from `build.yml` and `build-release.yml`.
2. **Makes the `Scan skills with Warlock` step non-blocking on fork PRs** in `build.yml`, via `continue-on-error: ${{ github.event.pull_request.head.repo.fork == true }}`.

## Why — remove the private-git-dep steps

`@posthog/warlock` is now published to npm — `package.json` pins `^0.2.2` and `pnpm-lock.yaml` resolves it from the registry (sha512 integrity hash, not a git URL). The CI runner no longer needs GitHub App credentials to clone it as a private git dependency, which is exactly what these two steps did.

These steps **fail on forked PRs**: GitHub does not pass repo/org secrets to fork workflows, so `secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_APP_ID` resolves empty and the action throws before anything builds:

```
Error: Input required and not supplied: app-id
```

The steps' own comment already said to remove them once warlock was published:

```
# TODO: Remove these two steps once @posthog/warlock is published to npm.
```

So this honors that TODO.

## Why — make the scan non-blocking on forks

Removing the steps above clears the `app-id` failure but exposes a *second* fork issue: the `Scan skills with Warlock` step needs `CONTEXT_MILL_WARLOCK_POSTHOG_PERSONAL_KEY` to reach the LLM gateway for triage. Forks don't get that secret, so the scan can't triage and reports **every** match (including false positives) as a threat → the build fails. Warlock is noisy against this repo's own skill docs, so fork contributors would routinely hit red builds they can't do anything about.

Scoping `continue-on-error` to forks fixes this:

- **On forks:** the scan still runs and still posts its annotations inline on the diff, but a scan failure no longer fails the job → the check goes green and the PR is mergeable without an admin override.
- **On trusted runs** (internal-branch PRs, push-to-main, release): the expression is `false`, so the scan stays a **hard gate** with full LLM triage.

It is scoped to that single step — install, build, lint, and bundle-size checks all still block the build normally on forks.

### Review workflow this implies

Fork PR scans become advisory: a maintainer reviews the Warlock annotations on the diff as part of normal review. Nothing unsafe can ship, because the full triaged scan still gates `build-release` (on merge to main, where the secret exists). If contribution volume ever makes manual triage annoying, the proper next step is an approval-gated workflow — intentionally out of scope here.

## Left untouched (intentionally)

- `build-release.yml` → `Generate skills repo token` (`SKILLS_PUSH_APP_ID`) — unrelated; pushes generated plugins to `skills`/`ai-plugin`.
- `wizard-ci-trigger.yml` → `Generate GitHub App token` — unrelated; handles the `/wizard-ci` command.
- The `Scan skills with Warlock` step still runs in both workflows — it's the actual security scan, and stays a hard gate everywhere except fork PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
