### PR TITLE
make audit all the default

### DIFF
--- a/context/skills/audit-events/config.yaml
+++ b/context/skills/audit-events/config.yaml
@@ -6,7 +6,6 @@ cli:
   role: command
   parentCommand: audit
   command: events
-  default: true
 references:
   preamble: "**Read ONLY this file.** Do not read any other reference file until this one tells you to."
 shared_docs:

--- a/context/skills/audit/config.yaml
+++ b/context/skills/audit/config.yaml
@@ -6,6 +6,7 @@ cli:
   role: command
   parentCommand: audit
   command: all
+  default: true
 references:
   preamble: "**Read ONLY this file.** Do not read any other reference file until this one tells you to."
 shared_docs:


### PR DESCRIPTION
mapping default command to the code audit instead of the events audit