### PR TITLE
emit dashboard URL and exact event field names

### DIFF
--- a/context/skills/integration/references/1-begin.md
+++ b/context/skills/integration/references/1-begin.md
@@ -30,7 +30,7 @@ Look for opportunities to track client-side events.
 
 Do not skip server-side events - they capture actions that cannot be tracked client-side.
 
-Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add: event name, event description, and the file path we want to place the event in. If events already exist, don't duplicate them; supplement them.
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add with these exact field names: `event_name` (the event name), `event_description` (one sentence), and `file` (the file path the event goes in). The wizard reads this file to surface the plan in the UI. If events already exist, don't duplicate them; supplement them.
 
 Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
 

--- a/context/skills/integration/references/4-conclude.md
+++ b/context/skills/integration/references/4-conclude.md
@@ -4,7 +4,9 @@ title: PostHog Setup - Conclusion
 description: Review and fix any errors in the PostHog integration implementation
 ---
 
-Use the PostHog MCP to create a new dashboard named "Analytics basics (wizard)" based on the events created here. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go. Make sure to use the exact same event names as implemented in the code. Populate it with up to five insights, with special emphasis on things like conversion funnels, churn events, and other business critical insights.  
+Use the PostHog MCP to create a new dashboard named "Analytics basics (wizard)" based on the events created here. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go. Make sure to use the exact same event names as implemented in the code. Populate it with up to five insights, with special emphasis on things like conversion funnels, churn events, and other business critical insights.
+
+Once the dashboard exists, emit its URL on its own line in your assistant message using this exact marker: `[DASHBOARD_URL] <full https url>`. The wizard parses this marker from your visible message and surfaces the link in the success summary. Mentioning the URL only in thinking or in prose without the marker means the link is dropped.
 
 Search for a file called `.posthog-events.json` and read it for available events.
 


### PR DESCRIPTION
I noticed sometimes the outrodata would render blank screens bc the agent would change up the field names in `.posthog-events.json`

<img width="869" height="483" alt="image" src="https://github.com/user-attachments/assets/38633a6c-df82-43ed-8c78-c7a769e2cbf0" />
