### PR TITLE
chore: migrate client getFeatureFlagPayload examples to getFeatureFlagResult

### DIFF
--- a/context/skills/creating-product-tours/description.md
+++ b/context/skills/creating-product-tours/description.md
@@ -100,8 +100,9 @@ export function useTour({
     const ready = isPosthogReady();
     if (ready) {
       // Production path: PostHog is wired, the flag decides.
-      if (!posthog.isFeatureEnabled(flagKey)) return;
-      const payload = posthog.getFeatureFlagPayload(flagKey) as {
+      const result = posthog.getFeatureFlagResult(flagKey);
+      if (!result?.enabled) return;
+      const payload = result.payload as {
         steps?: TourStep[];
       } | null;
       if (payload?.steps) setSteps(payload.steps);

--- a/context/skills/migrate/references/statsig/mapping.md
+++ b/context/skills/migrate/references/statsig/mapping.md
@@ -43,13 +43,13 @@ The Statsig server-side gate calls take a user object; PostHog takes a `distinct
 
 ## Dynamic configs and experiments
 
-PostHog represents both Statsig `DynamicConfig` and Statsig `Experiment` as **multivariate feature flags**. The flag's payload is read with `getFeatureFlagPayload`.
+PostHog represents both Statsig `DynamicConfig` and Statsig `Experiment` as **multivariate feature flags**. The flag's payload is read with `getFeatureFlagResult`.
 
 | Statsig | PostHog |
 |---|---|
-| `statsig.getConfig('my-config').get('key', fallback)` | `(posthog.getFeatureFlagPayload('my-config') ?? {})['key'] ?? fallback` |
+| `statsig.getConfig('my-config').get('key', fallback)` | `(posthog.getFeatureFlagResult('my-config')?.payload ?? {})['key'] ?? fallback` |
 | `statsig.getConfig('my-config').getValue('key', fallback)` | Same as above. |
-| `statsig.getExperiment('my-exp').get('variant', fallback)` | `posthog.getFeatureFlag('my-exp') ?? fallback` (variant key) **or** `posthog.getFeatureFlagPayload('my-exp')?.['variant'] ?? fallback` if the call is reading a config-style payload key. The bundled reference defers to the call shape: a single-variant-string read is the former; a structured key read is the latter. |
+| `statsig.getExperiment('my-exp').get('variant', fallback)` | `posthog.getFeatureFlag('my-exp') ?? fallback` (variant key) **or** `posthog.getFeatureFlagResult('my-exp')?.payload?.['variant'] ?? fallback` if the call is reading a config-style payload key. The bundled reference defers to the call shape: a single-variant-string read is the former; a structured key read is the latter. |
 | `useConfig('my-config').get('key', fallback)` | `(useFeatureFlagPayload('my-config') ?? {})['key'] ?? fallback` |
 | `useExperiment('my-exp').get('variant', fallback)` | `useFeatureFlagVariantKey('my-exp') ?? fallback` |
 


### PR DESCRIPTION
## Changes

Two authored skill references in context-mill still used the deprecated client `posthog.getFeatureFlagPayload(...)`. These are authored here (not generated from posthog.com), so they don't get fixed by the upstream doc changes and were drifting from posthog.com's already-migrated Statsig guide.

- **`migrate/statsig` mapping** — read the flag payload via `getFeatureFlagResult('...')?.payload` (3 spots: the prose plus the DynamicConfig and Experiment rows). Matches PostHog/posthog.com's migrated `migrate/statsig.mdx`.
- **`creating-product-tours`** — the example evaluated the flag twice (`isFeatureEnabled` then `getFeatureFlagPayload`); now reads `enabled` and `payload` from a single `getFeatureFlagResult` result.

Left unchanged: Laravel example app (PHP — backend SDK, separate `evaluateFlags` deprecation), the `useFeatureFlagPayload` React hook (not deprecated), experiment-exposure guidance prose, and the audit skills' grep detection patterns (which must keep matching `getFeatureFlagPayload` to find deprecated usage).

This is part of the client-SDK `getFeatureFlagPayload` → `getFeatureFlagResult` deprecation sweep. Companion source fixes: PostHog/posthog.com#17768 (feature-flag web/android snippets) and PostHog/posthog-js#3889 (JS SDK TSDoc example).
