### PR TITLE
Fix broken MCP path references after server move

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repo packages PostHog's developer content (docs, prompts, example code)
 into [Agent Skills](https://agentskills.io/specification)-compliant skill
 packages. The build pipeline emits a versioned manifest plus per-skill ZIPs,
 consumed by the PostHog [wizard](https://github.com/PostHog/wizard) and the
-PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp).
+PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp).
 
 User-facing intro: [README.md](README.md). Contributor handbook:
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We'd love your pull request!
 
 The context mill gathers up-to-date content from multiple sources, packaging PostHog developer docs, prompts, and working example code into a versioned manifest which can be shipped anywhere as a zip file. 
 
-The [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp) currently fetches the examples repo manifest and exposes it to any MCP-compatible client as resources and slash commands. This is what currently powers the PostHog [wizard](https://github.com/PostHog/wizard). 
+The [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp) currently fetches the examples repo manifest and exposes it to any MCP-compatible client as resources and slash commands. This is what currently powers the PostHog [wizard](https://github.com/PostHog/wizard).
 
 ## Context engine 
 


### PR DESCRIPTION
## Why

There is a stale MCP path in this repo’s docs that still points at `products/mcp`, which is no longer the active location in the PostHog repo.

PostHog moved MCP to `services/mcp`, and this update keeps links accurate for users who follow the README/agent docs.

## Historical context (verified)

- Root cause is PostHog commit `c4fe76bdcb85b7b0c6c44079a34854aa538c5005` dated **2025-12-23**
  (commit message: `chore(mcp): move mcp server to services folder (#43928)`).
- That commit is the MCP migration PR: https://github.com/PostHog/posthog/pull/43928.
- The migration renamed the folder from `products/mcp` to `services/mcp`, so the old path now 404s and we should point users at the new path.

## What changed

- Updated the broken MCP link in `README.md` to `https://github.com/PostHog/posthog/tree/master/services/mcp`.
- Updated the same MCP path in `AGENTS.md` for consistency across repo guidance.

## Evidence

- `https://github.com/PostHog/posthog/tree/master/products/mcp` now returns 404.
- `https://github.com/PostHog/posthog/tree/master/services/mcp` is reachable.

## Human summary

This is a small, low-risk docs-only fix to prevent dead links after the MCP folder migration.

## Testing

- Not run (documentation-only change).
- By virtue of opening said links in the browser, like men of Victorian culture used to do back in the day.
