### PR TITLE
Remove "install packages as a background task" instruction

### DIFF
--- a/context/skills/error-tracking-upload-source-maps/description.md
+++ b/context/skills/error-tracking-upload-source-maps/description.md
@@ -271,7 +271,7 @@ Confirm the upload landed and report what changed.
 - Two different keys, two different jobs: a **personal API key** uploads maps at build time; the **public project key** powers the SDK at runtime. Don't swap them.
 - Keep build artifacts and uploaded maps in sync — every deploy should inject + upload within the same build so stack traces always resolve.
 - Uploaded maps live in PostHog and never need to be served publicly.
-- Detect the project's package manager before installing any dependency, and let long installs run in the background instead of blocking on them.
+- Detect the project's package manager before installing any dependency.
 - Read a file (and note its exact contents) immediately before editing it — essential for any temporary test code you'll revert afterwards.
 
 ## Framework guidelines

--- a/context/skills/omnibus/instrument-error-tracking/description.md
+++ b/context/skills/omnibus/instrument-error-tracking/description.md
@@ -21,7 +21,6 @@ STEP 2: Research instrumentation. (Skip if PostHog is already set up.)
 
 STEP 3: Install and initialize the PostHog SDK. (Skip if PostHog is already set up.)
   - Add the PostHog SDK package for the detected platform. Do not manually edit package.json — use the package manager's install command.
-  - Always install packages as a background task. Don't await completion; proceed with other work immediately after starting the installation.
   - Follow the framework reference for where and how to initialize.
 
 STEP 4: Enable exception autocapture.

--- a/context/skills/omnibus/instrument-integration/description.md
+++ b/context/skills/omnibus/instrument-integration/description.md
@@ -21,7 +21,6 @@ STEP 2: Research integration.
 
 STEP 3: Install the PostHog SDK.
   - Add the PostHog SDK package for the detected platform. Do not manually edit package.json — use the package manager's install command.
-  - Always install packages as a background task. Don't await completion; proceed with other work immediately after starting the installation.
 
 STEP 4: Initialize PostHog.
   - Follow the framework reference for where and how to initialize. This varies significantly by framework (e.g., instrumentation-client.ts for Next.js 15.3+, AppConfig.ready() for Django, create_app() for Flask).

--- a/context/skills/omnibus/instrument-llm-analytics/description.md
+++ b/context/skills/omnibus/instrument-llm-analytics/description.md
@@ -24,7 +24,6 @@ STEP 2: Research instrumentation. (Skip if PostHog LLM tracing is already set up
 STEP 3: Install the PostHog SDK. (Skip if PostHog is already set up.)
   - Add the PostHog SDK and any required callback/integration packages.
   - Do not manually edit dependency files — use the package manager's install command.
-  - Always install packages as a background task. Don't await completion; proceed with other work immediately.
 
 STEP 4: Add LLM tracing.
   - Instrument LLM calls to capture input tokens, output tokens, model name, latency, and costs for every generation.

--- a/context/skills/omnibus/instrument-logs/description.md
+++ b/context/skills/omnibus/instrument-logs/description.md
@@ -22,7 +22,6 @@ STEP 2: Research log capture. (Skip if PostHog log export is already configured.
 STEP 3: Install dependencies. (Skip if PostHog log export is already configured.)
   - Install the OpenTelemetry SDK and OTLP exporter packages for the detected platform.
   - Do not manually edit dependency files — use the package manager's install command.
-  - Always install packages as a background task. Don't await completion; proceed with other work immediately.
 
 STEP 4: Configure the OTLP exporter. (Skip if PostHog log export is already configured.)
   - PostHog logs use the OpenTelemetry protocol. Set up an OTLP exporter pointed at PostHog's ingest endpoint.

--- a/context/skills/omnibus/instrument-product-analytics/description.md
+++ b/context/skills/omnibus/instrument-product-analytics/description.md
@@ -21,7 +21,6 @@ STEP 2: Research integration. (Skip if PostHog is already set up.)
 
 STEP 3: Install the PostHog SDK. (Skip if PostHog is already set up.)
   - Add the PostHog SDK package for the detected platform. Do not manually edit package.json — use the package manager's install command.
-  - Always install packages as a background task. Don't await completion; proceed with other work immediately after starting the installation.
 
 STEP 4: Initialize PostHog. (Skip if PostHog is already set up.)
   - Follow the framework reference for where and how to initialize. This varies significantly by framework (e.g., instrumentation-client.ts for Next.js 15.3+, AppConfig.ready() for Django, create_app() for Flask).


### PR DESCRIPTION
Drop the guidance telling the agent to background SDK installs and not
await them across the omnibus instrument-* skills and the source-maps
skill. Keeps the package-manager-detection guidance intact.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>