### PR TITLE
feat(skills): instrument @rekog/mcp-nest servers via serverMutator

### DIFF
--- a/context/skills/mcp-analytics/config.yaml
+++ b/context/skills/mcp-analytics/config.yaml
@@ -2,7 +2,7 @@
 type: skill
 template: description.md
 category: mcp-analytics
-description: Add PostHog MCP analytics to a TypeScript or JavaScript MCP server. Instruments the server with the @posthog/mcp SDK so every tool call, agent intent, and failure is captured as a $mcp_* event. Detects the server style (official @modelcontextprotocol/sdk Server/McpServer, mcp-handler, or a custom HTTP/edge dispatcher) and wires in the matching instrumentation, credentials, and graceful shutdown.
+description: Add PostHog MCP analytics to a TypeScript or JavaScript MCP server. Instruments the server with the @posthog/mcp SDK so every tool call, agent intent, and failure is captured as a $mcp_* event. Detects the server style (official @modelcontextprotocol/sdk Server/McpServer, mcp-handler, @rekog/mcp-nest, or a custom HTTP/edge dispatcher) and wires in the matching instrumentation, credentials, and graceful shutdown.
 tags: [mcp-analytics, mcp]
 cli:
   role: command

--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -21,6 +21,7 @@ Follow these steps IN ORDER.
 - Look for MCP server signals in dependencies and source:
   - `@modelcontextprotocol/sdk` — the official SDK (most common).
   - `mcp-handler` — the Next.js / Vercel adapter.
+  - `@rekog/mcp-nest` — the NestJS adapter (tools defined with `@Tool()` decorators; the server is built inside `McpModule.forRoot(...)`, so there's no `new McpServer` in user code).
   - `fastmcp`, `xmcp`, or a similar TS MCP framework.
   - A custom HTTP/edge handler that speaks the MCP protocol directly (JSON-RPC methods like `tools/call`, `initialize`, an `Mcp-Session-Id` header) without any of the above.
 - Identify the file and the exact place where the server is constructed or where MCP requests are dispatched. Read it before editing.
@@ -34,6 +35,7 @@ Pick exactly one based on what STEP 1 found. When in doubt, read the bundled ref
 - **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)` from `@modelcontextprotocol/sdk`): wrap it with `instrument(server, posthog)`. One line.
 - **Path B — `mcp-handler`** (`createMcpHandler((server) => { ... })`): same `instrument(server, posthog)` call, inside the setup callback. Because Vercel's transport is stateless, also wire `identify` (STEP 4) and flush per invocation (STEP 6).
 - **Path C — custom dispatcher** (Hono / Express / Cloudflare Worker / edge function with no SDK server object to wrap): use the `PostHogMCP` client and call `captureToolCall` / `captureInitialize` yourself at the dispatch points. More placement, same resulting events.
+- **Path D — `@rekog/mcp-nest`** (NestJS): the framework builds the server, so there's no `new McpServer` for you to wrap. Instrument it through the module's `serverMutator` hook in `McpModule.forRoot(...)`. See STEP 4.
 
 ### STEP 3: Install the SDKs
 
@@ -101,6 +103,33 @@ posthog.captureToolCall({
 ```
 
 Resolve `distinctId` / `sessionId` from whatever auth/session the dispatcher already has; omit them rather than inventing values. These calls are fire-and-forget and never throw, so they can't take down a tool.
+
+**Path D — `@rekog/mcp-nest` (NestJS):** the framework builds the server, so pass a `serverMutator` to `McpModule.forRoot(...)`. Call `instrument()` inside it and **return the server** — returning `instrument()`'s handle instead would replace the server and break the module. If a `serverMutator` already exists, compose with it (mutate, instrument, return). Handlers nest registers after `instrument()` runs are still captured.
+
+```ts
+import { Module } from "@nestjs/common"
+import { McpModule } from "@rekog/mcp-nest"
+import { instrument } from "@posthog/mcp"
+import { PostHog } from "posthog-node"
+
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: process.env.POSTHOG_HOST,
+})
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: "my-mcp-server",
+      version: "1.0.0",
+      serverMutator: (server) => {
+        instrument(server, posthog)
+        return server // return the server, NOT instrument()'s handle
+      },
+    }),
+  ],
+})
+class AppModule {}
+```
 
 ### STEP 5: Wire up credentials
 

--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -127,16 +127,7 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
 class AppModule {}
 ```
 
-`instrumentMutator` needs `@posthog/mcp` **≥ 0.5.0**. If the installed version (check `package.json`) doesn't export it, use the explicit form — call `instrument()` and **return the server**, not its handle (returning the handle replaces the server and breaks the module):
-
-```ts
-serverMutator: (server) => {
-  instrument(server, posthog)
-  return server
-}
-```
-
-Either way, handlers nest registers after the mutator runs are still captured, and compose with an existing `serverMutator` if there is one. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), use the explicit form and keep `instrument()`'s returned handle.
+`instrumentMutator` returns the server (not `instrument()`'s handle), so it slots straight into the hook. Compose with an existing `serverMutator` if there is one, and handlers nest registers after the mutator runs are still captured. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), call `instrument()` directly inside your own mutator and keep its handle, returning the server yourself.
 
 ### STEP 5: Wire up credentials
 

--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -104,13 +104,12 @@ posthog.captureToolCall({
 
 Resolve `distinctId` / `sessionId` from whatever auth/session the dispatcher already has; omit them rather than inventing values. These calls are fire-and-forget and never throw, so they can't take down a tool.
 
-**Path D — `@rekog/mcp-nest` (NestJS):** the framework builds the server, so pass a `serverMutator` to `McpModule.forRoot(...)`. Call `instrument()` inside it and **return the server** — returning `instrument()`'s handle instead would replace the server and break the module. If a `serverMutator` already exists, compose with it (mutate, instrument, return). Handlers nest registers after `instrument()` runs are still captured.
+**Path D — `@rekog/mcp-nest` (NestJS):** the framework builds the server, so pass a `serverMutator` to `McpModule.forRoot(...)`. Prefer the `instrumentMutator` helper — it instruments the server and returns it, so it drops straight into the hook:
 
 ```ts
 import { Module } from "@nestjs/common"
 import { McpModule } from "@rekog/mcp-nest"
-import { instrument } from "@posthog/mcp"
-import { PostHog } from "posthog-node"
+import { PostHog, instrumentMutator } from "@posthog/mcp"
 
 const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
   host: process.env.POSTHOG_HOST,
@@ -121,15 +120,23 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
     McpModule.forRoot({
       name: "my-mcp-server",
       version: "1.0.0",
-      serverMutator: (server) => {
-        instrument(server, posthog)
-        return server // return the server, NOT instrument()'s handle
-      },
+      serverMutator: instrumentMutator(posthog),
     }),
   ],
 })
 class AppModule {}
 ```
+
+`instrumentMutator` needs `@posthog/mcp` **≥ 0.5.0**. If the installed version (check `package.json`) doesn't export it, use the explicit form — call `instrument()` and **return the server**, not its handle (returning the handle replaces the server and breaks the module):
+
+```ts
+serverMutator: (server) => {
+  instrument(server, posthog)
+  return server
+}
+```
+
+Either way, handlers nest registers after the mutator runs are still captured, and compose with an existing `serverMutator` if there is one. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), use the explicit form and keep `instrument()`'s returned handle.
 
 ### STEP 5: Wire up credentials
 


### PR DESCRIPTION
## What

Teaches the `mcp-analytics` install skill to handle **NestJS** MCP servers built with [`@rekog/mcp-nest`](https://github.com/rekog-labs/MCP-Nest). Today the codemod looks for `new Server(...)` / `new McpServer(...)`, but nest users never construct the server — `McpModule.forRoot(...)` does, and tools are `@Tool()` decorators. So the wizard had no insertion point.

## How

- **Detection:** `@rekog/mcp-nest` added as a server signal in STEP 1.
- **Path D (STEP 2 + 4):** instrument through the module's `serverMutator` hook:
  ```ts
  McpModule.forRoot({
    serverMutator: (server) => { instrument(server, posthog); return server },
  })
  ```
  Return the *server*, not `instrument()`'s handle (that would replace the server and break the module). Compose with an existing mutator if present.

This works because of `@posthog/mcp` PR #3993 (now merged): `instrument()` patches `setRequestHandler` once and captures handlers nest registers *after* the mutator runs.

## Validation

- `pnpm test:skills` — 70 pass; `pnpm build` emits `mcp-analytics.zip` with the nest path bundled.

## Ships when

Needs a context-mill **release** (`mcp-publish` label) to reach the live `wizard mcp-analytics`. No wizard release required — the skill resolves from the published manifest.

## Follow-ups (separate)

A workbench NestJS fixture to exercise it end-to-end, and a docs adapter note on posthog.com.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
