### PR TITLE
Add ingestion-warnings skill

### DIFF
--- a/context/skills/ingestion-warnings/config.yaml
+++ b/context/skills/ingestion-warnings/config.yaml
@@ -1,0 +1,18 @@
+# Ingestion warnings - docs-only stepwise skill (no example projects)
+type: skill
+template: description.md
+description: Diagnose and fix the instrumentation behind a PostHog project's ingestion warnings — events PostHog had to drop, mis-merge, or degrade on the way in. Queries system.ingestion_warnings to see which warning types are actually firing, traces each one back to the code that produces it, and applies the fix. Covers illegal/already-identified merges, invalid UUIDs and timestamps, future-dated events, the 1MB size limit, ingestion overflow, invalid replay timestamps, $set on exception events, and invalid heatmap data (relative $current_url).
+tags: [best-practices]
+cli:
+  role: command
+  command: ingestion-warnings
+references:
+  preamble: "**Read ONLY this file.** Follow its contents in sequence. Do not read any other reference file until this one tells you to."
+shared_docs:
+  - https://posthog.com/docs/data/ingestion-warnings.md
+  - https://posthog.com/docs/getting-started/identify-users.md
+variants:
+  - id: all
+    display_name: PostHog ingestion warnings — diagnose & fix
+    tags: [best-practices]
+    docs_urls: []

--- a/context/skills/ingestion-warnings/description.md
+++ b/context/skills/ingestion-warnings/description.md
@@ -1,0 +1,48 @@
+# PostHog Ingestion Warnings — diagnose & fix
+
+This skill diagnoses a PostHog project's **ingestion warnings** and fixes the instrumentation producing them. Ingestion warnings are events PostHog had to drop, mis-merge, or degrade as they came in — so the affected data is incomplete or inaccurate. You can't fix this after the fact by reprocessing; you have to fix the code that sends the bad events.
+
+The skill is **data-first**: it queries `system.ingestion_warnings` to see which warning types are *actually firing* for this project, then traces each firing type back to the offending code and applies the fix. It does not blindly rewrite working instrumentation — only the patterns tied to a warning the project is really hitting.
+
+**Start by reading `references/1-triage.md`.** Do not Glob, ls, or find the skill directory. Do not preload `2-fix.md` or `3-report.md`. Read each step file once, in order; do not re-read an earlier step once you've moved past it. Do not re-read this file.
+
+Each step persists what the next step needs to a scratch file at the project root (`.posthog-ingestion-warnings.json`) so later steps never have to re-open earlier step files. The final step deletes that scratch file and writes the report.
+
+## Tools
+
+`ToolSearch` is only for loading a tool by its exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool this skill needs (`Glob`, `Grep`, `Read`, `Edit`, `Write`, `Bash`, and `mcp__posthog__execute-sql` for reading the project's warnings) is already named in the step files.
+
+Do **not** call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`. Progress is reported through `[STATUS]` lines and the scratch file, not a task list.
+
+## Status — `[STATUS]`
+
+The live "Working on …" banner reads from `[STATUS]` lines you emit in plain text. Whenever you start a new sub-step, emit a line like:
+
+```
+[STATUS] Querying ingestion warnings
+```
+
+Each step file lists the exact `[STATUS]` strings to emit. Use them freely — they are cheap.
+
+## Abort — `[ABORT]`
+
+Report unrecoverable preconditions with `[ABORT] <reason>` on its own line. The wizard runner catches it and terminates the run — you do not need to halt yourself afterwards. Abort reasons this skill uses:
+
+- No PostHog SDK initialization found in the project
+- Could not read ingestion warnings and no PostHog instrumentation found to scan
+
+## Guiding tenets
+
+Follow these for every fix:
+
+1. **Fix the cause, not the symptom.** Each warning maps to a specific SDK misuse. Change the code that sends the bad event; never add filtering, try/catch swallowing, or property stripping that just hides the warning while keeping the broken data.
+2. **Only touch what a firing warning points to.** If the triage query says only `invalid_heatmap_data` is firing, fix only that. Don't "while I'm here" refactor other instrumentation.
+3. **Never fabricate identifiers.** When a fix needs a stable `distinct_id` or user id and it isn't in scope, thread it from a caller that has it, or leave a clearly-marked `TODO` and record it in the report — never substitute a guessed or generic value.
+4. **Preserve existing behavior.** Make minimal, additive edits. Don't restructure unrelated code or change event names, payloads, or call sites beyond what the fix requires.
+5. **Report what you couldn't fix.** A warning whose producing code you can't locate, or that needs a human decision, goes in the report under "Needs manual attention" — don't guess.
+
+## Reference files
+
+{references}
+
+{commandments}

--- a/context/skills/ingestion-warnings/description.md
+++ b/context/skills/ingestion-warnings/description.md
@@ -26,9 +26,8 @@ Each step file lists the exact `[STATUS]` strings to emit. Use them freely — t
 
 ## Abort — `[ABORT]`
 
-Report unrecoverable preconditions with `[ABORT] <reason>` on its own line. The wizard runner catches it and terminates the run — you do not need to halt yourself afterwards. Abort reasons this skill uses:
+Report unrecoverable preconditions with `[ABORT] <reason>` on its own line. The wizard runner catches it and terminates the run — you do not need to halt yourself afterwards. The one abort reason this skill uses (emitted in `1-triage.md`):
 
-- No PostHog SDK initialization found in the project
 - Could not read ingestion warnings and no PostHog instrumentation found to scan
 
 ## Guiding tenets

--- a/context/skills/ingestion-warnings/references/1-triage.md
+++ b/context/skills/ingestion-warnings/references/1-triage.md
@@ -1,0 +1,81 @@
+---
+next_step: 2-fix.md
+---
+
+# Step 1 — Triage: which warnings are firing, and is there code to fix?
+
+This step decides what the rest of the run works on. It reads the project's real ingestion warnings, confirms the project has PostHog instrumentation to fix, and writes a prioritized worklist to the scratch file. It does **not** fix anything — `2-fix.md` owns the fixes.
+
+## Tools
+
+Load once at the start of this step:
+`ToolSearch select:Grep,mcp__posthog__execute-sql`
+
+## Status
+
+Emit, in order, as you reach each sub-step:
+
+```
+[STATUS] Querying ingestion warnings
+[STATUS] Checking for PostHog instrumentation
+[STATUS] Building the worklist
+```
+
+## a. Read which warning types are firing
+
+Call `mcp__posthog__execute-sql` to group recent warnings by type over the last 7 days:
+
+```sql
+SELECT type, count() AS cnt
+FROM system.ingestion_warnings
+WHERE timestamp > now() - INTERVAL 7 DAY
+GROUP BY type
+ORDER BY cnt DESC
+```
+
+If the table or a column name is rejected, retry once without the `WHERE` clause, then with `LIMIT 1000` over the raw rows (`SELECT type, details, timestamp FROM system.ingestion_warnings ...`) and aggregate the `type` values yourself. The exact schema can vary by project — adapt column names to what the error message reports rather than giving up.
+
+For **each** firing `type`, pull a few example payloads so you can see the affected event shape (the offending property usually shows up in `details`):
+
+```sql
+SELECT details, timestamp
+FROM system.ingestion_warnings
+WHERE type = '<type>'
+ORDER BY timestamp DESC
+LIMIT 5
+```
+
+**If the query path is entirely unavailable** (no `mcp__posthog__execute-sql`, or it errors on every variant): don't abort yet. Fall through to (b), and if instrumentation exists, build the worklist from the **full** catalog in `2-fix.md` instead of from query results — i.e. scan for every known anti-pattern. Record in the scratch file that warnings could not be read, so the report says findings are code-derived, not data-confirmed.
+
+## b. Confirm there's PostHog instrumentation to fix
+
+Run a single `Grep` (`output_mode: "files_with_matches"`) for SDK init / capture surfaces:
+
+```
+posthog\.init\(|new PostHog\(|posthog\.capture\(|posthog\.identify\(|PostHog\(|usePostHog\(
+```
+
+- **Zero hits anywhere** and the query in (a) also failed → emit `[ABORT] Could not read ingestion warnings and no PostHog instrumentation found to scan` and stop.
+- **Zero hits but (a) returned warnings** → the producing code may live in a sibling repo (e.g. a backend that sends events). Don't abort; record this and let the report flag that the offending sender wasn't found in this checkout.
+- **Hits found** → continue.
+
+## c. Write the worklist to the scratch file
+
+`Write` `.posthog-ingestion-warnings.json` at the project root. One entry per warning type to act on (from the query in (a), or the full catalog if you fell back). Use the `type` string verbatim as it appeared in the data so `2-fix.md` can match it. Shape:
+
+```json
+{
+  "source": "query",                  // "query" or "code-scan" (the fallback)
+  "queriedAt": "<ISO timestamp or null>",
+  "warnings": [
+    { "type": "invalid_heatmap_data", "count": 1284, "examples": ["<trimmed details>"], "status": "pending" }
+  ],
+  "notes": ["<anything the report should mention, e.g. 'sender not found in this checkout'>"]
+}
+```
+
+Order `warnings` by `count` descending (highest-volume first) when you have counts; otherwise keep catalog order. Set every `status` to `"pending"`.
+
+Do not read project source files in this step beyond the single presence `Grep`. Do not preload `2-fix.md`.
+
+Continue to **`2-fix.md`**.

--- a/context/skills/ingestion-warnings/references/2-fix.md
+++ b/context/skills/ingestion-warnings/references/2-fix.md
@@ -1,0 +1,88 @@
+---
+next_step: 3-report.md
+---
+
+# Step 2 — Locate and fix the producing code
+
+`1-triage.md` wrote a prioritized worklist to `.posthog-ingestion-warnings.json`. This step works through that list, fixes the code behind each firing warning, and updates each entry's `status`. It does **not** write the final report — `3-report.md` owns that.
+
+## Tools
+
+`Grep`, `Read`, `Edit`, `Write`, and `Bash` are already available. Load any deferred one by exact name with `ToolSearch select:<name>`.
+
+## Status
+
+`Read` `.posthog-ingestion-warnings.json` once. For each warning you work on, emit:
+
+```
+[STATUS] Fixing <type>
+```
+
+## How to work the list
+
+For each `warnings[]` entry with `status: "pending"`, in list order:
+
+1. Find its catalog entry below by matching the `type` string. If the project's `type` doesn't exactly match a heading (codes vary across PostHog versions), match on the closest **title / description** instead.
+2. Run the catalog's **Locate** grep(s). If you find no producing code in this checkout, set the entry's `status` to `"not-found"`, add a one-line `note`, and move on — do not guess.
+3. Apply the **Fix** with the smallest edit that removes the cause (tenets 1, 2, 4 in the entry-point file). Preserve existing behavior.
+4. Update that entry in `.posthog-ingestion-warnings.json`: set `status` to `"fixed"`, `"partial"`, or `"needs-manual"`, and add `file` (`path:line`) and a one-sentence `details`. Re-`Write` the whole file after each entry so progress survives.
+
+A `type` with no catalog match: set `status: "needs-manual"`, record the `type` and an example payload in `details`, and move on. `3-report.md` surfaces it.
+
+---
+
+## Catalog
+
+### `cannot_merge_with_illegal_distinct_id` — Refused to merge with an illegal distinct ID
+**Cause:** `identify()` or `alias()` was called with a generic / illegal distinct id — `null`, `undefined`, `"null"`, `"guest"`, `"anonymous"`, `"distinct_id"`, `"true"`, `"0"`, an email literal like `"email"`, etc. PostHog refuses the merge to avoid collapsing unrelated users.
+**Locate:** `Grep` for `posthog\.identify\(|posthog\.alias\(|\.identify\(|\.alias\(`. Inspect the **first argument** at each call site.
+**Fix:** Pass a real, stable per-user identifier (the value the app already uses as the logged-in user id). Remove `identify` calls that fire before a real user exists (e.g. on a logged-out landing page). If the id genuinely isn't in scope, thread it from a caller that has it; never substitute a placeholder (tenet 3). See https://posthog.com/docs/getting-started/identify-users
+
+### `cannot_merge_already_identified` — Refused to merge an already identified user
+**Cause:** `identify()` (or `alias()`) tried to merge a user that is **already identified** into another identity — typically `identify()` called on every page load / in an effect with a changing id, calling `identify` with a new id after login without `reset()` on the previous session, or aliasing two already-identified people.
+**Locate:** `Grep` for `posthog\.identify\(|posthog\.reset\(|posthog\.alias\(`. Flag `identify` calls inside `useEffect`, render bodies, route middleware, or per-request handlers.
+**Fix:** Call `identify()` exactly once, at the moment the user authenticates, with a consistent id. Call `posthog.reset()` on logout so the next user starts clean. Don't re-identify an already-identified user with a different id. See https://posthog.com/docs/getting-started/identify-users
+
+### `skipping_event_invalid_uuid` — Refused to process event with invalid UUID
+**Cause:** Events are sent with a manually-supplied event `uuid` that isn't a valid UUID, so they're dropped.
+**Locate:** `Grep` for `uuid` near `capture(` calls (capture options object).
+**Fix:** Stop passing a custom `uuid` — let PostHog generate it. There are very few legitimate reasons to set the event UUID yourself; if one applies, ensure it's a valid v4/v7 UUID string.
+
+### `ignored_invalid_timestamp` — Ignored an invalid timestamp, event was still ingested
+**Cause:** A `timestamp` (or `sent_at`) passed on capture isn't valid ISO 8601, so PostHog ignores it and stamps its own server time — skewing when the event appears.
+**Locate:** `Grep` for `timestamp` and `sent_at` near `capture(` calls (common in `posthog-node` / batch backends).
+**Fix:** Send timestamps as ISO 8601 strings (`new Date().toISOString()` / `datetime.now(timezone.utc).isoformat()`), or omit the field and let PostHog set it at ingest. Don't pass epoch numbers or locale-formatted strings.
+
+### `event_timestamp_in_future` — An event was sent more than 23 hours in the future
+**Cause:** An instrumentation bug — usually a wrong `sent_at`/`offset` calculation or a client with a badly-skewed clock. These events are stored but hidden from the UI, and new persons get a future "first seen".
+**Locate:** `Grep` for `timestamp`, `sent_at`, `offset` near capture/batch code; check any custom time-offset logic.
+**Fix:** Correct the timestamp/offset computation so events carry the real send time. If you depend on client clocks, prefer omitting `timestamp` and letting the server stamp it.
+
+### `message_size_too_large` — Discarded event exceeding the 1MB limit
+**Cause:** A single event exceeds 1MB after processing — almost always one or more oversized properties (full API responses, base64 blobs, giant arrays, serialized DOM), or an installed transformation/app that enriches events.
+**Locate:** `Grep` for large property assignments on capture calls — `JSON.stringify`, `base64`, `...response`, whole-object spreads into `capture(` properties.
+**Fix:** Send only the fields you need. Replace blobs with ids/lengths/hashes, truncate large strings, drop embedded payloads. If a transformation app inflates events, trim it there. Keep events well under 1MB.
+
+### Ingestion overflow — Event ingestion has overflowed capacity
+**Cause:** Far more events than the main pipeline expects are arriving for a **single `distinct_id`** — typically a loop or retry storm capturing the same event, or all traffic sharing one hard-coded distinct id. Events are still ingested via a slower overflow path.
+**Locate:** `Grep` for `capture(` inside loops, intervals, retry handlers, or hot code paths; check for a constant/hard-coded distinct id reused for everyone.
+**Fix:** Remove the duplicate/looping capture or debounce it. Ensure each user gets their own distinct id rather than a shared constant.
+
+### `replay_timestamp_invalid` / `replay_timestamp_too_far_in_future` — Replay event timestamp problems
+**Cause:** A session-replay event carried an invalid timestamp, or one more than 7 days in the future (usually a skewed device clock or a tampered/old replay setup). The replay event is dropped.
+**Locate:** `Grep` for `session_recording`, `disable_session_recording`, `posthog-js` version in the lockfile/`package.json`.
+**Fix:** Upgrade `posthog-js` to a recent version and don't hand-construct replay payloads. If device clocks are the cause, it's environmental — note it for the report rather than editing app code.
+
+### `$set` / `$set_once` on exception events — Invalid set operations on exception events
+**Cause:** `$set` or `$set_once` person properties were attached to `$exception` events (e.g. passed into `captureException`). They're ignored on exception events.
+**Locate:** `Grep` for `captureException\(|capture\(['"]\$exception` and inspect for `$set`/`$set_once` in the properties.
+**Fix:** Remove `$set`/`$set_once` from exception capture. Set person properties on a normal event (or `identify`) instead.
+
+### `invalid_heatmap_data` — Invalid heatmap data
+**Cause (most common, fixable):** `$current_url` is sent as a **relative path** (`/dashboard`) instead of an absolute URL (`https://app.example.com/dashboard`). Heatmap processing requires an absolute URL, so it warns on every affected `$pageview`. The classic source is a custom pageview capture (e.g. Next.js App Router building `$current_url` from `usePathname()` alone). **Other cause:** a hand-constructed or modified `$heatmap_data` property.
+**Locate:** `Grep` for `\$current_url` and `\$heatmap_data`. Inspect any manual `$pageview` capture that sets `$current_url`.
+**Fix:** Make `$current_url` absolute — prepend the origin, e.g. `window.location.origin + pathname` (or `window.location.href`) instead of the bare path. Never hand-build `$heatmap_data`; rely on a recent `posthog-js`. The event still ingests, but heatmaps stay broken until the URL is absolute.
+
+---
+
+When every entry has a non-`pending` status and the scratch file is saved, continue to **`3-report.md`**.

--- a/context/skills/ingestion-warnings/references/3-report.md
+++ b/context/skills/ingestion-warnings/references/3-report.md
@@ -1,0 +1,74 @@
+---
+next_step: null
+---
+
+# Step 3 — Write the report
+
+The report is rendered **directly from `.posthog-ingestion-warnings.json`** — that file is the source of truth. Every warning the worklist tracked ends up in the report; nothing is invented.
+
+## Status
+
+Emit:
+
+```
+[STATUS] Writing ingestion warnings report
+```
+
+## Action
+
+`Read` `.posthog-ingestion-warnings.json` once. Transform every `warnings[]` entry into the report below, using its `type`, `count`, `status`, `file`, and `details` verbatim. Then `Write` `posthog-ingestion-warnings-report.md` at the project root with the structure below. After the markdown lands, **delete** `.posthog-ingestion-warnings.json`.
+
+If `source` is `"code-scan"` (warnings couldn't be read from the project), say so in the Summary: findings are derived from a code scan of known anti-patterns, not confirmed against live data. Fold any `notes[]` into the Summary too (e.g. the offending sender wasn't found in this checkout).
+
+## Report template
+
+<wizard-report>
+# PostHog Ingestion Warnings Report
+
+## Summary
+
+[1–2 sentences: how warnings were determined (queried `system.ingestion_warnings` over the last 7 days, or code-scan fallback), how many distinct types were firing, and how many you fixed vs. left for manual attention. Surface any `notes`.]
+
+**Counts**
+
+- **Fixed**: [N]
+- **Partial**: [N]
+- **Needs manual attention**: [N]
+- **Producing code not found**: [N]
+
+## Fixed
+
+For each entry with `status: "fixed"` or `"partial"`, one row:
+
+| Warning type | Volume | What was wrong | Fix applied | File |
+|---|---|---|---|---|
+| `<type>` | [count] | [one-line cause] | [one-line fix] | [path:line] |
+
+If none, write `_No fixes applied._`
+
+## Needs manual attention
+
+For each entry with `status: "needs-manual"` or `"not-found"`, three sentences:
+
+1. **What's firing** — the warning and its volume.
+2. **Why it matters** — the data-quality consequence (dropped events, mis-merged people, broken heatmaps, skewed timestamps, hidden future-dated events).
+3. **What to do** — the concrete next step, with `file:line` if known, or where to look (e.g. a backend repo that sends events). End with the docs link.
+
+Format:
+
+1. **`<type>`** ([count] in 7 days) — [what's firing]. _Why it matters:_ [consequence]. _Next:_ [action]. See https://posthog.com/docs/data/ingestion-warnings
+
+If none, write `_Nothing left to do — every firing warning was fixed._`
+
+## About this report
+
+This report was produced by the PostHog `ingestion-warnings` skill. Ingestion warnings mean events were dropped, mis-merged, or degraded on the way in, so the affected data can't be recovered by reprocessing — the fix is always in the code that sends the events. The skill read the warnings actually firing for this project and changed only the instrumentation tied to them.
+
+Re-run `npx @posthog/wizard@latest ingestion-warnings` after deploying these fixes to confirm the warnings stop. They are sampled, so a small residual count can persist briefly after a fix ships.
+</wizard-report>
+
+After the report is written and the scratch file deleted, emit a final line so the wizard can surface the path:
+
+```
+Created ingestion warnings report: <absolute path to posthog-ingestion-warnings-report.md>
+```


### PR DESCRIPTION
## What

Adds a new stepwise context-mill skill, `ingestion-warnings`, that diagnoses and fixes the instrumentation behind a PostHog project's [ingestion warnings](https://posthog.com/docs/data/ingestion-warnings) — events PostHog had to drop, mis-merge, or degrade on the way in.

The skill is **data-first**:
1. **Triage** — queries `system.ingestion_warnings` over the last 7 days to see which warning types are *actually firing*, with example payloads. Falls back to a code scan of all known anti-patterns if the data can't be read.
2. **Fix** — works a per-type catalog (illegal / already-identified merges, invalid UUIDs and timestamps, future-dated events, the 1MB size limit, ingestion overflow, invalid replay timestamps, `$set` on exception events, and invalid heatmap data from a relative `$current_url`). Each entry has a locate-grep and a minimal fix; it only touches code tied to a firing warning.
3. **Report** — writes `posthog-ingestion-warnings-report.md` (fixed / partial / needs-manual / not-found).

The `cli:` block registers it as `wizard ingestion-warnings`, so the command ships with a context-mill release. A companion wizard PR adds a first-class program (custom messaging + abort cases) on top of the generic agent-skill path.

## Why

Ingestion warnings always trace back to an SDK misuse with a known fix, but today they surface as a generic health issue with no remediation path. This encodes the catalog once so an agent can fix the producing code directly. Raised in a Slack thread off the back of the recurring `invalid_heatmap_data` / relative-`$current_url` reports.

## Testing

- `node scripts/build.js` — skill assembles; chain links + preamble inject correctly (non-terminal steps get the "Read ONLY this file" preamble + continuation link; terminal step gets neither); `skill-menu.json` gets the `ingestion-warnings` command entry.
- `pnpm test:skills` — green (70 tests).
- `node scripts/scan-warlock.js dist/skills` — passed, no threats.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A7NDJ4DND/p1782832077766109?thread_ts=1782832077.766109&cid=C0A7NDJ4DND)*