### PR TITLE
fix(mcp-analytics): make codemod aborts thorough and always reasoned

### DIFF
--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -11,9 +11,18 @@ This is **not** about adding the PostHog MCP *server* to a coding agent (that's 
 ## Scope and guardrails
 
 - **TypeScript / JavaScript and Python are supported.** Detect the language in STEP 1 and follow the matching part of every step. If the MCP server is written in anything else (Go, Rust, …), **stop**: emit `[ABORT] unsupported language for mcp analytics` on its own line and do nothing else.
-- **This must be an MCP server.** If the project is a normal app with no MCP server, **stop**: emit `[ABORT] no mcp server found` on its own line and do nothing else.
+- **This must be an MCP server.** Search thoroughly before concluding there isn't one: check dependency manifests *and* source for the STEP 1 signals across the whole project, including monorepo workspace packages and subdirectories — a server is often under `packages/*`, `apps/*`, `server/`, or `src/`, not the repo root. Only after an exhaustive search finds nothing, **stop**: emit `[ABORT] no mcp server found` on its own line, and in the same message tell the user where you looked and to re-run the command from inside the package or directory that actually defines their MCP server. Do nothing else.
 - **Beta SDK.** Both SDKs are pre-1.0 and may ship breaking changes in minor releases. Pin a version (see STEP 3).
 - **Minimal, additive changes only.** Add instrumentation alongside the existing server; do not restructure tool handlers or change their behavior. The wrapper is designed to be one line.
+
+### Abort cases
+
+If anything blocks instrumentation, **always** emit exactly one `[ABORT] <reason>` line and stop — never halt, finish, or error out silently. The wizard catches `[ABORT]` and terminates the run for you; don't try to exit yourself. A silent stop is recorded as a failed run with no reason, which can't be acted on, so every dead end must carry a reason. Use one of:
+
+- `[ABORT] no mcp server found` — an exhaustive search (see the guardrail above) found no MCP server in the project.
+- `[ABORT] unsupported language for mcp analytics` — the server is neither TypeScript/JavaScript nor Python.
+- `[ABORT] could not locate the server entry point` — MCP signals are present, but the place the server is constructed or where requests are dispatched couldn't be found to instrument.
+- `[ABORT] <short specific reason>` — anything else that blocks the run (e.g. no readable project, or no PostHog credentials and no MCP server connected to fetch them). Keep it short and specific so it's useful when aggregated across runs.
 
 ## Instructions
 


### PR DESCRIPTION
## Problem

We instrumented and analyzed the `wizard mcp-analytics` install funnel (telemetry already flows to PostHog project 2, tagged `properties.command = 'mcp-analytics'`). The activation leak is the **agentic codemod**, and its failures are hard to act on.

Install funnel, last 90 days, by `run_id`:

| Stage | Runs |
|---|---|
| Wizard runs | 59 |
| Started | 56 |
| Codemod (agent) started | 41 |
| Codemod completed | 10 |
| Codemod aborted | 19 |

Of the aborts:

| Abort reason | Runs |
|---|---|
| `no mcp server found` | 9 |
| *(no reason emitted)* | 10 |

So the single biggest, named failure is **`no mcp server found`**, and an equally large bucket of failed runs **abort with no reason at all** — which makes them impossible to categorize or fix.

## Changes

Two edits to the mcp-analytics skill (`description.md`):

1. **Thorough, actionable `no mcp server found`.** Require an exhaustive search before aborting — check dependency manifests *and* source across monorepo workspace packages and subdirectories (`packages/*`, `apps/*`, `server/`, `src/`), not just the repo root. When it does abort, the message now tells the user where we looked and to re-run inside the package that defines their server, instead of silently doing nothing. (Several "no mcp server found" aborts are likely users running from a monorepo root or the wrong directory.)
2. **A closed "Abort cases" set + never stop silently.** Adds an explicit `[ABORT] <reason>` enumeration and a rule that every dead end must emit a reason — mirroring the `events-audit` skill's abort section. This directly targets the 10 reasonless aborts: a silent stop becomes a categorized failure we can act on.

Scope notes:
- Skill markdown only → **context-mill release** (no wizard PR needed per CONTRIBUTING). `npm run build` passes.
- The other big drop-off we found — ~18 runs abandoned at the `agent-skill-intro` screen *before authenticating* — is a wizard-flow/UX issue, **not** addressed here (different repo).
- This makes failures legible; it won't single-handedly fix completion. The next iteration should be driven by the now-reasoned abort data.

## How we discovered this

All from existing wizard telemetry in PostHog project 2 — no new instrumentation. Key HogQL:

Install funnel by run:
```sql
WITH mcp_runs AS (
  SELECT DISTINCT properties.run_id AS run_id FROM events
  WHERE event LIKE 'wizard%' AND properties.command = 'mcp-analytics'
    AND properties.run_id != '' AND timestamp >= now() - INTERVAL 90 DAY
)
SELECT
  count(DISTINCT if(event = 'wizard: agent started',   properties.run_id, NULL)) AS codemod_started,
  count(DISTINCT if(event = 'wizard: agent completed', properties.run_id, NULL)) AS codemod_completed,
  count(DISTINCT if(event = 'wizard: agent aborted',   properties.run_id, NULL)) AS codemod_aborted
FROM events
WHERE event LIKE 'wizard%' AND timestamp >= now() - INTERVAL 90 DAY
  AND properties.run_id IN (SELECT run_id FROM mcp_runs)
```

Abort reasons:
```sql
SELECT coalesce(nullIf(properties.reason, ''), '(no reason)') AS reason,
       count(DISTINCT properties.run_id) AS runs
FROM events
WHERE event = 'wizard: agent aborted' AND timestamp >= now() - INTERVAL 90 DAY
  AND properties.run_id IN (
    SELECT DISTINCT properties.run_id FROM events
    WHERE properties.command = 'mcp-analytics' AND properties.run_id != ''
      AND timestamp >= now() - INTERVAL 90 DAY)
GROUP BY reason ORDER BY runs DESC
```

Live tiles on the MCP analytics adoption dashboard (PostHog project 2): install funnel, install failure reasons, and failed-run drill-down.

## 🤖 Agent context

Authored by PostHog Code (Opus 4.8), human-directed by Lucas. Found while investigating why MCP analytics activation is low (~6% of opt-ins reach first value). The data pointed at the codemod's abort behavior; these are the smallest skill changes that make the failures diagnosable and the most common one actionable.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
