### PR TITLE
fix(fastapi): use the Python context API for identify

### DIFF
--- a/example-apps/fastapi/app/routers/main.py
+++ b/example-apps/fastapi/app/routers/main.py
@@ -7,7 +7,7 @@ import posthog
 from fastapi import APIRouter, Cookie, Depends, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from posthog import capture
+from posthog import capture, identify_context, new_context
 
 from app.dependencies import (
     CurrentUser,
@@ -47,15 +47,16 @@ async def login(
 
     if user:
         is_new_user = user.record_login(db)
-        posthog.identify(user.email, {"email": user.email, "is_staff": user.is_staff})
-        posthog.capture(
-            user.email,
-            "user_logged_in",
-            properties={
-                "username": user.email,
-                "is_new_user": is_new_user,
-            },
-        )
+        with new_context():
+            identify_context(user.email)
+            capture(
+                "user_logged_in",
+                properties={
+                    "$set": {"email": user.email, "is_staff": user.is_staff},
+                    "username": user.email,
+                    "is_new_user": is_new_user,
+                },
+            )
 
         # Create session and redirect
         response = RedirectResponse(url="/dashboard", status_code=302)
@@ -112,15 +113,16 @@ async def signup(
     # Create new user
     user = User.create_user(db, email=email, password=password, is_staff=False)
 
-    posthog.identify(user.email, {"email": user.email, "is_staff": user.is_staff})
-    posthog.capture(
-        user.email,
-        "user_signed_up",
-        properties={
-            "username": user.email,
-            "signup_method": "form",
-        },
-    )
+    with new_context():
+        identify_context(user.email)
+        capture(
+            "user_signed_up",
+            properties={
+                "$set": {"email": user.email, "is_staff": user.is_staff},
+                "username": user.email,
+                "signup_method": "form",
+            },
+        )
 
     # Create session and redirect
     response = RedirectResponse(url="/dashboard", status_code=302)


### PR DESCRIPTION
The fastapi example used `posthog.identify()` and positional `posthog.capture(distinct_id, event)`, neither of which exists in the Python SDK v6+, so switch it to the `new_context()`/`identify_context()`/`capture()` context API like the rest of the example.