### PR TITLE
CM3: migrate the audit family to the exec grammar

### DIFF
--- a/context/skills/audit-autocapture/description.md
+++ b/context/skills/audit-autocapture/description.md
@@ -15,7 +15,7 @@ The audit ledger is seeded by the wizard with one pending check per autocapture 
 
 **Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
 
-`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools, and `mcp__posthog__*` for optimize-side checks) is already named in this skill.
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. The optimize-side checks reach PostHog through its single `exec` tool, described in the optimize reference.
 
 **Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
 

--- a/context/skills/audit-autocapture/references/3-autocapture-optimize.md
+++ b/context/skills/audit-autocapture/references/3-autocapture-optimize.md
@@ -12,6 +12,8 @@ This step resolves three cost-optimization checks **in parallel**, one subagent 
 
 Two of them require PostHog MCP access to query the operator's tenant. If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion` and `details: "PostHog MCP unavailable — could not measure <signal>"`. Do not block the audit.
 
+{{> mcp-tool-calling}}
+
 ## Status
 
 Emit before dispatching:
@@ -38,7 +40,7 @@ This check requires PostHog MCP access. If the MCP server is unavailable, auth f
 
 Read this skill's bundled `cutting-costs.md` reference once (typically `.claude/skills/audit-autocapture/references/cutting-costs.md`; otherwise discover with `Glob` `**/skills/audit-autocapture/references/cutting-costs.md`). Focus on the "Configure autocapture" section — when `$autocapture` dominates event volume and few high-value custom events exist, the project is paying for noisy click data instead of meaningful product signals.
 
-Call `mcp__posthog__execute-sql` with:
+Call `execute-sql` with:
 
 ```sql
 SELECT
@@ -118,7 +120,7 @@ Step 1 — codebase pass:
 Run **one** Grep: `capture_dead_clicks`. Read each file that contains a hit, once. Record whether it's set to `true`, `false`, or unset.
 
 Step 2 — MCP pass (skip if MCP unavailable):
-Call `mcp__posthog__execute-sql` with:
+Call `execute-sql` with:
 
 ```sql
 SELECT

--- a/context/skills/audit-events/description.md
+++ b/context/skills/audit-events/description.md
@@ -15,7 +15,7 @@ The audit ledger is seeded by the wizard with one pending check per event check.
 
 **Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
 
-`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools, and `mcp__posthog__*` for optimize-side checks) is already named in this skill.
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. The optimize-side checks reach PostHog through its single `exec` tool, described in the optimize reference.
 
 **Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
 

--- a/context/skills/audit-events/references/3-events-optimize.md
+++ b/context/skills/audit-events/references/3-events-optimize.md
@@ -12,6 +12,8 @@ This step resolves three cost-optimization checks **in parallel**, one subagent 
 
 All three are grounded in PostHog's [product analytics cutting-costs guide](https://posthog.com/docs/product-analytics/cutting-costs). Two of them require PostHog MCP access to query the operator's tenant. If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion` and `details: "PostHog MCP unavailable — could not measure <signal>"`. Do not block the audit.
 
+{{> mcp-tool-calling}}
+
 ## Status
 
 Emit before dispatching:
@@ -40,7 +42,7 @@ This check needs PostHog MCP access to query the operator's tenant. If the MCP s
 
 Procedure:
 1. Run **one** Grep: `posthog\.capture\(`. Collect every distinct static event name passed to `capture()` from the project source.
-2. Call **`posthog:execute-sql`** with a query that joins event names captured in code against PostHog metadata. Specifically check whether each event is referenced by:
+2. Call **`execute-sql`** with a query that joins event names captured in code against PostHog metadata. Specifically check whether each event is referenced by:
    - `system.insights` (saved insights) — search `query::TEXT ILIKE '%<event>%'`
    - `system.dashboards` (via insight membership)
    - `system.cohorts` — `filters::TEXT ILIKE '%<event>%'`
@@ -94,7 +96,7 @@ Read each file that contains a hit, once. Record:
 - The init file:line where these defaults are (or could be) set.
 
 Step 2 — MCP pass (skip if MCP unavailable):
-Call `mcp__posthog__execute-sql` with this query to measure pageview volume:
+Call `execute-sql` with this query to measure pageview volume:
 
 ```sql
 SELECT
@@ -154,7 +156,7 @@ Procedure:
    - `$pageview` (web-only)
    - `$autocapture` (web-only)
    - any custom event captured everywhere (run a quick `posthog\.capture\(` Grep + an MCP count to pick the highest-volume custom event)
-2. Call `mcp__posthog__execute-sql` to break down that event by environment-signal properties over the last 7 days:
+2. Call `execute-sql` to break down that event by environment-signal properties over the last 7 days:
 
 ```sql
 SELECT

--- a/context/skills/audit-feature-flags/description.md
+++ b/context/skills/audit-feature-flags/description.md
@@ -17,7 +17,7 @@ The audit ledger is seeded by the wizard with one pending check per feature flag
 
 **Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
 
-`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools, and `mcp__posthog__*` for optimize-side checks) is already named in this skill.
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. The optimize-side checks reach PostHog through its single `exec` tool, described in the optimize reference.
 
 **Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
 

--- a/context/skills/audit-feature-flags/references/3-feature-flags-optimize.md
+++ b/context/skills/audit-feature-flags/references/3-feature-flags-optimize.md
@@ -17,6 +17,8 @@ All four are grounded in PostHog's [feature flag cutting-costs guide](https://po
 
 One check (`ff-active-but-unreferenced`) requires PostHog MCP access. If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, `mcp_skipped: true`, and `details: "PostHog MCP unavailable — could not list active flags"`. Do not block the audit.
 
+{{> mcp-tool-calling}}
+
 ## Status
 
 Emit before dispatching:
@@ -43,7 +45,7 @@ This check requires PostHog MCP access. If the MCP server is unavailable, auth f
 
 Read this skill's bundled `cutting-costs.md` reference once (typically `.claude/skills/audit-feature-flags/references/cutting-costs.md`; otherwise discover with `Glob` `**/skills/audit-feature-flags/references/cutting-costs.md`). Focus on the "unused flags still incur charges" callout — active flags continue to evaluate (and bill) even with zero code references, because survey targeting and the `/flags` endpoint evaluate all active flags. The only way to stop charges is to disable, delete, or archive the flag in PostHog (removing it from code is not enough).
 
-Step 1 — list active flags from PostHog. Prefer `mcp__posthog__feature-flag-get-all` or the equivalent listing tool. If only `mcp__posthog__execute-sql` is available, fall back to:
+Step 1 — list active flags from PostHog. Prefer `feature-flag-get-all` or the equivalent listing tool. If only `execute-sql` is available, fall back to:
 
 ```sql
 SELECT key

--- a/context/skills/audit-identify/description.md
+++ b/context/skills/audit-identify/description.md
@@ -16,7 +16,7 @@ The audit ledger is seeded by the wizard with one pending check per identify che
 
 **Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
 
-`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools, and `mcp__posthog__*` for optimize-side checks) is already named in this skill.
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. The optimize-side checks reach PostHog through its single `exec` tool, described in the optimize reference.
 
 **Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
 

--- a/context/skills/audit-identify/references/4-identify-optimize.md
+++ b/context/skills/audit-identify/references/4-identify-optimize.md
@@ -13,6 +13,8 @@ This step resolves four cost-optimization checks **in parallel**, one subagent p
 
 All four are grounded in PostHog's [product analytics cutting-costs guide](https://posthog.com/docs/product-analytics/cutting-costs). Three of them require PostHog MCP access to query the operator's tenant. If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion` and `details: "PostHog MCP unavailable — could not measure <signal>"`. Do not block the audit.
 
+{{> mcp-tool-calling}}
+
 ## Status
 
 Emit before dispatching:
@@ -43,7 +45,7 @@ Run **one** Grep: `person_profiles`. Read each file that contains a hit, once. R
 - The init file:line where it's set (or where init lives if unset; default is `'identified_only'` for posthog-js).
 
 Step 2 — MCP pass (skip if MCP unavailable):
-Call `mcp__posthog__execute-sql` with this query (adjust column names if the project's schema differs):
+Call `execute-sql` with this query (adjust column names if the project's schema differs):
 
 ```sql
 SELECT
@@ -127,7 +129,7 @@ This check requires PostHog MCP access. If the MCP server is unavailable, auth f
 
 Read this skill's bundled `cutting-costs.md` reference once (typically `.claude/skills/audit-identify/references/cutting-costs.md`; otherwise discover with `Glob` `**/skills/audit-identify/references/cutting-costs.md`).
 
-Call `mcp__posthog__execute-sql` with:
+Call `execute-sql` with:
 
 ```sql
 SELECT
@@ -195,7 +197,7 @@ Read this skill's bundled `cutting-costs.md` reference once (typically `.claude/
 
 First, verify the project actually uses groups. Run **one** Grep on the codebase: `posthog\.group\(|posthog\.groupIdentify\(|\$groupidentify`. If no matches AND a quick MCP probe returns zero `$groupidentify` events in the last 7 days, resolve `pass` with `details: "skip: project does not use group analytics"` and return.
 
-Otherwise, call `mcp__posthog__execute-sql` with:
+Otherwise, call `execute-sql` with:
 
 ```sql
 SELECT

--- a/context/skills/audit-session-replay/description.md
+++ b/context/skills/audit-session-replay/description.md
@@ -15,7 +15,7 @@ The audit ledger is seeded by the wizard with one pending check per session repl
 
 **Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
 
-`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools, and `mcp__posthog__*` for optimize-side checks) is already named in this skill.
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. The optimize-side checks reach PostHog through its single `exec` tool, described in the optimize reference.
 
 **Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
 

--- a/context/skills/audit-session-replay/references/3-session-replay-optimize.md
+++ b/context/skills/audit-session-replay/references/3-session-replay-optimize.md
@@ -13,6 +13,8 @@ This step resolves four cost-optimization checks **in parallel**, one subagent p
 
 Two of them require PostHog MCP access to read the project's replay settings. If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion` and `details: "PostHog MCP unavailable — could not measure <signal>"` plus `"mcp_skipped": true` in the JSON details. Do not block the audit.
 
+{{> mcp-tool-calling}}
+
 ## Status
 
 Emit before dispatching:
@@ -39,7 +41,7 @@ This check requires PostHog MCP access. If the MCP server is unavailable, auth f
 
 Read this skill's bundled `how-to-control-which-sessions-you-record.md` reference once (typically `.claude/skills/audit-session-replay/references/how-to-control-which-sessions-you-record.md`; otherwise discover with `Glob` `**/skills/audit-session-replay/references/how-to-control-which-sessions-you-record.md`). Focus on the "Sampling" section: sample rate is the deterministic per-session probability of recording. At 100% you record everything; large projects often cut volume meaningfully by sampling to 10-50%.
 
-Step 1 — read project replay settings via MCP. Try `mcp__posthog__project-set-active` then any project-settings read tool (e.g. `mcp__posthog__project-settings-get` or similar). If no specific tool exists, fall back to `mcp__posthog__execute-sql` to estimate recording volume:
+Step 1 — read project replay settings via MCP. Try `project-set-active` then any project-settings read tool (e.g. `project-settings-get` or similar). If no specific tool exists, fall back to `execute-sql` to estimate recording volume:
 
 ```sql
 SELECT count() AS replay_events_7d
@@ -79,7 +81,7 @@ This check requires PostHog MCP access. If the MCP server is unavailable, auth f
 
 Read this skill's bundled `how-to-control-which-sessions-you-record.md` reference once (typically `.claude/skills/audit-session-replay/references/how-to-control-which-sessions-you-record.md`; otherwise discover with `Glob` `**/skills/audit-session-replay/references/how-to-control-which-sessions-you-record.md`). Focus on the "URL trigger conditions", "Event trigger conditions", and "With feature flags" sections. Triggers let you record only sessions that hit a particular page, fire a particular event (like an exception), or match a feature flag — far cheaper than recording 100% of sessions for a high-volume project.
 
-Step 1 — read project replay-triggers settings via MCP. Try whatever project-settings read tool is available (e.g. `mcp__posthog__project-settings-get`). The settings of interest are URL triggers, event triggers, and the linked feature flag for recordings.
+Step 1 — read project replay-triggers settings via MCP. Try whatever project-settings read tool is available (e.g. `project-settings-get`). The settings of interest are URL triggers, event triggers, and the linked feature flag for recordings.
 
 Step 2 — estimate recording volume to gauge whether triggers would help:
 

--- a/context/skills/audit/references/5-report.md
+++ b/context/skills/audit/references/5-report.md
@@ -18,15 +18,17 @@ Emit, in order:
 
 ## MCP tools
 
+{{> mcp-tool-calling}}
+
 | MCP tool | When | Use |
 |----------|------|-----|
-| `mcp__posthog-wizard__notebooks-create` | (a) of "Upload to a PostHog notebook" | Create the notebook with a small placeholder skeleton (title + section headings + placeholder paragraphs). One call. |
-| `mcp__posthog-wizard__notebook-edit` | (b) of "Upload to a PostHog notebook" | Replace one placeholder paragraph in the cloud notebook with a real ProseMirror node. **Called many times** (one per placeholder). Required because the model can't emit the full assembled tree in a single `notebooks-create` tool_use input — it self-truncates. |
-| `mcp__posthog-wizard__notebooks-retrieve` | (c) of "Upload to a PostHog notebook" | Read the cloud notebook back to verify every placeholder has been replaced. |
+| `notebooks-create` | (a) of "Upload to a PostHog notebook" | Create the notebook with a small placeholder skeleton (title + section headings + placeholder paragraphs). One call. |
+| `notebook-edit` | (b) of "Upload to a PostHog notebook" | Replace one placeholder paragraph in the cloud notebook with a real ProseMirror node. **Called many times** (one per placeholder). Required because the model can't emit the full assembled tree in a single `notebooks-create` tool_use input — it self-truncates. |
+| `notebooks-retrieve` | (c) of "Upload to a PostHog notebook" | Read the cloud notebook back to verify every placeholder has been replaced. |
 
-Load all three via `ToolSearch select:mcp__posthog-wizard__notebooks-create,mcp__posthog-wizard__notebook-edit,mcp__posthog-wizard__notebooks-retrieve` once, right before the upload sub-step — not at the top, so step 5 stays cheap when MCP isn't needed yet. `mcp__wizard-tools__audit_resolve_checks` is already loaded — you'll use it again after the upload.
+Run `info <tool>` on each of these before its first `call`, right before the upload sub-step. `mcp__wizard-tools__audit_resolve_checks` is already loaded — you'll use it again after the upload.
 
-If `notebook-edit` doesn't appear in the search results, the project's `notebooks-collaboration` feature flag isn't enabled. Skip the notebook-upload sub-step entirely; emit `Notebook upload skipped: notebook-edit unavailable. The local report at posthog-audit-report.md is still the source of truth.` and resolve `upload-notebook` to `suggestion` with that reason.
+If `info notebook-edit` returns a not-found error, the project's `notebooks-collaboration` feature flag isn't enabled. Skip the notebook-upload sub-step entirely; emit `Notebook upload skipped: notebook-edit unavailable. The local report at posthog-audit-report.md is still the source of truth.` and resolve `upload-notebook` to `suggestion` with that reason.
 
 ## Action
 

--- a/context/skills/data-warehouse-source/description.md
+++ b/context/skills/data-warehouse-source/description.md
@@ -15,11 +15,13 @@ Consult the PostHog data warehouse source docs above for source-specific field r
 
 ## Tools you will use
 
-You have the PostHog MCP server and the wizard's local tools available:
+You have the PostHog MCP server and the wizard's local tools available. The PostHog tools below are reached through its `exec` tool:
 
-- **`mcp__posthog-wizard__external-data-sources-wizard`** — returns the required fields per source type. **Always call this for a source kind before creating it** — never guess field names. **Pass `source_type` with the kind(s) you need** (e.g. `source_type: "Postgres"`, or comma-separated `"Postgres,Stripe"`). The unfiltered response describes every source and is hundreds of KB — large enough to blow your context budget — so never call it without `source_type`.
-- **`mcp__posthog-wizard__external-data-sources-db-schema`** — validates credentials and lists the tables available for sync. Use this for database sources before creating.
-- **`mcp__posthog-wizard__external-data-sources-create`** — creates the source. Follow its input schema exactly for the `payload` and `schemas` shape; the tool definition is the source of truth.
+{{> mcp-tool-calling}}
+
+- **`external-data-sources-wizard`** — returns the required fields per source type. **Always call this for a source kind before creating it** — never guess field names. **Pass `source_type` with the kind(s) you need** (e.g. `source_type: "Postgres"`, or comma-separated `"Postgres,Stripe"`). The unfiltered response describes every source and is hundreds of KB — large enough to blow your context budget — so never call it without `source_type`.
+- **`external-data-sources-db-schema`** — validates credentials and lists the tables available for sync. Use this for database sources before creating.
+- **`external-data-sources-create`** — creates the source. Follow its input schema exactly for the `payload` and `schemas` shape; the tool definition is the source of truth.
 - **`mcp__wizard-tools__check_env_keys`** — tells you which `.env` keys EXIST. It never returns values.
 - **`mcp__wizard-tools__wizard_ask`** — the ONLY way to obtain credential values from the user.
 
@@ -31,7 +33,7 @@ You have the PostHog MCP server and the wizard's local tools available:
 
 3. **Don't pass secret references to the PostHog tools.** If you mark a `wizard_ask` field `sensitive`, the answer comes back as `{ secretRef: ... }`, which only `mcp__wizard-tools__set_env_values` can resolve — `external-data-sources-db-schema`/`-create` reject it. For credentials you'll hand straight to those tools, collect them as normal (non-`sensitive`) `text` answers so you get the real value; reserve `sensitive` for secrets you're only writing to `.env`.
 
-4. **The MCP defines the fields, not you.** Call `mcp__posthog-wizard__external-data-sources-wizard` (with `source_type`) for the kind and ask for exactly the fields it lists (respecting `required`). Don't invent extra fields or omit required ones.
+4. **The MCP defines the fields, not you.** Call `external-data-sources-wizard` (with `source_type`) for the kind and ask for exactly the fields it lists (respecting `required`). Don't invent extra fields or omit required ones.
 
 5. **Respect the mode.** Only collect credentials and create `in-cli` sources. For `deep-link` sources, provide the URL and stop — do not try to collect OAuth tokens.
 
@@ -54,12 +56,12 @@ Process each detected source in turn.
 ### For an `in-cli` source
 
 1. `[STATUS] Configuring <label>`
-2. Call `mcp__posthog-wizard__external-data-sources-wizard` **with `source_type` set to this `kind`** (never unfiltered) and read the field list. Check the pre-flight gotchas above for this kind before prompting.
+2. Call `external-data-sources-wizard` **with `source_type` set to this `kind`** (never unfiltered) and read the field list. Check the pre-flight gotchas above for this kind before prompting.
 3. Optionally call `mcp__wizard-tools__check_env_keys` to see which matching keys already exist — use this only to tailor your prompt (e.g. "we noticed `DATABASE_URL` is set; please paste the connection details"). You still cannot read the value.
 4. Call `mcp__wizard-tools__wizard_ask` ONCE, requesting all required fields for the source. If the user declines or cannot provide them, fall back to the deep-link path below for this source.
-5. For database sources, call `mcp__posthog-wizard__external-data-sources-db-schema` with the credentials to validate them and list tables. If validation fails, report the error and let the user correct it (one more `mcp__wizard-tools__wizard_ask`), or fall back to deep-link.
-6. Build the create payload: `source_type` = the kind, the credential `payload`, `access_method` = `warehouse` (use `direct` only if the user explicitly wants live querying without import), and a `schemas` array selecting tables to sync (default: sync the tables the user wants; pick `incremental` sync with the detected incremental field when available, otherwise `full_refresh`). Follow the `mcp__posthog-wizard__external-data-sources-create` input schema for the exact shape.
-7. Call `mcp__posthog-wizard__external-data-sources-create`. On success: `[STATUS] Connected <label>`. On failure: emit `[ABORT] Source creation failed`.
+5. For database sources, call `external-data-sources-db-schema` with the credentials to validate them and list tables. If validation fails, report the error and let the user correct it (one more `mcp__wizard-tools__wizard_ask`), or fall back to deep-link.
+6. Build the create payload: `source_type` = the kind, the credential `payload`, `access_method` = `warehouse` (use `direct` only if the user explicitly wants live querying without import), and a `schemas` array selecting tables to sync (default: sync the tables the user wants; pick `incremental` sync with the detected incremental field when available, otherwise `full_refresh`). Follow the `external-data-sources-create` input schema for the exact shape.
+7. Call `external-data-sources-create`. On success: `[STATUS] Connected <label>`. On failure: emit `[ABORT] Source creation failed`.
 
 ### For a `deep-link` source
 

--- a/context/skills/events-audit/references/4-query.md
+++ b/context/skills/events-audit/references/4-query.md
@@ -28,10 +28,12 @@ Emit:
 
 ## MCP tools
 
+{{> mcp-tool-calling}}
+
 | MCP tool | When | Use |
 |----------|------|-----|
-| `mcp__posthog-wizard__execute-sql` | (c) below | Execute HogQL/SQL. Filtered query returns volume + last_seen for inventory events. |
-| `mcp__posthog-wizard__entity-search` | **Avoid.** | Requires project-key permissions; personal API keys get "permission denied". The SQL approach below works regardless. |
+| `execute-sql` | (c) below | Execute HogQL/SQL. Filtered query returns volume + last_seen for inventory events. |
+| `entity-search` | **Avoid.** | Requires project-key permissions; personal API keys get "permission denied". The SQL approach below works regardless. |
 
 The active project comes from the wizard session – don't pick or switch projects yourself.
 
@@ -49,7 +51,7 @@ If the list is empty (every capture row is dynamic), skip the SQL call and proce
 
 ### c. Query volume for inventory events
 
-`mcp__posthog-wizard__execute-sql` with:
+Call `execute-sql` with:
 
 ```sql
 SELECT event,

--- a/context/skills/events-audit/references/6-dashboard.md
+++ b/context/skills/events-audit/references/6-dashboard.md
@@ -22,17 +22,19 @@ Emit, in order:
 
 ## MCP tools
 
+{{> mcp-tool-calling}}
+
 | MCP tool | When | Use |
 |----------|------|-----|
-| `mcp__posthog-wizard__dashboard-create` | (b) below | Create the parent dashboard. Returns a dashboard with `id` and a PostHog URL. |
-| `mcp__posthog-wizard__insight-create` | (c) below | Create each insight, attached to the dashboard via `dashboards: [<id>]`. |
-| `mcp__posthog-wizard__notebooks-create` | (e.1) below | Create the notebook with a small skeleton (title + section headings + placeholder paragraphs). One call. |
-| `mcp__posthog-wizard__notebook-edit` | (e.2) below | Replace one placeholder paragraph in the cloud notebook with a real ProseMirror node. **Called many times** (~50–80×, one per placeholder). Required because `notebooks-create` cannot accept the full assembled tree in one tool_use input — the model self-truncates. |
-| `mcp__posthog-wizard__notebooks-retrieve` | (e.3) below | Read the cloud notebook back to verify every placeholder has been replaced. |
+| `dashboard-create` | (b) below | Create the parent dashboard. Returns a dashboard with `id` and a PostHog URL. |
+| `insight-create` | (c) below | Create each insight, attached to the dashboard via `dashboards: [<id>]`. |
+| `notebooks-create` | (e.1) below | Create the notebook with a small skeleton (title + section headings + placeholder paragraphs). One call. |
+| `notebook-edit` | (e.2) below | Replace one placeholder paragraph in the cloud notebook with a real ProseMirror node. **Called many times** (~50–80×, one per placeholder). Required because `notebooks-create` cannot accept the full assembled tree in one tool_use input — the model self-truncates. |
+| `notebooks-retrieve` | (e.3) below | Read the cloud notebook back to verify every placeholder has been replaced. |
 
-Load all five via `ToolSearch select:mcp__posthog-wizard__dashboard-create,mcp__posthog-wizard__insight-create,mcp__posthog-wizard__notebooks-create,mcp__posthog-wizard__notebook-edit,mcp__posthog-wizard__notebooks-retrieve` once at the start of (a). They're write tools (except `notebooks-retrieve`) — every call mutates the user's PostHog project. `mcp__wizard-tools__audit_resolve_checks` is already loaded from step 1 — you'll use it again in (d) and (e).
+Run `info <tool>` on each of these before its first `call` at the start of (a). They're write tools (except `notebooks-retrieve`) — every call mutates the user's PostHog project. `mcp__wizard-tools__audit_resolve_checks` is already loaded from step 1 — you'll use it again in (d) and (e).
 
-If `notebook-edit` doesn't appear in the search results, the project's `notebooks-collaboration` feature flag isn't enabled. Skip the notebook-upload sub-step entirely; emit `Notebook upload skipped: notebook-edit unavailable. The local report at posthog-events-audit-report.md is still the source of truth.` and resolve `upload-notebook` to `suggestion` with that reason.
+If `info notebook-edit` returns a not-found error, the project's `notebooks-collaboration` feature flag isn't enabled. Skip the notebook-upload sub-step entirely; emit `Notebook upload skipped: notebook-edit unavailable. The local report at posthog-events-audit-report.md is still the source of truth.` and resolve `upload-notebook` to `suggestion` with that reason.
 
 ## Action
 
@@ -40,7 +42,7 @@ If `notebook-edit` doesn't appear in the search results, the project's `notebook
 
 `Read` `.posthog-events-inventory.json` once and rebuild the IN-list — same rule as step 4 (b): every distinct `event_name` from `rows[]` where `call_kind == "capture"` and `is_dynamic == false` and `event_name != null`. Hold it as `IN_LIST` in memory; you'll embed it into each insight's HogQL `source`.
 
-Call `mcp__posthog-wizard__dashboard-create` with:
+Call `dashboard-create` with:
 
 ```json
 {
@@ -66,7 +68,7 @@ If the call errors (permission denied, project misconfigured, network), emit one
 
 ### b. Create the three insights
 
-For each insight, call `mcp__posthog-wizard__insight-create` with `dashboards: [DASHBOARD_ID]` so it's attached on creation. The `query` field is a `DataVisualizationNode` wrapping a HogQL query — that's the simplest shape for these three views.
+For each insight, call `insight-create` with `dashboards: [DASHBOARD_ID]` so it's attached on creation. The `query` field is a `DataVisualizationNode` wrapping a HogQL query — that's the simplest shape for these three views.
 
 Embed `IN_LIST` directly in each SQL statement as a comma-separated list of single-quoted event names. Do not use parameter placeholders — the MCP `insight-create` tool persists the query verbatim, so the IN-list has to be inlined.
 
@@ -158,7 +160,7 @@ Substitute `<dashboard name>` and `<dashboard URL>` from the `dashboard-create` 
 
 The report ends up with no dashboard line at all — that's the right UX for "no dashboard available." Don't try to surface the failure reason inside the report; the wizard already shows the failure in the run output. **Always perform this Edit** even on failure — leaving an unresolved `{{dashboard_callout}}` in the report would leak templating internals to the reader.
 
-If every `insight-create` call failed but the dashboard itself was created, also try to delete the empty dashboard via `mcp__posthog-wizard__dashboard-delete` if that tool is available; otherwise note "Dashboard created but all insights failed; remove it manually at <URL>" in the run output and move on.
+If every `insight-create` call failed but the dashboard itself was created, also try to delete the empty dashboard via `dashboard-delete` if that tool is available; otherwise note "Dashboard created but all insights failed; remove it manually at <URL>" in the run output and move on.
 
 ### d. Resolve the dashboard phase
 

--- a/context/skills/self-driving/references/2-read-context.md
+++ b/context/skills/self-driving/references/2-read-context.md
@@ -16,7 +16,9 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:Read,Glob,Grep,mcp__posthog-wizard__signals-scout-project-profile-get,mcp__posthog-wizard__query-session-recordings-list,mcp__posthog-wizard__survey-list,mcp__posthog-wizard__error-issue-list`.
+{{> mcp-tool-calling}}
+
+Load the local tools via `ToolSearch select:Read,Glob,Grep`. Reach the PostHog tools through the `exec` tool — run `info <tool>` before the first `call` for `signals-scout-project-profile-get`, `query-session-recordings-list`, `survey-list`, and `error-issue-list`.
 
 ## Do
 

--- a/context/skills/self-driving/references/3-github.md
+++ b/context/skills/self-driving/references/3-github.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__integrations-list,mcp__wizard-tools__wizard_ask`.
+Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `integrations-list` through the PostHog `exec` tool (`info` then `call`).
 
 ## Do
 

--- a/context/skills/self-driving/references/3b-enable-products.md
+++ b/context/skills/self-driving/references/3b-enable-products.md
@@ -18,7 +18,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__products-enable`.
+Reach `products-enable` through the PostHog `exec` tool (`info products-enable`, then `call products-enable <json>`).
 
 ## Do
 

--- a/context/skills/self-driving/references/4-sources.md
+++ b/context/skills/self-driving/references/4-sources.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__inbox-source-configs-create,mcp__posthog-wizard__inbox-source-configs-partial-update,mcp__posthog-wizard__inbox-source-configs-list`.
+Reach the source-config tools through the PostHog `exec` tool — `info` then `call` for `inbox-source-configs-create`, `inbox-source-configs-partial-update`, and `inbox-source-configs-list`.
 
 ## The write recipe (use for every source here and in step 5)
 

--- a/context/skills/self-driving/references/5-connected-tools.md
+++ b/context/skills/self-driving/references/5-connected-tools.md
@@ -18,7 +18,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__wizard-tools__wizard_ask,mcp__posthog-wizard__external-data-sources-list` (the source-config tools from step 4 stay loaded).
+Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `external-data-sources-list` through the PostHog `exec` tool (`info` then `call`); the source-config tools from step 4 are reached the same way.
 
 ## Do
 

--- a/context/skills/self-driving/references/5a-github.md
+++ b/context/skills/self-driving/references/5a-github.md
@@ -14,7 +14,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__integrations-github-repos-retrieve,mcp__posthog-wizard__external-data-sources-create`.
+Reach `integrations-github-repos-retrieve` and `external-data-sources-create` through the PostHog `exec` tool (`info` then `call` for each).
 
 ## Do
 

--- a/context/skills/self-driving/references/5b-linear.md
+++ b/context/skills/self-driving/references/5b-linear.md
@@ -12,7 +12,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__external-data-sources-create` (`integrations-list` from step 3 stays loaded).
+Reach `external-data-sources-create` through the PostHog `exec` tool (`info` then `call`); `integrations-list` from step 3 is reached the same way.
 
 ## Do
 

--- a/context/skills/self-driving/references/6-scouts.md
+++ b/context/skills/self-driving/references/6-scouts.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__signals-scout-config-sync,mcp__posthog-wizard__signals-scout-config-list,mcp__posthog-wizard__signals-scout-config-update`.
+Reach the scout-config tools through the PostHog `exec` tool — `info` then `call` for `signals-scout-config-sync`, `signals-scout-config-list`, and `signals-scout-config-update`.
 
 ## Do
 

--- a/context/skills/self-driving/references/6b-tailor-scouts.md
+++ b/context/skills/self-driving/references/6b-tailor-scouts.md
@@ -20,7 +20,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__llma-skill-get,mcp__posthog-wizard__llma-skill-file-get,mcp__posthog-wizard__llma-skill-create,mcp__posthog-wizard__signals-scout-config-list`. (`signals-scout-config-sync` is already loaded from step 6 if you need it again.)
+Reach these PostHog tools through the `exec` tool — `info` then `call` for `llma-skill-get`, `llma-skill-file-get`, `llma-skill-create`, and `signals-scout-config-list` (`signals-scout-config-sync` from step 6 the same way if you need it again).
 
 ## Do
 

--- a/context/skills/web-analytics/description.md
+++ b/context/skills/web-analytics/description.md
@@ -26,19 +26,21 @@ The audit never changes anything. Changes happen only in the fix phase, and only
 
 ## Available tools
 
+{{> mcp-tool-calling}}
+
 **Audit (read-only):**
-- `mcp__posthog-wizard__query-run` (HogQL) — primary tool. Use for all event queries.
-- `mcp__posthog-wizard__project-get` — fetch project settings, including `app_urls` (the user-configured authorized URLs).
-- `mcp__posthog-wizard__docs-search` — to fetch the latest doc URL for a remediation link.
+- `query-run` (HogQL) — primary tool. Use for all event queries.
+- `project-get` — fetch project settings, including `app_urls` (the user-configured authorized URLs).
+- `docs-search` — to fetch the latest doc URL for a remediation link.
 
 **Confirm:**
 - `mcp__wizard-tools__wizard_ask` — ask the user which findings to fix. Call it **once** with a single multi-select question (see Phase 2).
 
 **Fix:**
 - `Read` and `Edit` — apply code fixes to the user's project (e.g. PostHog init options).
-- A PostHog settings-mutation MCP tool (e.g. `mcp__posthog-wizard__project-update` or an equivalent settings/property update tool) — apply settings fixes. If you cannot find such a tool, do NOT guess a tool name and do NOT fabricate a call: record the fix as manual guidance in the report instead.
+- A PostHog settings-mutation MCP tool (e.g. `project-update` or an equivalent settings/property update tool) — apply settings fixes. If you cannot find such a tool, do NOT guess a tool name and do NOT fabricate a call: record the fix as manual guidance in the report instead.
 
-If you're unsure which MCP tools exist, discover them (tool search is enabled) and name tools explicitly so their schemas load. Never edit `.env` directly — if a fix needs environment values, use the wizard-tools MCP.
+If you're unsure which MCP tools exist, discover them through the `exec` tool (`search <regex>`, then `info <tool>`) before calling. Never edit `.env` directly — if a fix needs environment values, use the wizard-tools MCP.
 
 ## Pre-flight
 

--- a/context/skills/web-analytics/references/checks.md
+++ b/context/skills/web-analytics/references/checks.md
@@ -54,7 +54,7 @@ LIMIT 50
 
 **What it detects:** The user configured authorized URLs in PostHog (via project settings), but one or more of those URLs has zero events in the analysis window. This often means an ad blocker is silently eating events for that domain — or the SDK was never installed there.
 
-**Step A — fetch authorized URLs:** call `mcp__posthog-wizard__project-get` and read `app_urls` from the response.
+**Step A — fetch authorized URLs:** call `project-get` and read `app_urls` from the response.
 
 **Step B — query event volume per known host:**
 

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -724,6 +724,7 @@ async function generateSkill({
         .replace(/{references}/g, referencesText)
         .replace(/{commandments}/g, commandmentsText)
         .replace(/{workflow}/g, workflowText);
+    body = expandPartials(body, configDir);
 
     skillContent += body;
 


### PR DESCRIPTION
Renames the hardcoded `mcp__posthog-wizard__*`/`mcp__posthog__*`/`posthog:*` tool references across the audit and events-audit skills to their bare inner names and includes the shared MCP grammar wherever a PostHog call is made, so audit runs work against the single-`exec` server while wizard-tools references and every JSON/SQL payload stay unchanged. Refs #850