### PR TITLE
CM4: migrate self-driving, web-analytics, data-warehouse to the exec grammar

### DIFF
--- a/context/skills/data-warehouse-source/description.md
+++ b/context/skills/data-warehouse-source/description.md
@@ -15,11 +15,13 @@ Consult the PostHog data warehouse source docs above for source-specific field r
 
 ## Tools you will use
 
-You have the PostHog MCP server and the wizard's local tools available:
+You have the PostHog MCP server and the wizard's local tools available. The PostHog tools below are reached through its `exec` tool:
 
-- **`mcp__posthog-wizard__external-data-sources-wizard`** — returns the required fields per source type. **Always call this for a source kind before creating it** — never guess field names. **Pass `source_type` with the kind(s) you need** (e.g. `source_type: "Postgres"`, or comma-separated `"Postgres,Stripe"`). The unfiltered response describes every source and is hundreds of KB — large enough to blow your context budget — so never call it without `source_type`.
-- **`mcp__posthog-wizard__external-data-sources-db-schema`** — validates credentials and lists the tables available for sync. Use this for database sources before creating.
-- **`mcp__posthog-wizard__external-data-sources-create`** — creates the source. Follow its input schema exactly for the `payload` and `schemas` shape; the tool definition is the source of truth.
+{{> mcp-tool-calling}}
+
+- **`external-data-sources-wizard`** — returns the required fields per source type. **Always call this for a source kind before creating it** — never guess field names. **Pass `source_type` with the kind(s) you need** (e.g. `source_type: "Postgres"`, or comma-separated `"Postgres,Stripe"`). The unfiltered response describes every source and is hundreds of KB — large enough to blow your context budget — so never call it without `source_type`.
+- **`external-data-sources-db-schema`** — validates credentials and lists the tables available for sync. Use this for database sources before creating.
+- **`external-data-sources-create`** — creates the source. Follow its input schema exactly for the `payload` and `schemas` shape; the tool definition is the source of truth.
 - **`mcp__wizard-tools__check_env_keys`** — tells you which `.env` keys EXIST. It never returns values.
 - **`mcp__wizard-tools__wizard_ask`** — the ONLY way to obtain credential values from the user.
 
@@ -31,7 +33,7 @@ You have the PostHog MCP server and the wizard's local tools available:
 
 3. **Don't pass secret references to the PostHog tools.** If you mark a `wizard_ask` field `sensitive`, the answer comes back as `{ secretRef: ... }`, which only `mcp__wizard-tools__set_env_values` can resolve — `external-data-sources-db-schema`/`-create` reject it. For credentials you'll hand straight to those tools, collect them as normal (non-`sensitive`) `text` answers so you get the real value; reserve `sensitive` for secrets you're only writing to `.env`.
 
-4. **The MCP defines the fields, not you.** Call `mcp__posthog-wizard__external-data-sources-wizard` (with `source_type`) for the kind and ask for exactly the fields it lists (respecting `required`). Don't invent extra fields or omit required ones.
+4. **The MCP defines the fields, not you.** Call `external-data-sources-wizard` (with `source_type`) for the kind and ask for exactly the fields it lists (respecting `required`). Don't invent extra fields or omit required ones.
 
 5. **Respect the mode.** Only collect credentials and create `in-cli` sources. For `deep-link` sources, provide the URL and stop — do not try to collect OAuth tokens.
 
@@ -54,12 +56,12 @@ Process each detected source in turn.
 ### For an `in-cli` source
 
 1. `[STATUS] Configuring <label>`
-2. Call `mcp__posthog-wizard__external-data-sources-wizard` **with `source_type` set to this `kind`** (never unfiltered) and read the field list. Check the pre-flight gotchas above for this kind before prompting.
+2. Call `external-data-sources-wizard` **with `source_type` set to this `kind`** (never unfiltered) and read the field list. Check the pre-flight gotchas above for this kind before prompting.
 3. Optionally call `mcp__wizard-tools__check_env_keys` to see which matching keys already exist — use this only to tailor your prompt (e.g. "we noticed `DATABASE_URL` is set; please paste the connection details"). You still cannot read the value.
 4. Call `mcp__wizard-tools__wizard_ask` ONCE, requesting all required fields for the source. If the user declines or cannot provide them, fall back to the deep-link path below for this source.
-5. For database sources, call `mcp__posthog-wizard__external-data-sources-db-schema` with the credentials to validate them and list tables. If validation fails, report the error and let the user correct it (one more `mcp__wizard-tools__wizard_ask`), or fall back to deep-link.
-6. Build the create payload: `source_type` = the kind, the credential `payload`, `access_method` = `warehouse` (use `direct` only if the user explicitly wants live querying without import), and a `schemas` array selecting tables to sync (default: sync the tables the user wants; pick `incremental` sync with the detected incremental field when available, otherwise `full_refresh`). Follow the `mcp__posthog-wizard__external-data-sources-create` input schema for the exact shape.
-7. Call `mcp__posthog-wizard__external-data-sources-create`. On success: `[STATUS] Connected <label>`. On failure: emit `[ABORT] Source creation failed`.
+5. For database sources, call `external-data-sources-db-schema` with the credentials to validate them and list tables. If validation fails, report the error and let the user correct it (one more `mcp__wizard-tools__wizard_ask`), or fall back to deep-link.
+6. Build the create payload: `source_type` = the kind, the credential `payload`, `access_method` = `warehouse` (use `direct` only if the user explicitly wants live querying without import), and a `schemas` array selecting tables to sync (default: sync the tables the user wants; pick `incremental` sync with the detected incremental field when available, otherwise `full_refresh`). Follow the `external-data-sources-create` input schema for the exact shape.
+7. Call `external-data-sources-create`. On success: `[STATUS] Connected <label>`. On failure: emit `[ABORT] Source creation failed`.
 
 ### For a `deep-link` source
 

--- a/context/skills/self-driving/references/2-read-context.md
+++ b/context/skills/self-driving/references/2-read-context.md
@@ -16,7 +16,9 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:Read,Glob,Grep,mcp__posthog-wizard__signals-scout-project-profile-get,mcp__posthog-wizard__query-session-recordings-list,mcp__posthog-wizard__survey-list,mcp__posthog-wizard__error-issue-list`.
+{{> mcp-tool-calling}}
+
+Load the local tools via `ToolSearch select:Read,Glob,Grep`. Reach the PostHog tools through the `exec` tool — run `info <tool>` before the first `call` for `signals-scout-project-profile-get`, `query-session-recordings-list`, `survey-list`, and `error-issue-list`.
 
 ## Do
 

--- a/context/skills/self-driving/references/3-github.md
+++ b/context/skills/self-driving/references/3-github.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__integrations-list,mcp__wizard-tools__wizard_ask`.
+Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `integrations-list` through the PostHog `exec` tool (`info` then `call`).
 
 ## Do
 

--- a/context/skills/self-driving/references/3b-enable-products.md
+++ b/context/skills/self-driving/references/3b-enable-products.md
@@ -18,7 +18,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__products-enable`.
+Reach `products-enable` through the PostHog `exec` tool (`info products-enable`, then `call products-enable <json>`).
 
 ## Do
 

--- a/context/skills/self-driving/references/4-sources.md
+++ b/context/skills/self-driving/references/4-sources.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__inbox-source-configs-create,mcp__posthog-wizard__inbox-source-configs-partial-update,mcp__posthog-wizard__inbox-source-configs-list`.
+Reach the source-config tools through the PostHog `exec` tool — `info` then `call` for `inbox-source-configs-create`, `inbox-source-configs-partial-update`, and `inbox-source-configs-list`.
 
 ## The write recipe (use for every source here and in step 5)
 

--- a/context/skills/self-driving/references/5-connected-tools.md
+++ b/context/skills/self-driving/references/5-connected-tools.md
@@ -18,7 +18,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__wizard-tools__wizard_ask,mcp__posthog-wizard__external-data-sources-list` (the source-config tools from step 4 stay loaded).
+Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `external-data-sources-list` through the PostHog `exec` tool (`info` then `call`); the source-config tools from step 4 are reached the same way.
 
 ## Do
 

--- a/context/skills/self-driving/references/5a-github.md
+++ b/context/skills/self-driving/references/5a-github.md
@@ -14,7 +14,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__integrations-github-repos-retrieve,mcp__posthog-wizard__external-data-sources-create`.
+Reach `integrations-github-repos-retrieve` and `external-data-sources-create` through the PostHog `exec` tool (`info` then `call` for each).
 
 ## Do
 

--- a/context/skills/self-driving/references/5b-linear.md
+++ b/context/skills/self-driving/references/5b-linear.md
@@ -12,7 +12,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__external-data-sources-create` (`integrations-list` from step 3 stays loaded).
+Reach `external-data-sources-create` through the PostHog `exec` tool (`info` then `call`); `integrations-list` from step 3 is reached the same way.
 
 ## Do
 

--- a/context/skills/self-driving/references/6-scouts.md
+++ b/context/skills/self-driving/references/6-scouts.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__signals-scout-config-sync,mcp__posthog-wizard__signals-scout-config-list,mcp__posthog-wizard__signals-scout-config-update`.
+Reach the scout-config tools through the PostHog `exec` tool — `info` then `call` for `signals-scout-config-sync`, `signals-scout-config-list`, and `signals-scout-config-update`.
 
 ## Do
 

--- a/context/skills/self-driving/references/6b-tailor-scouts.md
+++ b/context/skills/self-driving/references/6b-tailor-scouts.md
@@ -20,7 +20,7 @@ Emit:
 
 ## Tools
 
-Load via `ToolSearch select:mcp__posthog-wizard__llma-skill-get,mcp__posthog-wizard__llma-skill-file-get,mcp__posthog-wizard__llma-skill-create,mcp__posthog-wizard__signals-scout-config-list`. (`signals-scout-config-sync` is already loaded from step 6 if you need it again.)
+Reach these PostHog tools through the `exec` tool — `info` then `call` for `llma-skill-get`, `llma-skill-file-get`, `llma-skill-create`, and `signals-scout-config-list` (`signals-scout-config-sync` from step 6 the same way if you need it again).
 
 ## Do
 

--- a/context/skills/web-analytics/description.md
+++ b/context/skills/web-analytics/description.md
@@ -26,19 +26,21 @@ The audit never changes anything. Changes happen only in the fix phase, and only
 
 ## Available tools
 
+{{> mcp-tool-calling}}
+
 **Audit (read-only):**
-- `mcp__posthog-wizard__query-run` (HogQL) — primary tool. Use for all event queries.
-- `mcp__posthog-wizard__project-get` — fetch project settings, including `app_urls` (the user-configured authorized URLs).
-- `mcp__posthog-wizard__docs-search` — to fetch the latest doc URL for a remediation link.
+- `query-run` (HogQL) — primary tool. Use for all event queries.
+- `project-get` — fetch project settings, including `app_urls` (the user-configured authorized URLs).
+- `docs-search` — to fetch the latest doc URL for a remediation link.
 
 **Confirm:**
 - `mcp__wizard-tools__wizard_ask` — ask the user which findings to fix. Call it **once** with a single multi-select question (see Phase 2).
 
 **Fix:**
 - `Read` and `Edit` — apply code fixes to the user's project (e.g. PostHog init options).
-- A PostHog settings-mutation MCP tool (e.g. `mcp__posthog-wizard__project-update` or an equivalent settings/property update tool) — apply settings fixes. If you cannot find such a tool, do NOT guess a tool name and do NOT fabricate a call: record the fix as manual guidance in the report instead.
+- A PostHog settings-mutation MCP tool (e.g. `project-update` or an equivalent settings/property update tool) — apply settings fixes. If you cannot find such a tool, do NOT guess a tool name and do NOT fabricate a call: record the fix as manual guidance in the report instead.
 
-If you're unsure which MCP tools exist, discover them (tool search is enabled) and name tools explicitly so their schemas load. Never edit `.env` directly — if a fix needs environment values, use the wizard-tools MCP.
+If you're unsure which MCP tools exist, discover them through the `exec` tool (`search <regex>`, then `info <tool>`) before calling. Never edit `.env` directly — if a fix needs environment values, use the wizard-tools MCP.
 
 ## Pre-flight
 

--- a/context/skills/web-analytics/references/checks.md
+++ b/context/skills/web-analytics/references/checks.md
@@ -54,7 +54,7 @@ LIMIT 50
 
 **What it detects:** The user configured authorized URLs in PostHog (via project settings), but one or more of those URLs has zero events in the analysis window. This often means an ad blocker is silently eating events for that domain — or the SDK was never installed there.
 
-**Step A — fetch authorized URLs:** call `mcp__posthog-wizard__project-get` and read `app_urls` from the response.
+**Step A — fetch authorized URLs:** call `project-get` and read `app_urls` from the response.
 
 **Step B — query event volume per known host:**
 

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -724,6 +724,7 @@ async function generateSkill({
         .replace(/{references}/g, referencesText)
         .replace(/{commandments}/g, commandmentsText)
         .replace(/{workflow}/g, workflowText);
+    body = expandPartials(body, configDir);
 
     skillContent += body;
 


### PR DESCRIPTION
Rewrites the tool-load lines and named-tool references in the self-driving, web-analytics, and data-warehouse-source skills to reach PostHog through its single `exec` tool, and extends the SKILL.md template to expand build partials so docs-only skills carry the grammar in their description. Refs #850