### PR TITLE
fix: MCP resource name should be the display name, not the description sentence

### DIFF
--- a/scripts/lib/build-phases.js
+++ b/scripts/lib/build-phases.js
@@ -123,8 +123,13 @@ function generateManifest({ resources, uriSchema, version, docContents = {} }) {
                 ? `${scheme}${docPattern.replace('{id}', skill.id)}`
                 : `${scheme}${skillPattern.replace('{group}', skill.group).replace('{id}', skill.shortId)}`;
             const base = {
+                // The MCP resource name is a short, human-readable label (per the
+                // MCP spec) — use the display name, not the description sentence.
+                // Clients that mint a tool per resource derive the tool name from
+                // this; a sentence here overflows the 128-char tool-name limit and
+                // 400s the whole request. Docs carry their short name in `name`.
                 id: skill.id,
-                name: skill.name,
+                name: skill.displayName ?? skill.name,
                 description: skill.description,
                 tags: skill.tags,
                 uri,


### PR DESCRIPTION
Skill resources set `name` to the full description sentence, so any MCP client that mints a tool per resource (e.g. `pi-mcp-adapter` → `posthog_get_<name>`) generates tool names over Anthropic's 128-char limit — one invalid name 400s the whole request and the agent makes zero tool calls; this uses the short `displayName` for the resource `name` while leaving the agent-facing skill-menu's descriptive `name` untouched.

### Impact (derived MCP tool name = `posthog_get_<slugified resource name>`)

| | resource-tool names >128 chars | max name length |
|---|---|---|
| **Before** | **13** of 165 | **493** |
| **After** | **0** | **66** |

### Worst-case example

**Before** — resource `name` is the description sentence:
```
name: "Add PostHog MCP analytics to a TypeScript, JavaScript, or Python MCP server. Instruments …"
  → posthog_get_add_posthog_mcp_analytics_to_a_typescript_javascript_or_python_mcp_server_inst…   (493 chars → 400)
```

**After** — resource `name` is the `displayName`:
```
name: "any TypeScript or JavaScript MCP server"
  → posthog_get_any_typescript_or_javascript_mcp_server   (51 chars → ok)
```

The agent-facing `skill-menu.json` still carries the descriptive `skill.name` for skill selection — only the MCP resource `name` shortened.