### PR TITLE
fix(ci): only advertise CI-capable app categories in the wizard-ci menu

### DIFF
--- a/.github/workflows/wizard-ci-trigger.yml
+++ b/.github/workflows/wizard-ci-trigger.yml
@@ -33,6 +33,12 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             | jq -r '[.[] | select(.type == "dir") | .name] | sort | .[]')
 
+          # Only advertise directories whose workflow is CI-capable (apps/manifest.json).
+          # Left empty on fetch failure, in which case no filtering is applied.
+          CI_CAPABLE=$(curl -s "https://api.github.com/repos/PostHog/wizard-workbench/contents/apps/manifest.json" \
+            -H "Accept: application/vnd.github.raw" \
+            | jq -r '[.workflows[] | select(.ciCapable == true) | .dir] | .[]' 2>/dev/null || echo "")
+
           # Build lists by category
           CATEGORY_LIST=""
           APP_LIST_VISIBLE=""
@@ -41,6 +47,11 @@ jobs:
           VISIBLE_COUNT=3
 
           for category in $CATEGORIES; do
+            # Skip directories the manifest marks as not CI-capable.
+            if [ -n "$CI_CAPABLE" ] && ! echo "$CI_CAPABLE" | grep -qxF "$category"; then
+              continue
+            fi
+
             # Fetch apps in this category
             APPS=$(curl -s "https://api.github.com/repos/PostHog/wizard-workbench/contents/apps/$category" \
               -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
Mirrors [PostHog/wizard#867](https://github.com/PostHog/wizard/pull/867): the wizard-ci welcome comment now filters categories by `ciCapable` in wizard-workbench's `apps/manifest.json`, so it lists only the directories that actually run in CI instead of every `apps/` directory.