### PR TITLE
feat(data-warehouse): attribute deep-link handoffs to the wizard

### DIFF
--- a/context/skills/data-warehouse-source/description.md
+++ b/context/skills/data-warehouse-source/description.md
@@ -67,7 +67,8 @@ Process each detected source in turn.
 
 1. `[STATUS] <label> needs browser setup`
 2. Build the URL from the project context in your prompt (PostHog Host + Project ID):
-   `<host>/project/<projectId>/data-warehouse/new-source?kind=<kind>`
+   `<host>/project/<projectId>/data-warehouse/new-source?kind=<kind>&utm_source=wizard&utm_campaign=warehouse-source`
+   Keep the `utm_*` params exactly as written — they let PostHog attribute sources finished in the browser back to the wizard handoff.
 3. Tell the user to open that URL to finish connecting `<label>` (OAuth happens in the app). Include the URL in your report. Do not attempt credential collection.
 
 ### Non-interactive / CI


### PR DESCRIPTION
## Problem

When the warehouse-source skill routes a user to the browser (`deep-link` sources, declined credentials, or non-interactive runs), the handoff URL carries no attribution. Sources finished in the app after a wizard handoff are indistinguishable from organic web creations, so the handoff conversion rate is unmeasurable — and production traces show the deep-link path is taken in the majority of runs.

## Changes

Append `utm_source=wizard&utm_campaign=warehouse-source` to the deep-link URL template in the `data-warehouse-source` skill. posthog-js captures `utm_*` on the resulting pageviews/session, so web-completed sources can be tied back to wizard handoffs without any app changes.

## Testing

`pnpm test:skills` — 85 passed.
