### PR TITLE
test: lock Android source-map skill contract

### DIFF
--- a/scripts/lib/tests/error-tracking-upload-source-maps.test.js
+++ b/scripts/lib/tests/error-tracking-upload-source-maps.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'path';
+
+import { expandSkillGroups, loadSkillsConfig } from '../skill-generator.js';
+
+const CONFIG_DIR = join(process.cwd(), 'context');
+
+describe('error-tracking-upload-source-maps Android variant', () => {
+    it('expands to the skill contract consumed by the wizard', () => {
+        const config = loadSkillsConfig(CONFIG_DIR);
+        const skills = expandSkillGroups(config, CONFIG_DIR);
+        const android = skills.find((skill) => skill.id === 'error-tracking-upload-source-maps-android');
+
+        expect(android).toMatchObject({
+            id: 'error-tracking-upload-source-maps-android',
+            _shortId: 'android',
+            _category: 'error-tracking-upload-source-maps',
+            _group: 'error-tracking-upload-source-maps',
+            display_name: 'Android',
+            description: 'Upload ProGuard / R8 mapping files to PostHog Error Tracking for Android',
+            tags: ['error-tracking', 'source-maps', 'android', 'java', 'kotlin'],
+            docs_urls: ['https://posthog.com/docs/error-tracking/upload-mappings/android.md'],
+            _sharedDocs: [
+                'https://posthog.com/docs/error-tracking/upload-source-maps.md',
+                'https://posthog.com/docs/error-tracking/upload-source-maps/cli.md',
+            ],
+            _cli: null,
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- lock the existing `error-tracking-upload-source-maps-android` expansion contract consumed by the wizard
- verify the generated ID, short ID, category, display name, ProGuard/R8 description, tags, canonical Android reference, shared CLI references, and absence of independent CLI metadata
- prevent the wizard and context-mill source-map variants from drifting independently

## Testing
- `npm test -- scripts/lib/tests/error-tracking-upload-source-maps.test.js` — 13 files, 108 tests passed
- `npm run build` — generated `error-tracking-upload-source-maps-android.zip` and its manifest entry

## Companion PRs
- PostHog/wizard#874
- PostHog/wizard-workbench#2748