### PR TITLE
feat(integration): mirror the setup report into a PostHog notebook

### DIFF
--- a/context/skills/integration/references/4-conclude.md
+++ b/context/skills/integration/references/4-conclude.md
@@ -110,6 +110,8 @@ For the "Verify before merging" checklist, write GitHub-style checkboxes (`- [ ]
 
 Do not invent items beyond what applies. If only the two "Always" items apply, the checklist is just those two.
 
+Then mirror the report into a shareable PostHog notebook so the user has an in-app copy to link and comment on. Call `notebooks-create` with a `title` (e.g. `PostHog setup (wizard) – <repo_name>`) and `content` set to a single markdown node wrapping the report verbatim — `{"type":"doc","content":[{"type":"ph-markdown-notebook","attrs":{"nodeId":"markdown-notebook-v2","markdown":"<the full contents of posthog-setup-report.md>"}}]}`. Take the `short_id` from the response, build the notebook URL as `<host>/project/<project_id>/notebooks/<short_id>`, and emit it on its own line so the wizard can surface it: `[NOTEBOOK_URL]` followed by that URL. Keep the local `posthog-setup-report.md` — the notebook is an extra copy, not a replacement.
+
 Upon completion, update `.posthog-events.json` so it matches the events you actually implemented, then remove it with your file tools. If removal is blocked or fails in your environment, leave the file in place and move on — the wizard host cleans it up after the run. Do not retry the removal or reach for shell commands to force it.
 
 ## Status
@@ -118,3 +120,4 @@ Status to report in this phase:
 
 - Configured dashboard: [insert PostHog dashboard URL]
 - Created setup report: [insert full local file path]
+- Created notebook: [insert PostHog notebook URL]


### PR DESCRIPTION
Instruct the integration agent to create a shareable PostHog notebook from `posthog-setup-report.md` via the `notebooks-create` MCP tool and emit `[NOTEBOOK_URL]` for the wizard to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)