### PR TITLE
feat(self-driving): default to the single connected repo for GitHub Issues

### DIFF
--- a/context/skills/self-driving/references/5a-github.md
+++ b/context/skills/self-driving/references/5a-github.md
@@ -18,9 +18,9 @@ Reach `integrations-github-repos-retrieve` and `external-data-sources-create` th
 
 ## Do
 
-1. **Infer the repository.** Run `git remote get-url origin` in the project root and parse `owner/repo` from either form (`git@github.com:owner/repo.git` or `https://github.com/owner/repo[.git]`). No remote, or not a github.com remote → go to the dormant fallback (below).
+1. **List the connected repos first.** Call `integrations-github-repos-retrieve` with the step-3 GitHub integration id (no search). Exactly **one** repository connected → that's the repo: use it by default and skip repo research entirely — no `git remote` inference, no search calls — and go straight to the confirm (step 3). Several connected → research which one matches this project (step 2). None → dormant fallback (below).
 
-2. **Validate it against the integration.** Call `integrations-github-repos-retrieve` with the step-3 GitHub integration id and `search=<repo name>`. The inferred `full_name` appearing in the results means the GitHub App can see it. Not in the results → dormant fallback (below) — the App isn't installed on this repo, so don't redirect or re-prompt.
+2. **Several connected: infer the repository.** Run `git remote get-url origin` in the project root and parse `owner/repo` from either form (`git@github.com:owner/repo.git` or `https://github.com/owner/repo[.git]`). No remote, or not a github.com remote → go to the dormant fallback (below). Then validate the inferred repo against the step-1 list (search again with `search=<repo name>` if the list was truncated). The inferred `full_name` appearing in the results means the GitHub App can see it. Not in the results → dormant fallback (below) — the App isn't installed on this repo, so don't redirect or re-prompt.
 
 3. **Confirm — never create unconfirmed:**
 


### PR DESCRIPTION
## Problem

PostHog/wizard#878 makes GitHub Issues use the single connected repo by default, but the wizard prompt only carries order and mechanics — the HOW lives in this skill's references, so the change doesn't take effect without mirroring it here.

## Changes

- `5a-github.md` now lists the connected repos first: exactly one → use it by default with no repo research (no git remote inference, no search calls), straight to the confirm; several → research which one matches (previous flow); none → dormant fallback

## Test plan

- `npm test` (107 passed) and `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
