### PR TITLE
fix(omnibus): scope lint/format runs to files edited this session

### DIFF
--- a/context/skills/omnibus/instrument-error-tracking/description.md
+++ b/context/skills/omnibus/instrument-error-tracking/description.md
@@ -46,7 +46,7 @@ STEP 7: Set up environment variables.
 STEP 8: Verify and clean up.
   - Check the project for errors. Look for type checking or build scripts in package.json.
   - Ensure any components created were actually used.
-  - Run any linter or prettier-like scripts found in the package.json.
+  - Run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Never run formatting or linting across the entire project's codebase.
 
 ## Reference files
 

--- a/context/skills/omnibus/instrument-integration/description.md
+++ b/context/skills/omnibus/instrument-integration/description.md
@@ -40,7 +40,7 @@ STEP 6: Set up environment variables.
 STEP 7: Verify and clean up.
   - Check the project for errors. Look for type checking or build scripts in package.json.
   - Ensure any components created were actually used.
-  - Run any linter or prettier-like scripts found in the package.json.
+  - Run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Never run formatting or linting across the entire project's codebase.
 
 ## Reference files
 

--- a/context/skills/omnibus/instrument-product-analytics/description.md
+++ b/context/skills/omnibus/instrument-product-analytics/description.md
@@ -55,7 +55,7 @@ STEP 9: Set up environment variables.
 STEP 10: Verify and clean up.
   - Check the project for errors. Look for type checking or build scripts in package.json.
   - Ensure any components created were actually used.
-  - Run any linter or prettier-like scripts found in the package.json.
+  - Run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Never run formatting or linting across the entire project's codebase.
 
 ## Reference files
 


### PR DESCRIPTION
Brings the three omnibus skills in line with the integration skill's 3-revise.md wording, so an agent never runs a repo-wide format/lint pass (observed rewriting 429 unrelated files on a real app; complements PostHog/wizard#886's pi-side guard).