### PR TITLE
fix(content): version-gate the Next.js client init rule

### DIFF
--- a/context/commandments.yaml
+++ b/context/commandments.yaml
@@ -24,7 +24,7 @@ commandments:
 
   nextjs:
     # Initialization
-    - For Next.js 15.3+, initialize PostHog in instrumentation-client.ts for the simplest setup
+    - 'Initialize client-side PostHog in exactly one place, based on the "next" version in package.json: on 15.3 and later, use instrumentation-client.ts; below 15.3, use a "use client" PostHogProvider in the root layout (or _app), because instrumentation-client.ts is ignored there'
 
   nextjs-feature-flags:
     # Client-side feature flags


### PR DESCRIPTION
## Why

`instrumentation-client.ts` only runs on Next.js 15.3+. On older versions it is silently ignored, so an agent following our guidance leaves client-side PostHog uninitialized (seen in a benchmark run against a Next.js 14.2.5 app). The existing `nextjs` commandment recommended `instrumentation-client.ts` with no version check and no alternative.

## What

One line in `context/commandments.yaml` — the `nextjs` init commandment now says which init location to use for which version:

> Initialize client-side PostHog in exactly one place, based on the "next" version in package.json: on 15.3 and later, use instrumentation-client.ts; below 15.3, use a "use client" PostHogProvider in the root layout (or _app), because instrumentation-client.ts is ignored there

Commandments fold into every skill tagged `nextjs` at build time, so this reaches all Next.js skills without touching them individually.

## Verification

- `npm test` — 107/107 pass
- `npm run build` — clean; the new rule appears in every built Next.js `SKILL.md` under `dist/marketplace`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*