### PR TITLE
fix(skills): notebook JSON escaping + report overwrite guidance (terra telemetry)

### DIFF
--- a/context/skills/integration-v2/notebook/description.md
+++ b/context/skills/integration-v2/notebook/description.md
@@ -4,9 +4,13 @@ Once `posthog-setup-report.md` exists, mirror it into a shareable PostHog notebo
 so the user has an in-app copy to link and comment on. The notebook is an extra
 copy, not a replacement — keep the local report file in place.
 
-Call `notebooks-create` through `posthog_exec` with a `title` (e.g.
-`PostHog setup (wizard) – <repo name>`) and `content` set to a single markdown
-node that wraps the report verbatim:
+First `Read` the finished `posthog-setup-report.md` — don't reconstruct the
+report from memory, and don't try to read it before the report step has written
+it.
+
+Then call `notebooks-create` through `posthog_exec` — that exact tool name, no
+tool search needed — with a `title` (e.g. `PostHog setup (wizard) – <repo name>`)
+and `content` set to a single markdown node that wraps the report verbatim:
 
 ```json
 {
@@ -16,6 +20,13 @@ node that wraps the report verbatim:
   ]}
 }
 ```
+
+The `markdown` value is a JSON string, so the report's raw contents cannot be
+pasted in verbatim: escape every newline as `\n`, every double quote as `\"`,
+and every backslash as `\\`, yielding one single-line string. Getting this wrong
+is the most common failure in this step — the tool call fails to parse and you
+burn attempts re-escaping. If the payload is rejected, fix the escaping; do not
+trim or summarize the report to make it fit.
 
 Take the `short_id` from the response, build the URL as
 `<host>/project/<project_id>/notebooks/<short_id>`, and emit it on its own line in

--- a/context/skills/integration-v2/report/description.md
+++ b/context/skills/integration-v2/report/description.md
@@ -1,7 +1,10 @@
 # Write the setup report
 
 Write `posthog-setup-report.md` at the project root summarizing the integration.
-It is a new file you create — write it directly, do not read it first.
+When the file doesn't exist, write it directly — don't attempt a read first. If
+a previous run left one behind, `Read` it, then replace it wholesale (harnesses
+refuse to overwrite a file that wasn't read; nothing in the old report is worth
+merging).
 Draw on two sources only:
 
 - the run's queue log — `.posthog-wizard-cache/queue.json`, which holds each


### PR DESCRIPTION
## What

Two prompt fixes in the `integration-v2` report step, driven by wizard remark telemetry from the gpt-5.6-terra rollout (2026-07-15, ~10 remarks in the first hour of external traffic):

1. **`skills/integration-v2/notebook`** — agents repeatedly failed `notebooks-create` calls by pasting raw multi-line report markdown into the JSON payload ("repeated notebooks-create JSON parsing failures"). The skill now:
   - says to `Read` the finished `posthog-setup-report.md` first (and not before the report step wrote it)
   - names the exact tool (`notebooks-create` via `posthog_exec`) so no tool-search round-trip is needed — one run wasted a lookup on a scope-gated alias surfaced first
   - spells out the escaping contract: `\n` / `\"` / `\\`, one single-line string, and fix-the-escaping-don't-trim-the-report on rejection

2. **`skills/integration-v2/report`** — remarks disagreed about read-before-write because the correct behavior differs: fresh runs must write directly (a read errors on the missing file), re-runs must `Read` first (harnesses refuse to overwrite an unread file). The skill now states both cases.

## Why now

All terra runs still succeeded — these loops cost retries, tokens, and ~seconds of wall-clock per run, not outcomes. But they're the top remark cluster by far (notebook escaping alone is 10+ mentions) and the fix is decoupled from the wizard release cycle.

## Notes

- `npm test` passes (121/121). `npm run build` is broken on the `experiment/orchestrator` tip **before** this change: `agents/integration-v2/build.md` (and possibly siblings) still declare `flow: "posthog-integration"` after the rename in 23276d8. Not addressed here to avoid colliding with in-flight rename work — flagging for whoever owns it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*