### PR TITLE
Draft release until all assets upload, then publish

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -143,7 +143,12 @@ jobs:
 
             **Version:** ${{ steps.version.outputs.version }}
             **SHA:** ${{ github.sha }}
-          draft: false
+          # Publish as a draft so `releases/latest` keeps pointing at the previous
+          # complete release while assets upload. Uploading takes a few minutes and
+          # skill-menu.json lands last, so a live release here would 404 the wizard
+          # for that window. Flipped to published in "Publish release" once every
+          # asset is uploaded.
+          draft: true
           prerelease: false
 
       - name: Upload skills bundle
@@ -177,6 +182,15 @@ jobs:
             echo "Uploading $filename..."
             gh release upload "$RELEASE_TAG" "$file" --clobber
           done
+
+      - name: Publish release
+        # Every asset (bundle, skill ZIPs, skill-menu.json, docs) is now uploaded,
+        # so flip the draft to published atomically. This is the point `releases/latest`
+        # moves to the new version — the wizard never sees it without skill-menu.json.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest
 
       - name: Update latest tag
         env:


### PR DESCRIPTION
Fixes a race that bricks the wizard on every release.

## Problem

The release was created **published** (`draft: false`) *before* any assets were uploaded. Because the wizard resolves `releases/latest`, the new release went live the instant it was created — but `skill-menu.json` is uploaded last, a few minutes later. For that window `releases/latest` points at a release with no `skill-menu.json`, so the wizard 404s.

## Fix

Create the release as a **draft**, upload every asset, then flip it to published as the final step. `releases/latest` ignores drafts, so it keeps pointing at the previous complete release until the new one is fully populated — closing the window entirely.

## Why

Raised in a Slack thread: context-mill builds take a few minutes, and the publish-then-upload ordering left a ~3-minute window that broke the wizard on every release.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1784157890535239?thread_ts=1784157890.535239&cid=C09GTQY5RLZ)*