### PR TITLE
feat(build): ship step-skill variants as one bundle per group

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -170,6 +170,13 @@ jobs:
           # Upload skill-menu.json (used by the wizard to discover available skills)
           echo "Uploading skill-menu.json..."
           gh release upload "$RELEASE_TAG" dist/skills/skill-menu.json --clobber
+          # Upload each bundled group (one JSON of every variant, in place of per-variant ZIPs)
+          for file in dist/skills/*.json; do
+            filename=$(basename "$file")
+            case "$filename" in manifest.json|skill-menu.json) continue ;; esac
+            echo "Uploading $filename..."
+            gh release upload "$RELEASE_TAG" "$file" --clobber
+          done
           # Upload reference docs (used by the wizard for runtime-specific overrides)
           for file in dist/skills/*.md; do
             [ -f "$file" ] || continue

--- a/context/skills/integration-v2/capture/config.yaml
+++ b/context/skills/integration-v2/capture/config.yaml
@@ -7,3 +7,4 @@ tags: [orchestrator, capture]
 cli:
   role: internal
 variants_from: integration
+packaging: bundle

--- a/context/skills/integration-v2/error-tracking-step/config.yaml
+++ b/context/skills/integration-v2/error-tracking-step/config.yaml
@@ -7,3 +7,4 @@ tags: [orchestrator, error-tracking]
 cli:
   role: internal
 variants_from: integration
+packaging: bundle

--- a/context/skills/integration-v2/init/config.yaml
+++ b/context/skills/integration-v2/init/config.yaml
@@ -7,3 +7,4 @@ tags: [orchestrator, init]
 cli:
   role: internal
 variants_from: integration
+packaging: bundle

--- a/context/skills/integration-v2/install/config.yaml
+++ b/context/skills/integration-v2/install/config.yaml
@@ -7,3 +7,4 @@ tags: [orchestrator, install]
 cli:
   role: internal
 variants_from: integration
+packaging: bundle

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,6 +18,7 @@ import {
     loadDocsConfig,
     zipSkillToBuffer,
     createBundledArchive,
+    writeBundles,
     writeManifestAndMenu,
 } from './lib/build-phases.js';
 
@@ -35,17 +36,6 @@ async function fetchDocContent(doc) {
         }
     }
     return parts.join('\n\n---\n\n');
-}
-
-/** Read a built skill dir into { relativePath: contents }. */
-function readSkillFiles(dir) {
-    const files = {};
-    for (const entry of fs.readdirSync(dir, { recursive: true, withFileTypes: true })) {
-        if (!entry.isFile()) continue;
-        const abs = path.join(entry.parentPath ?? entry.path, entry.name);
-        files[path.relative(dir, abs)] = fs.readFileSync(abs, 'utf8');
-    }
-    return files;
 }
 
 async function main() {
@@ -72,20 +62,10 @@ async function main() {
 
         console.log('\nCreating skill ZIPs...');
         const skillZips = {};
-        const bundles = {};
         for (const skill of skills) {
-            const skillDir = path.join(tempDir, skill.id);
             // A bundled variant ships inside its group's JSON, not as its own zip.
-            if (skill.bundle) {
-                const group = skill.group.replace(/\//g, '-');
-                const variants = (bundles[group] ??= {});
-                // shortId is the only unique key — framework is the family (nextjs, astro), shared by several variants.
-                if (variants[skill.shortId]) {
-                    throw new Error(`Duplicate variant "${skill.shortId}" in bundle "${group}"`);
-                }
-                variants[skill.shortId] = readSkillFiles(skillDir);
-                continue;
-            }
+            if (skill.bundle) continue;
+            const skillDir = path.join(tempDir, skill.id);
             const buffer = await zipSkillToBuffer(skillDir);
             const filename = `${skill.id}.zip`;
             skillZips[filename] = buffer;
@@ -93,14 +73,12 @@ async function main() {
             fs.writeFileSync(path.join(skillsDir, filename), buffer);
             console.log(`  ✓ ${filename} (${(buffer.length / 1024).toFixed(1)} KB)`);
         }
-
-        for (const [group, variants] of Object.entries(bundles)) {
-            const json = JSON.stringify({ id: group, variants });
-            fs.writeFileSync(path.join(skillsDir, `${group}.json`), json);
-            console.log(
-                `  ✓ ${group}.json (${Object.keys(variants).length} variants, ${(json.length / 1024).toFixed(1)} KB)`,
-            );
-        }
+        const bundleFiles = writeBundles({
+            skills,
+            sourceDir: tempDir,
+            skillsDir,
+            log: console.log,
+        });
 
         console.log('\nGenerating marketplace plugins...');
         const marketplaceResult = generateMarketplace({
@@ -160,7 +138,10 @@ async function main() {
 
         console.log('\nCreating bundled archive...');
         const bundlePath = path.join(distDir, 'skills-mcp-resources.zip');
-        const bundleSize = await createBundledArchive(bundlePath, manifest, skillZips);
+        const bundleSize = await createBundledArchive(bundlePath, manifest, {
+            ...skillZips,
+            ...bundleFiles,
+        });
         console.log(`  ✓ skills-mcp-resources.zip (${(bundleSize / 1024).toFixed(1)} KB)`);
 
         console.log('\n' + '='.repeat(50));

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -83,11 +83,7 @@ async function main() {
                 if (variants[skill.shortId]) {
                     throw new Error(`Duplicate variant "${skill.shortId}" in bundle "${group}"`);
                 }
-                variants[skill.shortId] = {
-                    framework: skill.framework,
-                    default: skill.default || undefined,
-                    files: readSkillFiles(skillDir),
-                };
+                variants[skill.shortId] = readSkillFiles(skillDir);
                 continue;
             }
             const buffer = await zipSkillToBuffer(skillDir);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -37,6 +37,17 @@ async function fetchDocContent(doc) {
     return parts.join('\n\n---\n\n');
 }
 
+/** Read a built skill dir into { relativePath: contents }. */
+function readSkillFiles(dir) {
+    const files = {};
+    for (const entry of fs.readdirSync(dir, { recursive: true, withFileTypes: true })) {
+        if (!entry.isFile()) continue;
+        const abs = path.join(entry.parentPath ?? entry.path, entry.name);
+        files[path.relative(dir, abs)] = fs.readFileSync(abs, 'utf8');
+    }
+    return files;
+}
+
 async function main() {
     console.log('Building resources...');
     console.log(`Version: ${BUILD_VERSION}\n`);
@@ -61,14 +72,38 @@ async function main() {
 
         console.log('\nCreating skill ZIPs...');
         const skillZips = {};
+        const bundles = {};
         for (const skill of skills) {
             const skillDir = path.join(tempDir, skill.id);
+            // A bundled variant ships inside its group's JSON, not as its own zip.
+            if (skill.bundle) {
+                const group = skill.group.replace(/\//g, '-');
+                const variants = (bundles[group] ??= {});
+                // shortId is the only unique key — framework is the family (nextjs, astro), shared by several variants.
+                if (variants[skill.shortId]) {
+                    throw new Error(`Duplicate variant "${skill.shortId}" in bundle "${group}"`);
+                }
+                variants[skill.shortId] = {
+                    framework: skill.framework,
+                    default: skill.default || undefined,
+                    files: readSkillFiles(skillDir),
+                };
+                continue;
+            }
             const buffer = await zipSkillToBuffer(skillDir);
             const filename = `${skill.id}.zip`;
             skillZips[filename] = buffer;
 
             fs.writeFileSync(path.join(skillsDir, filename), buffer);
             console.log(`  ✓ ${filename} (${(buffer.length / 1024).toFixed(1)} KB)`);
+        }
+
+        for (const [group, variants] of Object.entries(bundles)) {
+            const json = JSON.stringify({ id: group, variants });
+            fs.writeFileSync(path.join(skillsDir, `${group}.json`), json);
+            console.log(
+                `  ✓ ${group}.json (${Object.keys(variants).length} variants, ${(json.length / 1024).toFixed(1)} KB)`,
+            );
         }
 
         console.log('\nGenerating marketplace plugins...');
@@ -102,7 +137,8 @@ async function main() {
         console.log(`\n  ✓ manifest.json`);
 
         const skillMenu = JSON.parse(fs.readFileSync(path.join(skillsDir, 'skill-menu.json'), 'utf8'));
-        console.log(`  ✓ skill-menu.json (${Object.keys(skillMenu.categories).length} categories, ${skills.length} skills)`);
+        const menuEntries = Object.values(skillMenu.categories).flat().length;
+        console.log(`  ✓ skill-menu.json (${Object.keys(skillMenu.categories).length} categories, ${menuEntries} entries)`);
 
         console.log('\nBuilding agent prompts...');
         const agentsResult = buildAgents({

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -282,10 +282,17 @@ function serveFile(res, filePath, contentType, attachmentName = null) {
 
 function createServer() {
     const server = http.createServer((req, res) => {
-        const skillMatch = req.url?.match(/^\/skills\/(.+\.zip)$/);
+        // A skill is served as its own zip, or — for a bundled group — as one JSON of every variant.
+        const skillMatch = req.url?.match(/^\/skills\/(.+\.(zip|json))$/);
         if (skillMatch) {
-            const skillFile = skillMatch[1];
-            serveFile(res, path.join(skillsDir, skillFile), 'application/zip', skillFile);
+            const [skillFile, ext] = [skillMatch[1], skillMatch[2]];
+            const isZip = ext === 'zip';
+            serveFile(
+                res,
+                path.join(skillsDir, skillFile),
+                isZip ? 'application/zip' : 'application/json',
+                isZip ? skillFile : undefined,
+            );
             return;
         }
 
@@ -316,13 +323,14 @@ function createServer() {
         }
 
         res.writeHead(404, { 'Content-Type': 'text/plain', ...NO_CACHE_HEADERS });
-        res.end('Not found. Available endpoints:\n  /skill-menu.json\n  /skills-mcp-resources.zip\n  /skills/{id}.zip\n  /agent-menu.json\n  /agents/{flow}/{type}.md');
+        res.end('Not found. Available endpoints:\n  /skill-menu.json\n  /skills-mcp-resources.zip\n  /skills/{id}.zip\n  /skills/{group}.json\n  /agent-menu.json\n  /agents/{flow}/{type}.md');
     });
 
     server.listen(PORT, () => {
         console.log('\n🚀 Development server started!');
         console.log(`\n📍 Skills bundle:   http://localhost:${PORT}/skills-mcp-resources.zip`);
         console.log(`📍 Individual skill: http://localhost:${PORT}/skills/{id}.zip`);
+        console.log(`📦 Bundled group:    http://localhost:${PORT}/skills/{group}.json`);
         console.log(`📋 Skills menu:      http://localhost:${PORT}/skill-menu.json`);
         console.log(`🤖 Agent prompt:     http://localhost:${PORT}/agents/{flow}/{type}.md`);
         console.log(`📋 Agents menu:      http://localhost:${PORT}/agent-menu.json`);

--- a/scripts/lib/build-phases.js
+++ b/scripts/lib/build-phases.js
@@ -351,7 +351,13 @@ function writeBundles({ skills, sourceDir, skillsDir, merge = false, log = () =>
                 ? JSON.parse(fs.readFileSync(file, 'utf8')).variants
                 : {};
         const bundle = { id: group, variants: { ...existing } };
+        const seen = new Set();
         for (const skill of variants) {
+            // Two variants resolving to one short id would silently overwrite each other.
+            if (seen.has(skill.shortId)) {
+                throw new Error(`Bundle "${group}" has duplicate variant id "${skill.shortId}"`);
+            }
+            seen.add(skill.shortId);
             bundle.variants[skill.shortId] = readSkillFiles(path.join(sourceDir, skill.id));
         }
         const json = JSON.stringify(bundle);

--- a/scripts/lib/build-phases.js
+++ b/scripts/lib/build-phases.js
@@ -187,16 +187,35 @@ function writeManifestAndMenu({ allSkills, docContents, distDir, configDir, vers
     fs.writeFileSync(path.join(skillsDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 
     const skillsByCategory = {};
+    const bundleEntries = new Map();
     for (const skill of allSkills) {
         const cat = skill.group;
         if (!skillsByCategory[cat]) skillsByCategory[cat] = [];
+        const group = skill.group.replace(/\//g, '-');
+        const url = manifest.resources.find(r => r.id === skill.id)?.downloadUrl;
+        // A bundled group publishes one entry; the consumer picks the variant inside.
+        if (skill.bundle) {
+            let entry = bundleEntries.get(group);
+            if (!entry) {
+                // `frameworks` lists what the bundle covers, so consumers can check a match without downloading it.
+                entry = {
+                    id: group,
+                    name: skill.name,
+                    group,
+                    bundle: true,
+                    frameworks: [],
+                    downloadUrl: url?.replace(/\/[^/]+\.zip$/, `/${group}.json`),
+                };
+                bundleEntries.set(group, entry);
+                skillsByCategory[cat].push(entry);
+            }
+            if (skill.framework && !entry.frameworks.includes(skill.framework)) {
+                entry.frameworks.push(skill.framework);
+            }
+            continue;
+        }
         // group/framework/default let consumers resolve a bare skill id + framework by exact match.
-        const entry = {
-            id: skill.id,
-            name: skill.name,
-            group: skill.group.replace(/\//g, '-'),
-            downloadUrl: manifest.resources.find(r => r.id === skill.id)?.downloadUrl,
-        };
+        const entry = { id: skill.id, name: skill.name, group, downloadUrl: url };
         if (skill.framework) entry.framework = skill.framework;
         if (skill.default) entry.default = true;
         skillsByCategory[cat].push(entry);

--- a/scripts/lib/build-phases.js
+++ b/scripts/lib/build-phases.js
@@ -197,21 +197,22 @@ function writeManifestAndMenu({ allSkills, docContents, distDir, configDir, vers
         if (skill.bundle) {
             let entry = bundleEntries.get(group);
             if (!entry) {
-                // `frameworks` lists what the bundle covers, so consumers can check a match without downloading it.
                 entry = {
                     id: group,
                     name: skill.name,
                     group,
                     bundle: true,
-                    frameworks: [],
+                    variants: [],
                     downloadUrl: url?.replace(/\/[^/]+\.zip$/, `/${group}.json`),
                 };
                 bundleEntries.set(group, entry);
                 skillsByCategory[cat].push(entry);
             }
-            if (skill.framework && !entry.frameworks.includes(skill.framework)) {
-                entry.frameworks.push(skill.framework);
-            }
+            // Each variant keeps its own id/framework/default so consumers resolve it exactly as they would a per-skill zip.
+            const variant = { id: skill.id };
+            if (skill.framework) variant.framework = skill.framework;
+            if (skill.default) variant.default = true;
+            entry.variants.push(variant);
             continue;
         }
         // group/framework/default let consumers resolve a bare skill id + framework by exact match.

--- a/scripts/lib/build-phases.js
+++ b/scripts/lib/build-phases.js
@@ -315,11 +315,61 @@ function validateDefault(entries) {
  * Delete `dist/skills/<id>.zip` files whose IDs are no longer in `allSkills`.
  * Returns the array of removed filenames.
  */
+/** Read a built skill dir into { relativePath: contents }. */
+function readSkillFiles(dir) {
+    const files = {};
+    for (const entry of fs.readdirSync(dir, { recursive: true, withFileTypes: true })) {
+        if (!entry.isFile()) continue;
+        const abs = path.join(entry.parentPath ?? entry.path, entry.name);
+        files[path.relative(dir, abs)] = fs.readFileSync(abs, 'utf8');
+    }
+    return files;
+}
+
+/**
+ * Write each bundled group as one `<group>.json` holding every variant's files,
+ * read from the built skill dirs under `sourceDir`.
+ *
+ * `merge` keeps the variants already on disk and replaces only the ones passed
+ * in — the dev server rebuilds a single variant at a time and must not drop the
+ * other 36. A full build writes fresh so a deleted variant cannot survive.
+ *
+ * Returns { filename: Buffer } so the caller can add the bundles to the archive.
+ */
+function writeBundles({ skills, sourceDir, skillsDir, merge = false, log = () => {} }) {
+    const groups = {};
+    for (const skill of skills) {
+        if (!skill.bundle) continue;
+        (groups[skill.group.replace(/\//g, '-')] ??= []).push(skill);
+    }
+
+    const artifacts = {};
+    for (const [group, variants] of Object.entries(groups)) {
+        const file = path.join(skillsDir, `${group}.json`);
+        const existing =
+            merge && fs.existsSync(file)
+                ? JSON.parse(fs.readFileSync(file, 'utf8')).variants
+                : {};
+        const bundle = { id: group, variants: { ...existing } };
+        for (const skill of variants) {
+            bundle.variants[skill.shortId] = readSkillFiles(path.join(sourceDir, skill.id));
+        }
+        const json = JSON.stringify(bundle);
+        fs.writeFileSync(file, json);
+        artifacts[`${group}.json`] = Buffer.from(json);
+        log(
+            `  ✓ ${group}.json (${Object.keys(bundle.variants).length} variants, ${(json.length / 1024).toFixed(1)} KB)`,
+        );
+    }
+    return artifacts;
+}
+
 function reconcileOrphans({ allSkills, distDir, log = () => {} }) {
     const skillsDir = path.join(distDir, 'skills');
     if (!fs.existsSync(skillsDir)) return [];
 
-    const validIds = new Set(allSkills.map(s => s.id));
+    // A bundled skill has no zip of its own, so a leftover one from an earlier build is an orphan.
+    const validIds = new Set(allSkills.filter(s => !s.bundle).map(s => s.id));
     const removed = [];
 
     for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
@@ -372,12 +422,15 @@ async function partialRebuild({
         });
 
         for (const skill of rebuiltSkills) {
+            if (skill.bundle) continue;
             const skillTempDir = path.join(tempDir, skill.id);
             const buffer = await zipSkillToBuffer(skillTempDir);
             const filename = `${skill.id}.zip`;
             fs.writeFileSync(path.join(skillsDir, filename), buffer);
             log(`  ✓ ${filename} (${(buffer.length / 1024).toFixed(1)} KB)`);
         }
+        // Patch the rebuilt variants into their bundle, leaving the group's untouched variants alone.
+        writeBundles({ skills: rebuiltSkills, sourceDir: tempDir, skillsDir, merge: true, log });
 
         writeManifestAndMenu({ allSkills, docContents, distDir, configDir, version });
         reconcileOrphans({ allSkills, distDir, log });
@@ -394,6 +447,7 @@ export {
     loadDocContentsFromManifest,
     zipSkillToBuffer,
     createBundledArchive,
+    writeBundles,
     generateManifest,
     generateCliEntries,
     writeManifestAndMenu,

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -284,6 +284,8 @@ function expandSkillGroups(config, configDir) {
         const baseSharedDocs = group.shared_docs || [];
         const baseExamplePaths = normalizeExamplePaths(group.example_paths);
         const baseCli = parseCliBlock(group.cli, `Skill group "${key}"`);
+        // `packaging: bundle` ships the group as one JSON whose variants live inside.
+        const bundled = group.packaging === 'bundle';
 
         // Category is the first segment of the composite key, or an explicit override
         const category = group.category || key.split('/')[0];
@@ -334,6 +336,7 @@ function expandSkillGroups(config, configDir) {
                 _examplePaths: [...baseExamplePaths, ...normalizeExamplePaths(variation.example_paths)],
                 _references: group.references || null,
                 _group: key,
+                _bundle: bundled,
                 _cli: cli,
             });
         }
@@ -810,6 +813,9 @@ function serializeSkill(s) {
     }
     if (s.default) {
         result.default = true;
+    }
+    if (s._bundle) {
+        result.bundle = true;
     }
     if (s._cli) {
         result.cli = s._cli;

--- a/scripts/lib/tests/bundle-writer.test.js
+++ b/scripts/lib/tests/bundle-writer.test.js
@@ -97,6 +97,16 @@ describe('writeBundles', () => {
         expect(Object.keys(readBundle().variants)).toEqual(['django']);
     });
 
+    it('rejects duplicate variant ids instead of silently overwriting', () => {
+        expect(() =>
+            writeBundles({
+                skills: [skill('django'), skill('django')],
+                sourceDir: sourceDir(),
+                skillsDir: skillsDir(),
+            }),
+        ).toThrow('duplicate variant id "django"');
+    });
+
     it('returns the written bundles so the caller can archive them', () => {
         const artifacts = writeBundles({
             skills: [skill('django')],

--- a/scripts/lib/tests/bundle-writer.test.js
+++ b/scripts/lib/tests/bundle-writer.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { writeBundles } from '../build-phases.js';
+
+// Two variants of one bundled group, plus an unbundled skill that must stay a zip.
+const skill = (shortId, bundle = true) => ({
+    id: `capture-${shortId}`,
+    shortId,
+    group: 'capture',
+    bundle,
+});
+
+let dir;
+const sourceDir = () => path.join(dir, 'src');
+const skillsDir = () => path.join(dir, 'skills');
+const readBundle = () =>
+    JSON.parse(fs.readFileSync(path.join(skillsDir(), 'capture.json'), 'utf8'));
+
+function writeVariantSource(shortId, contents) {
+    const variantDir = path.join(sourceDir(), `capture-${shortId}`);
+    fs.mkdirSync(path.join(variantDir, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(variantDir, 'SKILL.md'), contents);
+    fs.writeFileSync(path.join(variantDir, 'references', `${shortId}.md`), `${shortId} docs`);
+}
+
+beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-writer-'));
+    fs.mkdirSync(skillsDir(), { recursive: true });
+    writeVariantSource('django', 'django v1');
+    writeVariantSource('nextjs', 'nextjs v1');
+});
+
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('writeBundles', () => {
+    it('writes one JSON per group holding every variant, keyed by short id', () => {
+        writeBundles({
+            skills: [skill('django'), skill('nextjs')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+
+        const bundle = readBundle();
+        expect(bundle.id).toBe('capture');
+        expect(Object.keys(bundle.variants).sort()).toEqual(['django', 'nextjs']);
+        expect(bundle.variants.django['SKILL.md']).toBe('django v1');
+        expect(bundle.variants.django['references/django.md']).toBe('django docs');
+    });
+
+    it('leaves an unbundled skill out of the bundle entirely', () => {
+        writeBundles({
+            skills: [skill('django'), skill('nextjs', false)],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+
+        expect(Object.keys(readBundle().variants)).toEqual(['django']);
+    });
+
+    it('merges a rebuilt variant into the group without dropping the others', () => {
+        writeBundles({
+            skills: [skill('django'), skill('nextjs')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+        writeVariantSource('django', 'django v2');
+
+        // The dev server rebuilds only the variant whose source changed.
+        writeBundles({
+            skills: [skill('django')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+            merge: true,
+        });
+
+        const bundle = readBundle();
+        expect(Object.keys(bundle.variants).sort()).toEqual(['django', 'nextjs']);
+        expect(bundle.variants.django['SKILL.md']).toBe('django v2');
+        expect(bundle.variants.nextjs['SKILL.md']).toBe('nextjs v1');
+    });
+
+    it('drops a removed variant on a full write', () => {
+        writeBundles({
+            skills: [skill('django'), skill('nextjs')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+
+        writeBundles({
+            skills: [skill('django')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+
+        expect(Object.keys(readBundle().variants)).toEqual(['django']);
+    });
+
+    it('returns the written bundles so the caller can archive them', () => {
+        const artifacts = writeBundles({
+            skills: [skill('django')],
+            sourceDir: sourceDir(),
+            skillsDir: skillsDir(),
+        });
+
+        expect(Object.keys(artifacts)).toEqual(['capture.json']);
+        expect(JSON.parse(artifacts['capture.json'].toString()).id).toBe('capture');
+    });
+});


### PR DESCRIPTION
The four integration-v2 step groups expanded to 148 near-identical zips, so `packaging: bundle` now ships each group as one JSON holding every variant and the release carries 144 artifacts instead of 288.