### PR TITLE
fix(integration): be explicit that insights are created before events ingest

### DIFF
--- a/context/skills/integration-v2/dashboard/description.md
+++ b/context/skills/integration-v2/dashboard/description.md
@@ -18,10 +18,11 @@ returned `id` — the insight step attaches every insight to it via
 ```
 
 Then create the insights (see the insight step) and attach each one to this
-dashboard's `id`. The dashboard is not done until those insights are attached —
-an empty dashboard shell is not a success, even when no events have been
-ingested yet (fresh insights render empty and fill in as events arrive; that is
-the expected state of a brand-new integration, not a reason to hold back).
+dashboard's `id`. Always create the dashboard and its insights based on the
+intended captures, regardless of whether those events have been observed yet —
+an empty dashboard shell is not a success. Fresh insights render empty and fill
+in as events arrive; that is the expected state of a brand-new integration, not
+a reason to hold back.
 
 ## Hand off the dashboard
 

--- a/context/skills/integration-v2/dashboard/description.md
+++ b/context/skills/integration-v2/dashboard/description.md
@@ -18,7 +18,10 @@ returned `id` — the insight step attaches every insight to it via
 ```
 
 Then create the insights (see the insight step) and attach each one to this
-dashboard's `id`.
+dashboard's `id`. The dashboard is not done until those insights are attached —
+an empty dashboard shell is not a success, even when no events have been
+ingested yet (fresh insights render empty and fill in as events arrive; that is
+the expected state of a brand-new integration, not a reason to hold back).
 
 ## Hand off the dashboard
 

--- a/context/skills/integration-v2/insight/description.md
+++ b/context/skills/integration-v2/insight/description.md
@@ -6,13 +6,13 @@ activation, and churn signals. Use the exact event names from the capture step's
 handoff; never invent events that were not instrumented. Keep each name tagged
 `(wizard)` with that exact casing.
 
-Create the insights now, in this run — do not skip or defer them because the
-newly instrumented events haven't been ingested yet. An insight is a definition
-over event names, not a snapshot of current data: it is expected to render
-empty until the first events arrive, and it fills in on its own once they do.
-"No data ingested yet", "the events aren't in the schema", or "the query would
-return nothing today" are never reasons to omit insights — a dashboard handed
-off without them is an incomplete integration, not a cautious one.
+Always create these insights based on the intended captures, regardless of
+whether those events have been observed yet. An insight is a definition over
+event names, not a snapshot of current data: it is expected to render empty
+until the first events arrive, and it fills in on its own once they do. "No
+data ingested yet", "the events aren't in the schema", or "the query would
+return nothing today" are never reasons to skip or defer insights — a dashboard
+handed off without them is an incomplete integration, not a cautious one.
 
 Every call goes through `posthog_exec` (`call insight-create <json>`). Attach each
 insight to the dashboard by passing its id in `dashboards: [<dashboard id>]`.

--- a/context/skills/integration-v2/insight/description.md
+++ b/context/skills/integration-v2/insight/description.md
@@ -6,6 +6,14 @@ activation, and churn signals. Use the exact event names from the capture step's
 handoff; never invent events that were not instrumented. Keep each name tagged
 `(wizard)` with that exact casing.
 
+Create the insights now, in this run — do not skip or defer them because the
+newly instrumented events haven't been ingested yet. An insight is a definition
+over event names, not a snapshot of current data: it is expected to render
+empty until the first events arrive, and it fills in on its own once they do.
+"No data ingested yet", "the events aren't in the schema", or "the query would
+return nothing today" are never reasons to omit insights — a dashboard handed
+off without them is an incomplete integration, not a cautious one.
+
 Every call goes through `posthog_exec` (`call insight-create <json>`). Attach each
 insight to the dashboard by passing its id in `dashboards: [<dashboard id>]`.
 

--- a/context/skills/integration/references/4-conclude.md
+++ b/context/skills/integration/references/4-conclude.md
@@ -6,7 +6,7 @@ description: Review and fix any errors in the PostHog integration implementation
 
 Create a live PostHog dashboard named "Analytics basics (wizard)" from the events you just instrumented, then populate it with up to five insights — lead with the business-critical views: conversion funnels, churn events, and other key signals. Use the exact same event names as implemented in the code. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go.
 
-Create the insights now, in this run — do not skip or defer them because the newly instrumented events haven't been ingested yet. An insight is a definition over event names, not a snapshot of current data: it is expected to render empty until the first events arrive, and it fills in on its own once they do. "No data ingested yet", "the events aren't in the schema", or "the query would return nothing today" are never reasons to omit insights — a dashboard handed off without them is an incomplete integration, not a cautious one.
+Always create the dashboard and insights based on the intended captures, regardless of whether those events have been observed yet. An insight is a definition over event names, not a snapshot of current data: it is expected to render empty until the first events arrive, and it fills in on its own once they do. "No data ingested yet", "the events aren't in the schema", or "the query would return nothing today" are never reasons to skip or defer insights — a dashboard handed off without them is an incomplete integration, not a cautious one.
 
 {{> mcp-tool-calling}}
 

--- a/context/skills/integration/references/4-conclude.md
+++ b/context/skills/integration/references/4-conclude.md
@@ -6,6 +6,8 @@ description: Review and fix any errors in the PostHog integration implementation
 
 Create a live PostHog dashboard named "Analytics basics (wizard)" from the events you just instrumented, then populate it with up to five insights — lead with the business-critical views: conversion funnels, churn events, and other key signals. Use the exact same event names as implemented in the code. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go.
 
+Create the insights now, in this run — do not skip or defer them because the newly instrumented events haven't been ingested yet. An insight is a definition over event names, not a snapshot of current data: it is expected to render empty until the first events arrive, and it fills in on its own once they do. "No data ingested yet", "the events aren't in the schema", or "the query would return nothing today" are never reasons to omit insights — a dashboard handed off without them is an incomplete integration, not a cautious one.
+
 {{> mcp-tool-calling}}
 
 Create the parent dashboard first with `dashboard-create`, capture its returned `id`, then attach every insight to it via `dashboards: [<id>]`:


### PR DESCRIPTION
## Summary

Agents running the wizard's dashboard/insight step sometimes shipped an **empty dashboard shell** when the freshly instrumented events hadn't been ingested yet — and the skill text let them: it says to build insights "from the events this integration instrumented", with nothing about the (universal for new integrations) case where those events have no data yet. Several external runs in a row skipped insight creation for exactly this reason, and each left the same end-of-run remark asking us to clarify "whether dashboards should omit insights until newly instrumented events appear."

This makes the intent explicit in both integration flows (`integration` linear + `integration-v2`): insights are definitions over event names, they are *expected* to render empty at creation and fill in as events arrive, and pre-ingestion emptiness is never a reason to skip or defer them.

Deliberately a wording fix, not a hard gate — models that skipped did so from a defensible reading of an ambiguous spec, and legitimately-empty cases still exist.

## Why

Multiple production runs delivered success with a dashboard containing zero insights, each flagging the same instruction ambiguity in its remark. One sentence of explicitness closes it without constraining agent judgment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*