### PR TITLE
feat(data-warehouse): offer Intercom and HubSpot in self-driving onboarding

### DIFF
--- a/context/skills/self-driving/references/5-connected-tools.md
+++ b/context/skills/self-driving/references/5-connected-tools.md
@@ -9,7 +9,7 @@ External tools can feed the inbox too: issue trackers (GitHub Issues, Linear, Ji
 The run can connect **every** one of them, each with at most one click from the user, and it never asks anyone to paste a credential into this chat:
 
 - **GitHub Issues** — reuses the GitHub App connected in step 3 (connector: `5a-github.md`).
-- **Linear** — a one-click OAuth link (connector: `5b-linear.md`).
+- **Linear, Intercom, HubSpot** — one-click OAuth links (connector: `5b-linear.md`; the flow is identical, only the `kind` and `<kind>_integration_id` payload key differ).
 - **Zendesk, pganalyze, Jira** (and any other API-credential source) — a secure PostHog **connect link**. The user enters their credentials on a PostHog page in their own browser, PostHog stores them, and the run creates the live source from that stored credential — no secret ever passes through this chat (connector: `5c-credentials.md`).
 
 A tool falls back to a **dormant responder** (the row is enabled but silent until a warehouse source exists) plus a follow-up **only** when the user skips or can't finish its connect step. That used to be the default for credential sources; it is now the exception.
@@ -39,6 +39,8 @@ Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `
     { label: "None of these", value: "none" },
     { label: "GitHub Issues", value: "github-issues" },
     { label: "Linear", value: "linear" },
+    { label: "Intercom", value: "intercom" },
+    { label: "HubSpot", value: "hubspot" },
     { label: "Jira", value: "jira" },
     { label: "GitLab", value: "gitlab" },
     { label: "Gitea", value: "gitea" },
@@ -76,18 +78,20 @@ Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `
 }
 ```
 
-2. Call `external-data-sources-list` once (step 2's project profile also lists warehouse sources when it exists). For each picked tool whose source already exists, match its warehouse `source_type`: `Github` / `Linear` / `Jira` / `GitLab` / `Gitea` / `Shortcut` / `Sentry` / `Rollbar` / `Bugsnag` / `Honeybadger` / `Raygun` / `Zendesk` / `Freshdesk` / `Freshservice` / `Front` / `Gorgias` / `Kustomer` / `Dixa` / `Plain` / `PgAnalyze` / `Snyk` / `Sonarqube` / `Semgrep` / `Rapid7Insightvm` / `Featurebase` / `Frill` / `Aha` / `Uservoice` / `Productboard` / `Canny` / `Asknicely` / `Retently` / `Appfigures` / `Appfollow` / `JudgeMeReviews`. Record "already connected" — no connector flow needed, just enable its responder row (step 4 below).
+2. Call `external-data-sources-list` once (step 2's project profile also lists warehouse sources when it exists). For each picked tool whose source already exists, match its warehouse `source_type`: `Github` / `Linear` / `Jira` / `GitLab` / `Gitea` / `Shortcut` / `Sentry` / `Rollbar` / `Bugsnag` / `Honeybadger` / `Raygun` / `Zendesk` / `Freshdesk` / `Freshservice` / `Front` / `Gorgias` / `Kustomer` / `Dixa` / `Plain` / `PgAnalyze` / `Snyk` / `Sonarqube` / `Semgrep` / `Rapid7Insightvm` / `Featurebase` / `Frill` / `Aha` / `Uservoice` / `Productboard` / `Canny` / `Asknicely` / `Retently` / `Appfigures` / `Appfollow` / `JudgeMeReviews` / `Intercom` / `Hubspot`. Record "already connected" — no connector flow needed, just enable its responder row (step 4 below).
 
 3. Dispatch each picked tool that's still missing:
 
    - **GitHub Issues** → read `references/5a-github.md` and follow it.
-   - **Linear** → read `references/5b-linear.md` and follow it.
+   - **Linear / Intercom / HubSpot** (one-click OAuth) → read `references/5b-linear.md` and follow it, substituting the `kind` (`linear` / `intercom` / `hubspot`), the `<kind>_integration_id` payload key, and the DWH `source_type` (`Linear` / `Intercom` / `Hubspot`).
    - **Zendesk / pganalyze / Jira** (and any other API-credential source) → read `references/5c-credentials.md` and follow it. It hands the user a secure PostHog connect link, waits for them to store their credentials in the browser, then creates the live source from that stored credential. If they skip or don't finish, it falls back to the dormant responder + follow-up (step 4 below).
 
 4. Enable the source row (step 4's write recipe) for every tool the user picked — created, verified, and picked-but-not-connected alike (a dormant row is harmless and saves a later trip):
 
    - GitHub Issues → `github` / `issue`
    - Linear → `linear` / `issue`
+   - Intercom → `intercom` / `ticket`
+   - HubSpot → `hubspot` / `ticket`
    - Jira → `jira` / `issue`
    - GitLab → `gitlab` / `issue`
    - Gitea → `gitea` / `issue`

--- a/context/skills/self-driving/references/5b-linear.md
+++ b/context/skills/self-driving/references/5b-linear.md
@@ -1,4 +1,8 @@
-# Connector — Linear warehouse source
+# Connector — Linear (and other one-click OAuth) warehouse source
+
+> Reused for every one-click OAuth source (Linear, Intercom, HubSpot). The flow is identical —
+> substitute the `kind` (`linear` / `intercom` / `hubspot`), the `<kind>_integration_id` payload
+> key, and the DWH `source_type` (`Linear` / `Intercom` / `Hubspot`) throughout.
 
 Creates the Linear warehouse source with at most **one click** from the user: Linear needs an OAuth'd Integration row, and the only part this run can't do is the user consenting in their browser. Hand them the authorize link, then check **once** for the integration — if it's there, create the source yourself (no UI form-filling); if it isn't, leave a dormant responder and move on. Never nudge or wait through retry rounds.
 


### PR DESCRIPTION
## Summary

Make `npx @posthog/wizard self-driving` offer the two OAuth support sources — Intercom and
HubSpot — alongside the 30 added in #254.

## Changes

In `5-connected-tools.md`: added Intercom + HubSpot to the step-5 `wizard_ask` options, the
"already connected" warehouse `source_type` detection, and the responder mapping
(`intercom`/`ticket`, `hubspot`/`ticket`). Both are one-click OAuth, so they reuse the Linear
connector (`5b-linear.md`) — the authorize flow is identical, only the `kind`,
`<kind>_integration_id` payload key, and `source_type` differ (noted in both files).

## Testing

- `node scripts/build.js` — bundles and validates (115 skills).

## Dependencies

Stacked on #254. Corresponds to backend PostHog/posthog#72535 and the Code inbox wiring
PostHog/code#3614 (+ generic OAuth flow starter PostHog/code#3613).
