### PR TITLE
feat(integration): route the flutter variant to wizard framework detection

### DIFF
--- a/context/skills/integration/config.yaml
+++ b/context/skills/integration/config.yaml
@@ -258,6 +258,7 @@ variants:
       - https://posthog.com/docs/libraries/ios/configuration.md
 
   - id: flutter
+    framework: flutter
     template: description-docs-only.md
     display_name: Flutter
     description: PostHog integration for Flutter applications using the posthog_flutter SDK


### PR DESCRIPTION
Related PRs:
- wizard: https://github.com/PostHog/wizard/pull/942

Declares `framework: flutter` on the existing docs-only `integration-flutter` variant so the built `skill-menu.json` emits it and the wizard's `resolveSkillVariantId()` can route a detected Flutter project to the skill. Needs to release before the wizard PR merges — the wizard resolves the live menu at runtime.

Verified: `pnpm build` emits `{id: integration-flutter, framework: flutter, group: integration}` into the menu; `pnpm test` passes (137 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)