### PR TITLE
fix(integration-v2): CSP guidance — script-src is required even when bundling

### DIFF
--- a/context/agents/integration-v2/init.md
+++ b/context/agents/integration-v2/init.md
@@ -30,5 +30,7 @@ file, never hardcoded in source, and `.env.example` lists the key names (with
 placeholder values) so the next developer knows what to set. Your handoff names the
 files you changed, how the client is constructed in them, and how a call site
 reaches that client — every step after you has to reach the same one the same way.
-If the app ships a Content-Security-Policy, the handoff also says how the SDK
-loads and sends past it: policy extended, or bundled with a same-origin path.
+If the app ships a Content-Security-Policy, the handoff also names exactly
+which directives you touched (`script-src`, `connect-src`, `worker-src`) and
+which you left alone — the review verifies directive-by-directive, and an
+unnamed directive reads as unhandled, not as fine.

--- a/context/skills/integration-v2/build/description.md
+++ b/context/skills/integration-v2/build/description.md
@@ -42,13 +42,16 @@ about most:
   integration was edited. If a step deleted or rewrote code it shouldn't have, or
   reformatted an untouched region, restore it. Flag anything you can't safely fix
   in `conflict`.
-- **The CSP lets it run.** If the app ships a Content-Security-Policy — a meta
-  tag or a server-sent header — confirm the policy allows the SDK to load
-  (`script-src`) and events to send (`connect-src`, which falls back to
-  `default-src`). A CSP-blocked integration builds clean and sends nothing: the
-  snippet's stub queues calls into an array nothing drains. The init step's
-  handoff says how it handled the policy; if it didn't, flag the mismatch in
-  `conflict` rather than reworking the integration here.
+- **The CSP lets it run.** If any handoff touched a Content-Security-Policy —
+  a meta tag or a server-sent header — verify it directive-by-directive; do
+  not take the handoff's word that the policy is handled. Required:
+  `script-src` allows the PostHog hosts (needed even when posthog-js is
+  bundled — replay/surveys/toolbar lazy-load from the assets CDN),
+  `connect-src` allows the API host (falls back to `default-src`, so a bare
+  `default-src 'self'` blocks sending), and `worker-src blob:` if session
+  replay is on. A partial CSP is the worst failure shape: events send, so the
+  integration looks alive, while replay and surveys silently never load. Fix a
+  missing directive; flag anything structural in `conflict`.
 
 ## Flag out-of-scope conflicts and move on
 

--- a/context/skills/integration-v2/init/description.md
+++ b/context/skills/integration-v2/init/description.md
@@ -50,10 +50,22 @@ and the diff looks complete while zero events send. Either:
 - **Extend the policy.** Allow the PostHog hosts in `script-src` and
   `connect-src`, per the CSP reference below.
 - **Work within it.** Bundle the `posthog-js` dependency the manifest already
-  declares instead of loading it from the CDN, which satisfies `script-src`.
-  Events still have to send: allow the PostHog host in `connect-src`, or route
-  them through a same-origin proxy. `connect-src` falls back to `default-src`,
-  so a bare `default-src 'self'` blocks sending too.
+  declares instead of loading it from the CDN — but bundling only covers the
+  entry bundle. posthog-js lazy-loads the session-replay recorder, surveys, and
+  toolbar from the PostHog assets CDN at runtime, so `script-src` must allow
+  the PostHog hosts even when bundled. Events still have to send: allow the
+  PostHog host in `connect-src`, or route everything through a same-origin
+  proxy. `connect-src` falls back to `default-src`, so a bare
+  `default-src 'self'` blocks sending too.
+
+Whenever you extend a CSP, extend every directive the SDK needs in one pass —
+partial edits fail silently (events send but replay/surveys never load):
+
+```
+script-src:  https://*.posthog.com   (lazy-loaded bundles, even when self-hosting the entry)
+connect-src: <the api host>          (event ingestion + feature flags)
+worker-src:  blob:                   (session replay's worker)
+```
 
 Say in your handoff which you did — the review and the report need to know how
 events leave the page.


### PR DESCRIPTION
Root cause of the recurring "adds connect-src, misses script-src" review finding (e.g. wizard-workbench#3112 react-router/saas-template): init/description.md's "Work within it" bullet said bundling posthog-js satisfies script-src. It doesn't — replay recorder, surveys, and the toolbar lazy-load from the assets CDN as scripts regardless of how the entry bundle ships. Agents followed the skill faithfully and produced partial CSPs; the review dimension then deferred to the init handoff's "handled". Sol-effort reviews only caught it by over-reading into posthog-best-practices/references/session-replay.md, where the correct fact lives.

Three edits: init teaches the full directive set with a copy-paste block (script-src / connect-src / worker-src), the init handoff names exactly which directives were touched, and the build/review dimension verifies directive-by-directive rather than trusting the handoff — converting an accidental sol-only catch into a deterministic check both arms pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*