### PR TITLE
Add WordPress integration skill for self-hosted sites

### DIFF
--- a/context/commandments.yaml
+++ b/context/commandments.yaml
@@ -166,6 +166,7 @@ commandments:
     - Capture pageviews with the client SDK and reserve PostHog::capture for real server-side WordPress actions (comment_post, woocommerce_thankyou, user_register)
     - Call PostHog::flush() at the end of a capture - a web request has no single exit point like a CLI script does
     - Evaluate feature flags client-side on pages served by full-page caching (Varnish, batcache, WP Super Cache) - server-side flag checks are baked into the cached HTML for every visitor
+    - WordPress catches fatals with its own WP_Fatal_Error_Handler and renders the recovery-mode page, so a fatal can be swallowed before a PHP handler reports it - capture exceptions explicitly with PostHog::captureException in a try/catch, and do not rely on WP_DEBUG being on in production to surface them
 
   ruby:
     - "posthog-ruby is the Ruby SDK gem name (add `gem 'posthog-ruby'` to Gemfile) but require it with `require 'posthog'` (NOT `require 'posthog-ruby'`)"

--- a/context/commandments.yaml
+++ b/context/commandments.yaml
@@ -158,6 +158,15 @@ commandments:
     - Register PostHog configuration in config/posthog.php using env() for all settings (api_key, host, disabled)
     - Do NOT use Laravel's event system or observers for analytics - call capture explicitly where actions occur
 
+  wordpress:
+    - Ship the integration as a standalone plugin in wp-content/plugins - do NOT edit a theme's functions.php, which is lost on theme switch or theme update
+    - Guard every plugin entry file with `if (!defined('ABSPATH')) { exit; }` before any other code
+    - Print the client snippet from a wp_head hook and escape the interpolated token with esc_js() - never echo a raw token into markup
+    - Read the project token from a wp-config.php constant or a WordPress option - do NOT hardcode it in plugin source
+    - Capture pageviews with the client SDK and reserve PostHog::capture for real server-side WordPress actions (comment_post, woocommerce_thankyou, user_register)
+    - Call PostHog::flush() at the end of a capture - a web request has no single exit point like a CLI script does
+    - Evaluate feature flags client-side on pages served by full-page caching (Varnish, batcache, WP Super Cache) - server-side flag checks are baked into the cached HTML for every visitor
+
   ruby:
     - "posthog-ruby is the Ruby SDK gem name (add `gem 'posthog-ruby'` to Gemfile) but require it with `require 'posthog'` (NOT `require 'posthog-ruby'`)"
     - "Use PostHog::Client.new(api_key: key, host: host) for instance-based initialization in scripts and CLIs"

--- a/context/skills/error-tracking/config.yaml
+++ b/context/skills/error-tracking/config.yaml
@@ -67,6 +67,13 @@ variants:
       - https://posthog.com/docs/error-tracking/installation/php.md
       - https://posthog.com/docs/libraries/laravel.md
 
+  - id: wordpress
+    display_name: WordPress
+    tags: [wordpress, php, cms]
+    docs_urls:
+      - https://posthog.com/docs/error-tracking/installation/php.md
+      - https://posthog.com/docs/libraries/wordpress.md
+
   - id: ruby
     display_name: Ruby
     tags: [ruby]

--- a/context/skills/feature-flags/config.yaml
+++ b/context/skills/feature-flags/config.yaml
@@ -71,6 +71,13 @@ variants:
       - https://posthog.com/docs/feature-flags/installation/php.md
       - https://posthog.com/docs/libraries/laravel.md
 
+  - id: wordpress
+    display_name: WordPress
+    tags: [wordpress, php, cms]
+    docs_urls:
+      - https://posthog.com/docs/feature-flags/installation/php.md
+      - https://posthog.com/docs/libraries/wordpress.md
+
   - id: ruby
     display_name: Ruby
     tags: [ruby]

--- a/context/skills/integration/config.yaml
+++ b/context/skills/integration/config.yaml
@@ -161,6 +161,16 @@ variants:
     docs_urls:
       - https://posthog.com/docs/libraries/php.md
 
+  - id: wordpress
+    framework: wordpress
+    example_paths: example-apps/wordpress
+    display_name: WordPress
+    description: PostHog integration for self-hosted WordPress sites and plugins, combining client-side autocapture with server-side PHP SDK capture
+    tags: [wordpress, php, cms]
+    docs_urls:
+      - https://posthog.com/docs/libraries/wordpress.md
+      - https://posthog.com/docs/libraries/php.md
+
   - id: ruby-on-rails
     framework: rails
     example_paths: example-apps/ruby-on-rails

--- a/example-apps/wordpress/README.md
+++ b/example-apps/wordpress/README.md
@@ -15,7 +15,7 @@ The existing PostHog WordPress docs teach editing a theme's `functions.php` for 
 
 ## Features Demonstrated
 
-- **Client-side autocapture** — the same `wp_head` JS-snippet pattern as the PostHog WordPress docs, sourced from env instead of hardcoded
+- **Client-side autocapture** — the same `wp_head` JS-snippet pattern as the PostHog WordPress docs, sourced from a `wp-config.php` constant instead of hardcoded
 - **One server-side event** — captures a real WordPress action (`comment_post`) with `PostHog::capture(...)`, then flushes immediately since a PHP-FPM/mod_php request has no single explicit exit point
 - **Error tracking** — enabled in `PostHog::init(...)` so unhandled PHP errors reach PostHog
 
@@ -24,11 +24,16 @@ The existing PostHog WordPress docs teach editing a theme's `functions.php` for 
 ```bash
 cd posthog-example
 composer install
-cp .env.example .env
-# edit .env and add your PostHog project token
 ```
 
-Drop `posthog-example/` into any WordPress install's `wp-content/plugins/` directory and activate it.
+Add your PostHog project token to the site's `wp-config.php` — the same file that holds `DB_PASSWORD`:
+
+```php
+define('POSTHOG_PROJECT_TOKEN', 'phc_your_project_token_here');
+define('POSTHOG_HOST', 'https://us.i.posthog.com'); // optional, this is the default
+```
+
+Then drop `posthog-example/` into the install's `wp-content/plugins/` directory and activate it.
 
 ## What Gets Tracked
 
@@ -46,8 +51,7 @@ example-apps/wordpress/
 └── posthog-example/                # The plugin — copy this into wp-content/plugins/
     ├── posthog-example.php         # Plugin entry: init, client snippet, server capture
     ├── composer.json               # Pulls in posthog/posthog-php
-    ├── .env.example                # Environment variable template
-    └── .gitignore                  # Ignores vendor/, .env, composer.lock
+    └── .gitignore                  # Ignores vendor/, composer.lock
 ```
 
 ## Key Implementation Patterns
@@ -72,14 +76,14 @@ PostHog::init($token, [
 add_action('plugins_loaded', 'posthog_example_init');
 ```
 
-### 3. Client snippet on `wp_head`, token escaped
+### 3. Config from `wp-config.php`, snippet on `wp_head`, token escaped
 
 ```php
-$token = esc_js(getenv('POSTHOG_PROJECT_TOKEN'));
+$token = esc_js(posthog_example_token()); // reads the POSTHOG_PROJECT_TOKEN constant
 add_action('wp_head', 'posthog_example_client_snippet', 999);
 ```
 
-Never echo a raw token into markup. Priority 999 keeps the snippet late in `<head>`.
+The token lives in `wp-config.php`, never in plugin source. Never echo a raw token into markup. Priority 999 keeps the snippet late in `<head>`.
 
 ### 4. Server-side capture on a real WordPress action
 
@@ -103,13 +107,13 @@ A web request has no single exit point like a CLI script does, so flush where yo
 
 ## Running Without PostHog
 
-The plugin works fine without PostHog configured. If `POSTHOG_PROJECT_TOKEN` is missing — or still holds the `phc_your_...` placeholder — the plugin skips initialization, prints no snippet, and captures nothing. WordPress is unaffected.
+The plugin works fine without PostHog configured. If the `POSTHOG_PROJECT_TOKEN` constant is undefined — or still holds the `phc_your_...` placeholder — the plugin skips initialization, prints no snippet, and captures nothing. WordPress is unaffected.
 
 ## Next Steps
 
 - Track another WordPress action: `user_register`, `publish_post`, or `woocommerce_thankyou`
 - Identify logged-in users with `PostHog::identify(...)` instead of the hashed anonymous id
-- Read the token from a `wp-config.php` constant or a WordPress option instead of `.env`
+- Move the token to a WordPress option with a settings screen if the plugin should be configurable from wp-admin
 - Add feature flags — evaluate them client-side if the site sits behind full-page caching
 
 ## Learn More

--- a/example-apps/wordpress/README.md
+++ b/example-apps/wordpress/README.md
@@ -1,0 +1,35 @@
+# PostHog WordPress Example
+
+A minimal WordPress plugin demonstrating PostHog integration for self-hosted WordPress sites: client-side autocapture plus one server-side capture call via the PHP SDK.
+
+## Why a plugin, not `functions.php`
+
+The existing PostHog WordPress docs teach editing a theme's `functions.php` for the client snippet, which is theme-coupled and has no path to server-side capture. This example uses a small standalone plugin instead — the same approach a real integration on self-hosted WordPress (VIP, WP Engine, Pantheon, or any host with file access) would take.
+
+## Features Demonstrated
+
+- **Client-side autocapture** — the same `wp_head` JS-snippet pattern as the PostHog WordPress docs, sourced from env instead of hardcoded
+- **One server-side event** — captures a real WordPress action (`comment_post`) with `PostHog::capture(...)`, then flushes immediately since a PHP-FPM/mod_php request has no single explicit exit point
+
+## Quick Start
+
+```bash
+cd posthog-example
+composer install
+cp .env.example .env
+# edit .env and add your PostHog project token
+```
+
+Drop `posthog-example/` into any WordPress install's `wp-content/plugins/` directory and activate it.
+
+## What Gets Tracked
+
+| Event | Trigger | Properties |
+|-------|---------|------------|
+| `$pageview` (autocapture) | Any page load | Standard PostHog JS autocapture |
+| `comment_posted` | `comment_post` action | `comment_id`, `post_id`, `comment_approved` |
+
+## Learn More
+
+- [PostHog WordPress docs](https://posthog.com/docs/libraries/wordpress)
+- [PostHog PHP SDK docs](https://posthog.com/docs/libraries/php)

--- a/example-apps/wordpress/README.md
+++ b/example-apps/wordpress/README.md
@@ -2,6 +2,13 @@
 
 A minimal WordPress plugin demonstrating PostHog integration for self-hosted WordPress sites: client-side autocapture plus one server-side capture call via the PHP SDK.
 
+## Purpose
+
+This example serves as:
+- **Verification** that the context-mill wizard works for self-hosted WordPress projects
+- **Reference implementation** of PostHog best practices for WordPress plugin code
+- **Working example** you can drop into a real WordPress install and modify
+
 ## Why a plugin, not `functions.php`
 
 The existing PostHog WordPress docs teach editing a theme's `functions.php` for the client snippet, which is theme-coupled and has no path to server-side capture. This example uses a small standalone plugin instead — the same approach a real integration on self-hosted WordPress (VIP, WP Engine, Pantheon, or any host with file access) would take.
@@ -10,6 +17,7 @@ The existing PostHog WordPress docs teach editing a theme's `functions.php` for 
 
 - **Client-side autocapture** — the same `wp_head` JS-snippet pattern as the PostHog WordPress docs, sourced from env instead of hardcoded
 - **One server-side event** — captures a real WordPress action (`comment_post`) with `PostHog::capture(...)`, then flushes immediately since a PHP-FPM/mod_php request has no single explicit exit point
+- **Error tracking** — enabled in `PostHog::init(...)` so unhandled PHP errors reach PostHog
 
 ## Quick Start
 
@@ -28,8 +36,84 @@ Drop `posthog-example/` into any WordPress install's `wp-content/plugins/` direc
 |-------|---------|------------|
 | `$pageview` (autocapture) | Any page load | Standard PostHog JS autocapture |
 | `comment_posted` | `comment_post` action | `comment_id`, `post_id`, `comment_approved` |
+| `$exception` | Unhandled PHP errors | Exception details from the PHP SDK |
+
+## Code Structure
+
+```
+example-apps/wordpress/
+├── README.md                       # This file
+└── posthog-example/                # The plugin — copy this into wp-content/plugins/
+    ├── posthog-example.php         # Plugin entry: init, client snippet, server capture
+    ├── composer.json               # Pulls in posthog/posthog-php
+    ├── .env.example                # Environment variable template
+    └── .gitignore                  # Ignores vendor/, .env, composer.lock
+```
+
+## Key Implementation Patterns
+
+### 1. Guard the entry file
+
+```php
+if (!defined('ABSPATH')) {
+    exit;
+}
+```
+
+Every plugin file must refuse to run outside WordPress.
+
+### 2. Initialize once, on `plugins_loaded`
+
+```php
+PostHog::init($token, [
+    'host' => $host,
+    'error_tracking' => ['enabled' => true],
+]);
+add_action('plugins_loaded', 'posthog_example_init');
+```
+
+### 3. Client snippet on `wp_head`, token escaped
+
+```php
+$token = esc_js(getenv('POSTHOG_PROJECT_TOKEN'));
+add_action('wp_head', 'posthog_example_client_snippet', 999);
+```
+
+Never echo a raw token into markup. Priority 999 keeps the snippet late in `<head>`.
+
+### 4. Server-side capture on a real WordPress action
+
+```php
+PostHog::capture([
+    'distinctId' => (string) $distinct_id,
+    'event' => 'comment_posted',
+    'properties' => ['comment_id' => $comment_id],
+]);
+```
+
+Use the client SDK for pageviews. Reserve the PHP SDK for actions that only exist server-side (`comment_post`, `woocommerce_thankyou`, `user_register`).
+
+### 5. Flush after capture
+
+```php
+PostHog::flush();
+```
+
+A web request has no single exit point like a CLI script does, so flush where you capture.
+
+## Running Without PostHog
+
+The plugin works fine without PostHog configured. If `POSTHOG_PROJECT_TOKEN` is missing — or still holds the `phc_your_...` placeholder — the plugin skips initialization, prints no snippet, and captures nothing. WordPress is unaffected.
+
+## Next Steps
+
+- Track another WordPress action: `user_register`, `publish_post`, or `woocommerce_thankyou`
+- Identify logged-in users with `PostHog::identify(...)` instead of the hashed anonymous id
+- Read the token from a `wp-config.php` constant or a WordPress option instead of `.env`
+- Add feature flags — evaluate them client-side if the site sits behind full-page caching
 
 ## Learn More
 
 - [PostHog WordPress docs](https://posthog.com/docs/libraries/wordpress)
 - [PostHog PHP SDK docs](https://posthog.com/docs/libraries/php)
+- [PostHog PHP error tracking](https://posthog.com/docs/error-tracking/installation/php)

--- a/example-apps/wordpress/posthog-example/.env.example
+++ b/example-apps/wordpress/posthog-example/.env.example
@@ -1,0 +1,2 @@
+POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
+POSTHOG_HOST=https://us.i.posthog.com

--- a/example-apps/wordpress/posthog-example/.env.example
+++ b/example-apps/wordpress/posthog-example/.env.example
@@ -1,2 +1,0 @@
-POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
-POSTHOG_HOST=https://us.i.posthog.com

--- a/example-apps/wordpress/posthog-example/.gitignore
+++ b/example-apps/wordpress/posthog-example/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+.env
+composer.lock

--- a/example-apps/wordpress/posthog-example/.gitignore
+++ b/example-apps/wordpress/posthog-example/.gitignore
@@ -1,3 +1,2 @@
 vendor/
-.env
 composer.lock

--- a/example-apps/wordpress/posthog-example/composer.json
+++ b/example-apps/wordpress/posthog-example/composer.json
@@ -1,0 +1,10 @@
+{
+  "name": "posthog/context-mill-wordpress-example",
+  "description": "Minimal WordPress plugin demonstrating PostHog client + server integration",
+  "type": "wordpress-plugin",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.0",
+    "posthog/posthog-php": "^4.0"
+  }
+}

--- a/example-apps/wordpress/posthog-example/posthog-example.php
+++ b/example-apps/wordpress/posthog-example/posthog-example.php
@@ -59,6 +59,9 @@ function posthog_example_init(): void
 
     PostHog::init(getenv('POSTHOG_PROJECT_TOKEN'), [
         'host' => getenv('POSTHOG_HOST') ?: 'https://us.i.posthog.com',
+        'error_tracking' => [
+            'enabled' => true,
+        ],
     ]);
 }
 add_action('plugins_loaded', 'posthog_example_init');

--- a/example-apps/wordpress/posthog-example/posthog-example.php
+++ b/example-apps/wordpress/posthog-example/posthog-example.php
@@ -17,48 +17,39 @@ require __DIR__ . '/vendor/autoload.php';
 use PostHog\PostHog;
 
 /**
- * Load POSTHOG_* values from a .env file next to this plugin (dev/example
- * convenience only — a production plugin would read these from WP options
- * or wp-config.php constants instead).
+ * Configuration comes from wp-config.php constants — the same file that
+ * already holds DB_PASSWORD and the auth salts:
+ *
+ *     define('POSTHOG_PROJECT_TOKEN', 'phc_...');
+ *     define('POSTHOG_HOST', 'https://us.i.posthog.com'); // optional
+ *
+ * A distributable plugin would offer a settings screen backed by
+ * get_option() instead.
  */
-function posthog_example_load_env(string $path): void
+function posthog_example_token(): string
 {
-    if (!file_exists($path)) {
-        return;
-    }
+    return defined('POSTHOG_PROJECT_TOKEN') ? (string) POSTHOG_PROJECT_TOKEN : '';
+}
 
-    foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
-        $line = trim($line);
-        if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) {
-            continue;
-        }
-
-        [$key, $value] = explode('=', $line, 2);
-        $key = trim($key);
-        $value = trim($value, " \t\n\r\0\x0B\"'");
-
-        if ($key !== '' && getenv($key) === false) {
-            putenv($key . '=' . $value);
-        }
-    }
+function posthog_example_host(): string
+{
+    return defined('POSTHOG_HOST') ? (string) POSTHOG_HOST : 'https://us.i.posthog.com';
 }
 
 function posthog_example_configured(): bool
 {
-    $token = getenv('POSTHOG_PROJECT_TOKEN');
-    return $token && !str_starts_with($token, 'phc_your_');
+    $token = posthog_example_token();
+    return $token !== '' && !str_starts_with($token, 'phc_your_');
 }
 
 function posthog_example_init(): void
 {
-    posthog_example_load_env(__DIR__ . '/.env');
-
     if (!posthog_example_configured()) {
         return;
     }
 
-    PostHog::init(getenv('POSTHOG_PROJECT_TOKEN'), [
-        'host' => getenv('POSTHOG_HOST') ?: 'https://us.i.posthog.com',
+    PostHog::init(posthog_example_token(), [
+        'host' => posthog_example_host(),
         'error_tracking' => [
             'enabled' => true,
         ],
@@ -69,8 +60,8 @@ add_action('plugins_loaded', 'posthog_example_init');
 /**
  * Client-side autocapture. Same pattern as the PostHog WordPress docs
  * (https://posthog.com/docs/libraries/wordpress) — inject the JS snippet
- * on wp_head at priority 999, but sourced from env instead of hardcoded so
- * this examples repo's build/CI can inject a real project token.
+ * on wp_head at priority 999, but sourced from the wp-config.php constants
+ * above instead of hardcoded in plugin source.
  */
 function posthog_example_client_snippet(): void
 {
@@ -78,8 +69,8 @@ function posthog_example_client_snippet(): void
         return;
     }
 
-    $token = esc_js(getenv('POSTHOG_PROJECT_TOKEN'));
-    $host = esc_js(getenv('POSTHOG_HOST') ?: 'https://us.i.posthog.com');
+    $token = esc_js(posthog_example_token());
+    $host = esc_js(posthog_example_host());
     ?>
     <script>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);

--- a/example-apps/wordpress/posthog-example/posthog-example.php
+++ b/example-apps/wordpress/posthog-example/posthog-example.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Plugin Name: PostHog Example
+ * Description: Minimal WordPress plugin demonstrating client-side autocapture plus one server-side PostHog PHP SDK capture.
+ * Version: 0.1.0
+ * License: MIT
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require __DIR__ . '/vendor/autoload.php';
+
+use PostHog\PostHog;
+
+/**
+ * Load POSTHOG_* values from a .env file next to this plugin (dev/example
+ * convenience only — a production plugin would read these from WP options
+ * or wp-config.php constants instead).
+ */
+function posthog_example_load_env(string $path): void
+{
+    if (!file_exists($path)) {
+        return;
+    }
+
+    foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        $line = trim($line);
+        if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) {
+            continue;
+        }
+
+        [$key, $value] = explode('=', $line, 2);
+        $key = trim($key);
+        $value = trim($value, " \t\n\r\0\x0B\"'");
+
+        if ($key !== '' && getenv($key) === false) {
+            putenv($key . '=' . $value);
+        }
+    }
+}
+
+function posthog_example_configured(): bool
+{
+    $token = getenv('POSTHOG_PROJECT_TOKEN');
+    return $token && !str_starts_with($token, 'phc_your_');
+}
+
+function posthog_example_init(): void
+{
+    posthog_example_load_env(__DIR__ . '/.env');
+
+    if (!posthog_example_configured()) {
+        return;
+    }
+
+    PostHog::init(getenv('POSTHOG_PROJECT_TOKEN'), [
+        'host' => getenv('POSTHOG_HOST') ?: 'https://us.i.posthog.com',
+    ]);
+}
+add_action('plugins_loaded', 'posthog_example_init');
+
+/**
+ * Client-side autocapture. Same pattern as the PostHog WordPress docs
+ * (https://posthog.com/docs/libraries/wordpress) — inject the JS snippet
+ * on wp_head at priority 999, but sourced from env instead of hardcoded so
+ * this examples repo's build/CI can inject a real project token.
+ */
+function posthog_example_client_snippet(): void
+{
+    if (!posthog_example_configured()) {
+        return;
+    }
+
+    $token = esc_js(getenv('POSTHOG_PROJECT_TOKEN'));
+    $host = esc_js(getenv('POSTHOG_HOST') ?: 'https://us.i.posthog.com');
+    ?>
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('<?php echo $token; ?>',{api_host:'<?php echo $host; ?>'})
+    </script>
+    <?php
+}
+add_action('wp_head', 'posthog_example_client_snippet', 999);
+
+/**
+ * One server-side event: capture a real WordPress action (a new comment)
+ * with PostHog::capture(...), then flush immediately since a PHP-FPM /
+ * mod_php request has no single explicit exit point to hook otherwise.
+ */
+function posthog_example_track_comment(int $comment_id, $comment_approved, array $comment_data): void
+{
+    if (!posthog_example_configured()) {
+        return;
+    }
+
+    $distinct_id = $comment_data['user_id'] ?? 'anon_' . md5($comment_data['comment_author_email'] ?? (string) $comment_id);
+
+    PostHog::capture([
+        'distinctId' => (string) $distinct_id,
+        'event' => 'comment_posted',
+        'properties' => [
+            'comment_id' => $comment_id,
+            'post_id' => $comment_data['comment_post_ID'] ?? null,
+            'comment_approved' => $comment_approved,
+        ],
+    ]);
+
+    PostHog::flush();
+}
+add_action('comment_post', 'posthog_example_track_comment', 10, 3);


### PR DESCRIPTION
Adds a `wordpress` variant to the integration skill group, plus a minimal example plugin demonstrating client-side autocapture (matching the existing WordPress docs snippet pattern) combined with one server-side PHP SDK capture on the `comment_post` action.

Scoped to self-hosted WordPress (VIP, WP Engine, Pantheon, or any host with file access) rather than WordPress.com, since the coding agent needs filesystem access the way it already does for the Laravel and PHP skills.

### Registered everywhere `laravel` and `php` are

`laravel` and `php` each appear in four places; WordPress initially appeared in one. The second commit closes that, so the wizard has something to say about WordPress beyond installation:

| | `integration` | `error-tracking` | `feature-flags` | `commandments.yaml` |
|---|---|---|---|---|
| laravel | ✅ | ✅ | ✅ | ✅ |
| php | ✅ | ✅ | ✅ | ✅ |
| wordpress | ✅ | ✅ | ✅ | ✅ |

The `error-tracking` and `feature-flags` entries follow the docs-only shape every existing variant in those two files uses — `id`, `display_name`, `tags`, `docs_urls`, no example app. Each is backed by a WordPress-specific rule in `commandments.yaml` rather than only re-pointing at the PHP docs:

- **feature flags** — evaluate client-side on pages served by full-page caching (Varnish, batcache, WP Super Cache); a server-side check is baked into the cached HTML every visitor then receives
- **error tracking** — WordPress catches fatals with its own `WP_Fatal_Error_Handler` and renders the recovery-mode page, so a fatal can be swallowed before a PHP handler reports it

The other commandments cover the rules that decide whether a WordPress integration survives: a plugin rather than the active theme's `functions.php` (a theme update silently removes it), the `ABSPATH` guard, `esc_js()` on the interpolated token, the token in a `wp-config.php` constant, client SDK for pageviews with the PHP SDK reserved for server-side actions, and a flush after each capture.

### On example-app scope

The example plugin is deliberately minimal — autocapture, one server-side event, error tracking enabled in `init` — matching this repo's own "model airplane" philosophy and the shape of `example-apps/php`. An earlier draft of the *plugin* also demonstrated identify and feature flags; those came out. That trim is about the example app only. It is unrelated to the skill variants above, which are docs-only entries by the convention of the files they live in.

### Verified

- `npm test` — 137/137 passing
- `npm run build` — emits `integration-wordpress.zip`, `error-tracking-wordpress.zip`, and `feature-flags-wordpress.zip`, with correct manifest entries
- `composer install` in the example plugin resolves `posthog/posthog-php` cleanly

### Related

PostHog/wizard#983 (draft) adds the other half — `Integration.wordpress` and the detector. The wizard's `variant-resolution.test.ts` asserts every framework in its enum resolves to a context-mill variant, so that PR depends on the `framework: wordpress` variant here. **Merge order: this PR first, then the wizard one.**
