### PR TITLE
Add WooCommerce, Shopify, and WordPress to data-warehouse-source skill

### DIFF
--- a/context/skills/data-warehouse-source/config.yaml
+++ b/context/skills/data-warehouse-source/config.yaml
@@ -15,3 +15,5 @@ variants:
       - https://posthog.com/docs/cdp/sources/snowflake.md
       - https://posthog.com/docs/cdp/sources/bigquery.md
       - https://posthog.com/docs/cdp/sources/stripe.md
+      - https://posthog.com/docs/cdp/sources/woocommerce.md
+      - https://posthog.com/docs/cdp/sources/shopify.md

--- a/context/skills/data-warehouse-source/config.yaml
+++ b/context/skills/data-warehouse-source/config.yaml
@@ -17,3 +17,4 @@ variants:
       - https://posthog.com/docs/cdp/sources/stripe.md
       - https://posthog.com/docs/cdp/sources/woocommerce.md
       - https://posthog.com/docs/cdp/sources/shopify.md
+      - https://posthog.com/docs/cdp/sources/wordpress.md


### PR DESCRIPTION
Both are live, full-availability PostHog data warehouse sources already (confirmed against posthog.com/docs/cdp/sources/), just not referenced from this skill's docs_urls — the skill only knew about Postgres, MySQL, Snowflake, BigQuery, and Stripe.

Verified: npm test (137/137), npm run build (manifest still emits cleanly).