### PR TITLE
feat(laravel): require PostHog::flush() in long-running processes

### DIFF
--- a/context/commandments.yaml
+++ b/context/commandments.yaml
@@ -157,6 +157,7 @@ commandments:
     - Create a dedicated PostHogService class in app/Services/ - do NOT scatter PostHog::capture calls throughout controllers
     - Register PostHog configuration in config/posthog.php using env() for all settings (api_key, host, disabled)
     - Do NOT use Laravel's event system or observers for analytics - call capture explicitly where actions occur
+    - Call PostHog::flush() after capture in queue jobs, Horizon, and Octane - a long-running worker never destructs, so its events sit in the SDK buffer until batch_size (default 100) is reached and are silently lost on restart
 
   ruby:
     - "posthog-ruby is the Ruby SDK gem name (add `gem 'posthog-ruby'` to Gemfile) but require it with `require 'posthog'` (NOT `require 'posthog-ruby'`)"


### PR DESCRIPTION
An agent following this skill wrote `PostHog::capture()` inside a Laravel queue job with no flush. In production, `feedback_received` (fired from a web request) reached PostHog. `feedback_triage_completed`, fired from the same integration inside `queue:work`, never did – the worker had been alive two hours.

`posthog-php` only sends when `batch_size` (default 100) is reached or the client destructs. A `queue:work` process never destructs, so job events sit in memory until 99 more accumulate, and go on restart.

Isolated check, same SDK and token:

| | result |
|---|---|
| capture + `PostHog::flush()` | arrives |
| capture, `SIGKILL` before destructor | never arrives |

The guidance already exists – `contents/docs/libraries/laravel.md` has a "Long-running processes" section – and this skill bundles that page, so it was in the agent's context at `references/laravel.md:140`. The agent skipped it while following every commandment exactly, including reproducing the mandated missing-config error string word for word.

That is the pattern worth acting on: rules in `COMMANDMENTS.md` get followed, reference prose does not. The `wordpress` block already carries a flush rule for the same underlying reason; `laravel`, where queue workers are idiomatic, had none.

One line. `dist/` is gitignored; on build it propagates to the five Laravel skills. `npm test` (137 passing) and `npm run build` both clean.