### PR TITLE
fix(build): look up example skip patterns by directory name

### DIFF
--- a/scripts/lib/example-processor.js
+++ b/scripts/lib/example-processor.js
@@ -75,6 +75,14 @@ function mergeSkipPatterns(globalPatterns, examplePatterns = {}) {
 }
 
 /**
+ * Global patterns plus any override for this example. The `examples:` block in
+ * skip-patterns.yaml is keyed by directory name, not skill id.
+ */
+function skipPatternsForExample(skipPatterns, dirName) {
+    return mergeSkipPatterns(skipPatterns.global, skipPatterns.examples?.[dirName]);
+}
+
+/**
  * Recursively collect all files in a directory
  */
 function collectFiles(dirPath, baseDir, skipPatterns) {
@@ -199,6 +207,7 @@ const defaultPlugins = [ignoreFilePlugin, ignoreBlockPlugin, ignoreLinePlugin];
 export {
     loadSkipPatterns,
     mergeSkipPatterns,
+    skipPatternsForExample,
     shouldSkip,
     processExample,
     defaultPlugins,

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -41,7 +41,7 @@ import path from 'path';
 import crypto from 'crypto';
 import yaml from 'js-yaml';
 import matter from 'gray-matter';
-import { processExample, loadSkipPatterns, mergeSkipPatterns, defaultPlugins } from './example-processor.js';
+import { processExample, loadSkipPatterns, skipPatternsForExample, defaultPlugins } from './example-processor.js';
 import { CLI_ROLES, validateCommandName } from './cli-block-validation.js';
 
 /**
@@ -641,7 +641,7 @@ async function generateSkill({
                 displayName: isSingle ? skill.display_name : dirName,
                 id: skill.id,
                 repoRoot,
-                skipPatterns: mergeSkipPatterns(skipPatterns.global, skipPatterns.examples[isSingle ? skill.id : dirName]),
+                skipPatterns: skipPatternsForExample(skipPatterns, dirName),
                 plugins: defaultPlugins,
             });
 

--- a/scripts/lib/tests/skip-patterns.test.js
+++ b/scripts/lib/tests/skip-patterns.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeSkipPatterns, shouldSkip } from '../example-processor.js';
+import { mergeSkipPatterns, shouldSkip, skipPatternsForExample } from '../example-processor.js';
 
 const globalPatterns = {
     includes: ['.yml', '.gitignore', 'node_modules'],
@@ -39,6 +39,45 @@ describe('shouldSkip', () => {
 
     it('tolerates merged patterns with no allow key', () => {
         expect(shouldSkip('project.yml', { includes: ['.yml'], regex: [] })).toBe(true);
+    });
+});
+
+describe('skipPatternsForExample', () => {
+    const config = {
+        global: globalPatterns,
+        examples: {
+            laravel: { includes: ['bootstrap/cache'] },
+            'swift-xcodegen': { allow: ['project.yml'] },
+        },
+    };
+
+    it('finds an example override by directory name', () => {
+        const patterns = skipPatternsForExample(config, 'laravel');
+        expect(shouldSkip('bootstrap/cache/services.php', patterns)).toBe(true);
+    });
+
+    // The lookup key is the example directory, never the skill id — a skill
+    // with a single example used to be looked up as `integration-laravel`,
+    // silently missing every override written for `laravel`.
+    it('does not look overrides up by skill id', () => {
+        const patterns = skipPatternsForExample(config, 'integration-laravel');
+        expect(shouldSkip('bootstrap/cache/services.php', patterns)).toBe(false);
+    });
+
+    it('applies allow overrides by directory name', () => {
+        const patterns = skipPatternsForExample(config, 'swift-xcodegen');
+        expect(shouldSkip('project.yml', patterns)).toBe(false);
+    });
+
+    it('falls back to global patterns for an example with no overrides', () => {
+        const patterns = skipPatternsForExample(config, 'php');
+        expect(shouldSkip('node_modules/foo.js', patterns)).toBe(true);
+        expect(shouldSkip('bootstrap/cache/services.php', patterns)).toBe(false);
+    });
+
+    it('tolerates a config with no examples block', () => {
+        const patterns = skipPatternsForExample({ global: globalPatterns }, 'laravel');
+        expect(shouldSkip('node_modules/foo.js', patterns)).toBe(true);
     });
 });
 


### PR DESCRIPTION
Fixes #284.

## Problem

Per-example overrides in `context/skip-patterns.yaml` were looked up by the wrong key for any skill with a single example, so they never applied.

`scripts/lib/skill-generator.js:644`

```js
skipPatterns.examples[isSingle ? skill.id : dirName]
```

Keys in the `examples:` block are example directory names — `laravel`, `android`, `swift-xcodegen`. With one example path the lookup used `skill.id` (`integration-laravel`) instead, missed, and returned `undefined`. `mergeSkipPatterns` treats that as "no overrides" and the build carried on with no error.

`isSingle` is the right switch for the other two things it controls — the output filename and the display title, both generated by the build. Config keys are typed by hand, and they are always directory names, so the same branch shouldn't apply here.

## Fix

One lookup, always by directory name, extracted so it can be tested:

```js
function skipPatternsForExample(skipPatterns, dirName) {
    return mergeSkipPatterns(skipPatterns.global, skipPatterns.examples?.[dirName]);
}
```

No key in `skip-patterns.yaml` is a skill id today, so nothing that currently resolves stops resolving.

## Effect on shipped skills

Two skills had overrides that were being dropped. Rebuilt and compared `references/EXAMPLE.md`:

| Skill | Before | After | Removed |
|---|---|---|---|
| `integration-laravel` | 81,558 | 60,662 | 20,896 (26%) |
| `integration-android` | 67,047 | 50,906 | 16,141 (24%) |

The Laravel case is almost entirely `bootstrap/cache/services.php`, Laravel's generated package-discovery cache — a machine-written list of class names that Laravel's own `.gitignore` excludes. It was 17% of that skill. For scale, `references/COMMANDMENTS.md` in the same bundle is 1,618 bytes.

`integration-swift` has two example paths, so it was already taking the `dirName` branch. Its `allow` rescue for `project.yml` still works after the change — verified, still 8 occurrences in `EXAMPLE-swift-xcodegen.md`.

## Tests

Five added to `scripts/lib/tests/skip-patterns.test.js`, including the one that pins the bug:

```js
it('does not look overrides up by skill id', () => {
    const patterns = skipPatternsForExample(config, 'integration-laravel');
    expect(shouldSkip('bootstrap/cache/services.php', patterns)).toBe(false);
});
```

The existing suite covered `mergeSkipPatterns` and `shouldSkip`, which were both correct — the bug was in the key handed to them, which nothing exercised.

```
npm test       ✅ 142 passing
npm run build  ✅ 118 skills
```

## Worth a follow-up

The lookup failed silently. A key in `examples:` that matches no example directory produces no warning, so a rule can look right in the file and do nothing. A build-time check that every `examples:` key resolves would turn this class of bug into an error. Left out here to keep the change to one thing — happy to add it if you want it.

Separately, `bootstrap/cache/*.php` is generated output committed to `example-apps/laravel`. This PR stops it reaching the bundle, but removing it from the repo would be worth doing on its own.
