### PR TITLE
fix(wizard): Whack a mole part 3: editing tasks defer verification to the review task

### DIFF
--- a/context/agents/integration-v2/capture.md
+++ b/context/agents/integration-v2/capture.md
@@ -7,7 +7,7 @@ effort_pi: medium
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-capture, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
+allowedTools: [Read, Write, Edit, Glob, Grep]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init, identify]
 ---

--- a/context/agents/integration-v2/capture.md
+++ b/context/agents/integration-v2/capture.md
@@ -7,7 +7,7 @@ effort_pi: medium
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-capture, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep]
+allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init, identify]
 ---

--- a/context/agents/integration-v2/capture.md
+++ b/context/agents/integration-v2/capture.md
@@ -47,3 +47,5 @@ user the way the identify docs describe, not the event.
 The meaningful user actions across the app have capture calls that fire on the
 real action, not on page load, each one attributable to the user who took it, and
 `.posthog-wizard-cache/.posthog-events.json` lists the events you instrumented.
+
+You do not run builds, linters, or tests — the review task verifies the whole integration after you; your edits just need to be right by reading.

--- a/context/agents/integration-v2/error-tracking.md
+++ b/context/agents/integration-v2/error-tracking.md
@@ -31,6 +31,6 @@ this project's directory and set up that one place; that is the whole job.
 ## How you know you succeeded
 
 An error the app does not catch reaches PostHog, through the mechanism this SDK
-gives you rather than one you invented. You did not install anything, run a build
-or tests, search outside the project, or read through the whole app or hand-wrap
+gives you rather than one you invented. You did not install anything, run a build,
+lint, or tests (the review task verifies after you), search outside the project, or read through the whole app or hand-wrap
 individual components or routes.

--- a/context/agents/integration-v2/error-tracking.md
+++ b/context/agents/integration-v2/error-tracking.md
@@ -7,7 +7,7 @@ effort_pi: low
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-error-tracking-step, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep]
+allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init]
 ---

--- a/context/agents/integration-v2/error-tracking.md
+++ b/context/agents/integration-v2/error-tracking.md
@@ -7,7 +7,7 @@ effort_pi: low
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-error-tracking-step, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
+allowedTools: [Read, Write, Edit, Glob, Grep]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init]
 ---

--- a/context/agents/integration-v2/identify.md
+++ b/context/agents/integration-v2/identify.md
@@ -7,7 +7,7 @@ effort_pi: medium
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-identify, posthog-best-practices]
-allowedTools: [Read, Edit, Glob, Grep, Bash]
+allowedTools: [Read, Edit, Glob, Grep]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init]
 ---

--- a/context/agents/integration-v2/identify.md
+++ b/context/agents/integration-v2/identify.md
@@ -7,7 +7,7 @@ effort_pi: medium
 model_sdk: claude-sonnet-4-6
 effort_sdk: high
 skills: [integration-v2-identify, posthog-best-practices]
-allowedTools: [Read, Edit, Glob, Grep]
+allowedTools: [Read, Edit, Glob, Grep, Bash]
 disallowedTools: [enqueue_task]
 dependsOn: [install, init]
 ---

--- a/context/agents/integration-v2/identify.md
+++ b/context/agents/integration-v2/identify.md
@@ -58,3 +58,5 @@ again there is the point, not a duplicate. Your handoff names the files you
 changed, how identity is established in them, and what a later step must do for its
 own calls to inherit it — whether that is nothing at all, or tagging each call
 itself. If the app has no auth or user concept, say so and stop.
+
+You do not run builds, linters, or tests — the review task verifies the whole integration after you; your edits just need to be right by reading.

--- a/context/agents/integration-v2/init.md
+++ b/context/agents/integration-v2/init.md
@@ -7,7 +7,7 @@ effort_pi: low
 model_sdk: claude-sonnet-4-6
 effort_sdk: medium
 skills: [integration-v2-init, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep]
+allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
 disallowedTools: [enqueue_task]
 dependsOn: []
 ---

--- a/context/agents/integration-v2/init.md
+++ b/context/agents/integration-v2/init.md
@@ -34,3 +34,5 @@ If the app ships a Content-Security-Policy, the handoff also names exactly
 which directives you touched (`script-src`, `connect-src`, `worker-src`) and
 which you left alone — the review verifies directive-by-directive, and an
 unnamed directive reads as unhandled, not as fine.
+
+You do not run builds, linters, or tests — the review task verifies the whole integration after you; your edits just need to be right by reading.

--- a/context/agents/integration-v2/init.md
+++ b/context/agents/integration-v2/init.md
@@ -7,7 +7,7 @@ effort_pi: low
 model_sdk: claude-sonnet-4-6
 effort_sdk: medium
 skills: [integration-v2-init, posthog-best-practices]
-allowedTools: [Read, Write, Edit, Glob, Grep, Bash]
+allowedTools: [Read, Write, Edit, Glob, Grep]
 disallowedTools: [enqueue_task]
 dependsOn: []
 ---


### PR DESCRIPTION
Stop the editing tasks (identify, capture, init, error-tracking) hunting for a command tool — verification is the review task's job, stated in each prompt.

```
Before: capture agent: "A command-execution tool would allow running the existing npm run lint validation script after TypeScript edits."
        → burns turns searching for bash, remarks the gap every run (6+ runs)
After:  prompt states: "You do not run builds, linters, or tests — the review task verifies the whole integration after you; your edits just need to be right by reading."
```

The earlier Bash-grant approach is reverted in this same branch — capture should not be running lint; review (which already has Bash) owns verification for the whole integration.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*