### PR TITLE
fix(wizard): Whack a mole part 4: align init token rule with the commandments' no-env exception

### DIFF
--- a/context/skills/integration-v2/init/description.md
+++ b/context/skills/integration-v2/init/description.md
@@ -10,8 +10,8 @@ Use the framework's public env-var convention so the client can read them.
 - the public project token
 - the PostHog host
 
-One exception, matching the commandments: where a build genuinely has no
-environment to read from (iOS/Android release and archive builds), embed the
+Where a build genuinely has no valid environment to read from, often
+mobile projects, (iOS/Android release and archive builds), embed the
 real public token in the config the build ships — never an empty string or
 placeholder. Env-based configuration still covers development and any build
 that can read the environment.

--- a/context/skills/integration-v2/init/description.md
+++ b/context/skills/integration-v2/init/description.md
@@ -10,6 +10,12 @@ Use the framework's public env-var convention so the client can read them.
 - the public project token
 - the PostHog host
 
+One exception, matching the commandments: where a build genuinely has no
+environment to read from (iOS/Android release and archive builds), embed the
+real public token in the config the build ships — never an empty string or
+placeholder. Env-based configuration still covers development and any build
+that can read the environment.
+
 Then document these keys for other developers: add them to `.env.example` (create
 it if the project has none), with the real names and empty or placeholder values —
 never the real secret. This file is committed, so the next developer knows which


### PR DESCRIPTION
State the commandments' no-environment token carve-out in the integration-v2 init skill — both Swift runs independently hit the contradiction.

```
Before: skill: "Set the PostHog keys through the wizard tools (set_env_values), never hardcoded."
        commandment: "…where a build genuinely has no environment to read from (e.g. iOS/Android release and archive builds), embed the real token…"
        → agent remark: "the supplied Swift commandments recommend embedding a real public token for archive builds, but this task explicitly requires env-based configuration and prohibits hardcoding"
After:  skill adds: "One exception, matching the commandments: where a build genuinely has no environment to read from (iOS/Android release and archive builds), embed the real public token in the config the build ships — never an empty string or placeholder."
```

Generally mobile apps will just have these in a giant config file. Because environment variables are so strangely handled and Swift doesn't allow possibly undefined strings, we can either:
Just stick it in as a constant
default to '' and fail silently

It seems better to just stick it in as a constant

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*