### PR TITLE
fix: Say that Self-driving opens a PR per issue

### DIFF
--- a/context/skills/self-driving/references/5-connected-tools.md
+++ b/context/skills/self-driving/references/5-connected-tools.md
@@ -6,6 +6,14 @@ next_step: 6-scouts.md
 
 External tools can feed the inbox too: issue trackers (GitHub Issues, Linear, Jira, GitLab, Gitea, Shortcut), error tracking (Sentry, Rollbar, Bugsnag, Honeybadger, Raygun), support desks (Zendesk, Freshdesk, Freshservice, Front, Gorgias, Kustomer, Dixa, Plain), database performance (pganalyze), security scanners (Snyk, SonarQube, Semgrep, Rapid7 InsightVM), product feedback / reviews (Featurebase, Frill, Aha, UserVoice, Productboard, Canny, AskNicely, Retently, Appfigures, AppFollow, Judge.me), and search analytics (Google Search Console — surfaces pages that rank in Google but lose clicks to a weak title or description). Each needs a **data warehouse source** before its signal source produces anything — a source row without the warehouse connection is dormant: harmless, but silent until the source syncs. Never enable one the user hasn't confirmed.
 
+**Say what picking a tool actually does, per tool.** This is the most consequential ask in the run. Connecting a tool means Self-driving reads **everything open in it** — including issues the user filed as future work for themselves — and **each record it judges fixable automatically gets its own draft PR, at $15 per PR**, with nobody asked first. Users have picked a tracker here reading the question as "which tools do you use?" and woken up to a stack of unrequested PRs and a bill.
+
+Phrase that as **"automatically opens a draft PR"** — never "no approval step" or "without approval". Same behaviour, but the negative framing reads to anyone at a larger org as *this bypasses our review process*, when the opposite is true: it opens a **draft**, which still goes through their normal review and CI before anything merges. Lead with the automatic part and keep the word *draft*. What you must never do is soften it into something the user triggers themselves — the surprise being fixed here is exactly that they don't.
+
+So each option names **the record that bills**, in brackets after the tool name. The unit is not a category guess — it is the table that tool's emitter actually reads in posthog (`products/signals/backend/emission/registry.py`, one `register_signal_source(<source>, "<table>", …)` line per tool), which is why Shortcut bills per *story*, Plain per *thread*, and Raygun per *error group* rather than all of them saying "per issue". Adding a source here means reading its unit off that registry line.
+
+The brackets carry the per-tool detail, which is what keeps the **prompt one line**. Don't restate the units in the prompt, don't explain what the brackets mean, and don't move them into a `description` — a dimmed sub-line per row would double the list height, and a prompt that spells all this out is a wall of text above a 36-row picker. Short prompt, unit in the label.
+
 The run can connect **every** one of them, each with at most one click from the user, and it never asks anyone to paste a credential into this chat:
 
 - **GitHub Issues** — reuses the GitHub App connected in step 3 (connector: `5a-github.md`).
@@ -37,18 +45,20 @@ Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `
 
    If the detected block found nothing, the list is just the SaaS basics + "Show more (31 more hidden)" — 36 catalog tools minus the 5 basics. **"None of these" stays the first option** (an accidental `enter` declines). Example shape (detected tools spliced in between "None of these" and the basics):
 
+   Send the prompt and the per-tool unit brackets **exactly** as written — neither is yours to trim or soften, and a tool you splice in from the detected block carries the same bracket the catalog gives it. The `value`s are unchanged, so step 4's enable map still keys off them.
+
 ```
 {
   id: "connected-tools",
-  prompt: "Self-driving can also watch your other tools and investigate and fix the problems they surface. Which of these do you use?",
+  prompt: "Self-driving reads everything open in these and automatically opens a draft PR for what it can fix — $15 each. Which do you use?",
   kind: "multi",
   options: [
     { label: "None of these", value: "none" },
-    { label: "GitHub Issues", value: "github-issues" },
-    { label: "Linear", value: "linear" },
-    { label: "Jira", value: "jira" },
-    { label: "Sentry", value: "sentry" },
-    { label: "Zendesk", value: "zendesk" },
+    { label: "GitHub Issues (per issue)", value: "github-issues" },
+    { label: "Linear (per issue)", value: "linear" },
+    { label: "Jira (per issue)", value: "jira" },
+    { label: "Sentry (per issue)", value: "sentry" },
+    { label: "Zendesk (per ticket)", value: "zendesk" },
     { label: "Show more (31 more hidden)", value: "show-more" }
   ]
 }
@@ -56,54 +66,58 @@ Load `wizard_ask` via `ToolSearch select:mcp__wizard-tools__wizard_ask`. Reach `
 
 1b. **Only if the user picked the "Show more" option**, ask a second multi-select with the full catalog below, minus the tools already shown in the first ask. Merge both answers into one picked set and drop the `show-more` sentinel — it is not a tool. If "Show more" was not picked, skip this step entirely and never render the full catalog.
 
-   Full catalog (for the "Show more" expansion only):
+   Full catalog (for the "Show more" expansion only). Same rule: every row carries its billing unit.
 
 ```
 {
   id: "connected-tools-all",
-  prompt: "Pick any others Self-driving should watch:",
+  prompt: "Pick any others — same deal, $15 per PR:",
   kind: "multi",
   options: [
     { label: "None of these", value: "none" },
-    { label: "GitHub Issues", value: "github-issues" },
-    { label: "Linear", value: "linear" },
-    { label: "Jira", value: "jira" },
-    { label: "GitLab", value: "gitlab" },
-    { label: "Gitea", value: "gitea" },
-    { label: "Shortcut", value: "shortcut" },
-    { label: "Sentry", value: "sentry" },
-    { label: "Rollbar", value: "rollbar" },
-    { label: "Bugsnag", value: "bugsnag" },
-    { label: "Honeybadger", value: "honeybadger" },
-    { label: "Raygun", value: "raygun" },
-    { label: "Zendesk", value: "zendesk" },
-    { label: "Freshdesk", value: "freshdesk" },
-    { label: "Freshservice", value: "freshservice" },
-    { label: "Front", value: "front" },
-    { label: "Gorgias", value: "gorgias" },
-    { label: "Kustomer", value: "kustomer" },
-    { label: "Dixa", value: "dixa" },
-    { label: "Plain", value: "plain" },
-    { label: "pganalyze", value: "pganalyze" },
-    { label: "Snyk", value: "snyk" },
-    { label: "SonarQube", value: "sonarqube" },
-    { label: "Semgrep", value: "semgrep" },
-    { label: "Rapid7 InsightVM", value: "rapid7_insightvm" },
-    { label: "Featurebase", value: "featurebase" },
-    { label: "Frill", value: "frill" },
-    { label: "Aha", value: "aha" },
-    { label: "UserVoice", value: "uservoice" },
-    { label: "Productboard", value: "productboard" },
-    { label: "Canny", value: "canny" },
-    { label: "AskNicely", value: "asknicely" },
-    { label: "Retently", value: "retently" },
-    { label: "Appfigures", value: "appfigures" },
-    { label: "AppFollow", value: "appfollow" },
-    { label: "Judge.me", value: "judgeme_reviews" },
+    { label: "GitHub Issues (per issue)", value: "github-issues" },
+    { label: "Linear (per issue)", value: "linear" },
+    { label: "Jira (per issue)", value: "jira" },
+    { label: "GitLab (per issue)", value: "gitlab" },
+    { label: "Gitea (per issue)", value: "gitea" },
+    { label: "Shortcut (per story)", value: "shortcut" },
+    { label: "Sentry (per issue)", value: "sentry" },
+    { label: "Rollbar (per item)", value: "rollbar" },
+    { label: "Bugsnag (per error)", value: "bugsnag" },
+    { label: "Honeybadger (per fault)", value: "honeybadger" },
+    { label: "Raygun (per error group)", value: "raygun" },
+    { label: "Zendesk (per ticket)", value: "zendesk" },
+    { label: "Freshdesk (per ticket)", value: "freshdesk" },
+    { label: "Freshservice (per ticket)", value: "freshservice" },
+    { label: "Front (per conversation)", value: "front" },
+    { label: "Gorgias (per ticket)", value: "gorgias" },
+    { label: "Kustomer (per conversation)", value: "kustomer" },
+    { label: "Dixa (per conversation)", value: "dixa" },
+    { label: "Plain (per thread)", value: "plain" },
+    { label: "pganalyze (per issue)", value: "pganalyze" },
+    { label: "Snyk (per issue)", value: "snyk" },
+    { label: "SonarQube (per issue)", value: "sonarqube" },
+    { label: "Semgrep (per SAST finding)", value: "semgrep" },
+    { label: "Rapid7 InsightVM (per vulnerability)", value: "rapid7_insightvm" },
+    { label: "Featurebase (per post)", value: "featurebase" },
+    { label: "Frill (per idea)", value: "frill" },
+    { label: "Aha (per idea)", value: "aha" },
+    { label: "UserVoice (per suggestion)", value: "uservoice" },
+    { label: "Productboard (per note)", value: "productboard" },
+    { label: "Canny (per post)", value: "canny" },
+    { label: "AskNicely (per response)", value: "asknicely" },
+    { label: "Retently (per feedback item)", value: "retently" },
+    { label: "Appfigures (per review)", value: "appfigures" },
+    { label: "AppFollow (per review)", value: "appfollow" },
+    { label: "Judge.me (per review)", value: "judgeme_reviews" },
     { label: "Google Search Console", value: "google_search_console" }
   ]
 }
 ```
+
+**Google Search Console carries no unit on purpose.** It is the one tool in this list with no emitter registered in `registry.py`, so nothing it syncs becomes a signal — and therefore nothing it syncs bills. Don't invent a unit for it; if an emitter lands, give it the bracket its registry line names.
+
+Two things narrow what actually bills, so don't imply every record becomes a PR: each emitter's `where_clause` drops records the tool already closed (Linear, for instance, skips `completed` and `canceled` states — but **not** backlog or todo, which is why future-work tickets are in scope), and most emitters then run an `actionability_prompt` before emitting. The user-facing claim stays "each record it judges fixable" — "judges" is carrying that nuance, so keep the word.
 
 2. Call `external-data-sources-list` once (step 2's project profile also lists warehouse sources when it exists). For each picked tool whose source already exists, match its warehouse `source_type`: `Github` / `Linear` / `Jira` / `GitLab` / `Gitea` / `Shortcut` / `Sentry` / `Rollbar` / `Bugsnag` / `Honeybadger` / `Raygun` / `Zendesk` / `Freshdesk` / `Freshservice` / `Front` / `Gorgias` / `Kustomer` / `Dixa` / `Plain` / `PgAnalyze` / `Snyk` / `Sonarqube` / `Semgrep` / `Rapid7Insightvm` / `Featurebase` / `Frill` / `Aha` / `Uservoice` / `Productboard` / `Canny` / `Asknicely` / `Retently` / `Appfigures` / `Appfollow` / `JudgeMeReviews` / `GoogleSearchConsole`. Record "already connected" — no connector flow needed, just enable its responder row (step 4 below).
 


### PR DESCRIPTION
_Description by Claude, by I think quite good here:_

## Problem

[Support ticket #65283.](https://us.posthog.com/project/2/support/tickets/65283?status=%5B%22new%22,%22open%22,%22on_hold%22%5D) The step-5 ask asked *"Which of these do you use?"* over a list of bare tool names. A user read that as a question about their tooling, picked Linear, and woke up to 14 unrequested PRs and a $345 bill — against issues they'd filed as future work for themselves.

Autostart is on by default at every priority (`autostart_enabled` is nullable, only explicit `False` disables it; `default_autostart_priority` = P4) and runs as whoever enabled the sources. So this ask *is* the consent, and it never said what it was consenting to — least of all the unit it bills on.

## Changes

The unit goes in the label, so the prompt stays one line:

```
Self-driving reads everything open in these and opens a draft PR for what it
can fix — no approval step, $15 each. Which do you use?

  ☐ None of these
  ☐ GitHub Issues (per issue)
  ☐ Linear (per issue)
  ☐ Jira (per issue)
  ☐ Sentry (per issue)
  ☐ Zendesk (per ticket)
  ☐ Show more (31 more hidden)
```

…and behind "Show more", the rest of the catalog with the same treatment — `Shortcut (per story)`, `Raygun (per error group)`, `Plain (per thread)`, `Rapid7 InsightVM (per vulnerability)`, `Productboard (per note)`, and so on.

The units aren't category guesses — each is the table that tool's emitter actually reads, off its `register_signal_source(<source>, "<table>", …)` line in `products/signals/backend/emission/registry.py`. That's why Shortcut bills per *story* and Raygun per *error group* instead of everything flattening to "per issue". All 36 cross-checked against the registry, applied to both asks.

Skill-only on purpose: the question text lives here, so this needs no wizard release.

Needs the `mcp-publish` label.

## Test plan

`pnpm build` — `self-driving-setup.zip` renders. Units diffed line-by-line against `registry.py`. Copy-only otherwise.
