### PR TITLE
feat(feature-flags): add an end-to-end setup workflow

### DIFF
--- a/context/commandments.yaml
+++ b/context/commandments.yaml
@@ -37,7 +37,8 @@ commandments:
     - Do NOT wrap components in PostHogProvider just for feature flags - it's unnecessary if posthog-js is initialized globally
     # Server-side feature flags
     - Server Components and Route Handlers cannot use React hooks - use posthog-node SDK instead
-    - Create a server-side PostHog client with posthog-node, call getAllFlags() or getFeatureFlag(), then await posthog.shutdown()
+    - For new server-side code, call posthog-node evaluateFlags() once per person and request, then read the result with isEnabled(), getFlag(), or getFlagPayload(); getAllFlags(), isFeatureEnabled(), getFeatureFlag(), and getFeatureFlagPayload() are legacy APIs
+    - Pass the same evaluated flags snapshot to related server-side capture() calls, filtered with onlyAccessed() or only() when appropriate, instead of making another feature flag request
     - 'Route Handlers and Server Actions are short-lived per request. Create the posthog-node client with flushAt 1 and flushInterval 0, and `await posthog.flush()` after capturing and before returning, or the function freezes before the event is sent and it is silently dropped'
     - Pass flag values from server to client components as props to avoid hydration mismatches
     # Avoiding flicker

--- a/context/skills/feature-flags/config.yaml
+++ b/context/skills/feature-flags/config.yaml
@@ -3,19 +3,21 @@ type: skill
 template: description.md
 description: PostHog feature flags for {display_name} applications
 tags: [feature-flags]
+references:
+  preamble: "**Read only this step.** Do not preload later workflow steps; follow the `next_step` link when this step is complete."
 shared_docs:
   - https://posthog.com/docs/feature-flags/adding-feature-flag-code.md
   - https://posthog.com/docs/feature-flags/best-practices.md
 variants:
   - id: react
     display_name: React
-    tags: [react, javascript]
+    tags: [react, javascript, javascript_web]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/react.md
 
   - id: nextjs
     display_name: Next.js
-    tags: [nextjs, nextjs-feature-flags, react, javascript]
+    tags: [nextjs, nextjs-feature-flags, react, javascript, javascript_web, javascript_node]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/react.md
       - https://posthog.com/docs/libraries/next-js.md
@@ -28,13 +30,13 @@ variants:
 
   - id: web
     display_name: Web (JavaScript)
-    tags: [javascript]
+    tags: [javascript, javascript_web]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/web.md
 
   - id: nodejs
     display_name: Node.js
-    tags: [javascript]
+    tags: [javascript, javascript_node]
     docs_urls:
       - https://posthog.com/docs/feature-flags/installation/nodejs.md
 

--- a/context/skills/feature-flags/description.md
+++ b/context/skills/feature-flags/description.md
@@ -1,23 +1,29 @@
 # PostHog feature flags for {display_name}
 
-This skill helps you add PostHog feature flags to {display_name} applications.
+This skill adds a real PostHog feature flag to an existing {display_name} application. It inspects the application, finds or creates the flag, implements one safe use case, verifies the result, and leaves a short report.
+
+## Workflow
+
+{workflow}
+
+Start with `references/1-assess.md` and follow the steps in order. Each step links to the next one. Do not skip directly to implementation or preload every reference.
 
 ## Reference files
 
 {references}
 
-Consult the documentation for API details and framework-specific patterns.
+The workflow references control the job. Consult the framework documentation and `COMMANDMENTS.md` for API details and implementation patterns when a step asks for them.
 
 ## Key principles
 
-- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
-- **Minimal changes**: Add feature flag code alongside existing logic. Don't replace or restructure existing code.
-- **Boolean flags first**: Default to boolean flag checks unless the user specifically asks for multivariate flags.
-- **Server-side when possible**: Prefer server-side flag evaluation to avoid UI flicker.
-
-## PostHog MCP tools
-
-Check if a PostHog MCP server is connected. If available, look for tools related to feature flag management (creating, listing, updating, deleting flags). Use these tools to manage flags directly in PostHog rather than requiring the user to do it manually in the dashboard.
+- **Existing integration**: This workflow requires a working PostHog SDK integration. It does not install PostHog from scratch.
+- **Idempotent flag management**: Reuse an exact flag key. Never create a duplicate or silently change an existing flag's conditions, rollout, or evaluation context.
+- **Conservative rollout**: Do not expose a new experience broadly without the user's explicit intent.
+- **Minimal changes**: Add the flag alongside existing logic without restructuring unrelated code.
+- **Boolean flags first**: Use a boolean flag unless the requested behavior needs variants or a payload.
+- **Safe evaluation**: Resolve identity first, handle loading and failure states explicitly, and keep authorization or other security decisions outside feature flags.
+- **Configuration and secret handling**: Follow the framework's supported configuration pattern. For environment-backed apps, check variable names and presence without reading values. The project token is a public client-side key, but do not print it or include it in reports. Never expose personal API keys, OAuth tokens, or other secrets to the model.
+- **Evidence-based completion**: Local SDK state, a queued event, or a passing build does not prove PostHog received a live evaluation. Report each verification layer separately.
 
 ## Framework guidelines
 

--- a/context/skills/feature-flags/description.md
+++ b/context/skills/feature-flags/description.md
@@ -18,7 +18,7 @@ The workflow references control the job. Consult the framework documentation and
 
 - **Existing integration**: This workflow requires a working PostHog SDK integration. It does not install PostHog from scratch.
 - **Idempotent flag management**: Reuse an exact flag key. Never create a duplicate or silently change an existing flag's conditions, rollout, or evaluation context.
-- **Conservative rollout**: Do not expose a new experience broadly without the user's explicit intent.
+- **Safe initial rollout**: Create every new flag with an explicit zero-percent rollout, or inactive when the API represents "off" that way. Never rely on a tool's default. Read the flag back before editing application code, and require confirmation before wiring new behavior to an existing flag that already reaches users.
 - **Minimal changes**: Add the flag alongside existing logic without restructuring unrelated code.
 - **Boolean flags first**: Use a boolean flag unless the requested behavior needs variants or a payload.
 - **Safe evaluation**: Resolve identity first, handle loading and failure states explicitly, and keep authorization or other security decisions outside feature flags.

--- a/context/skills/feature-flags/references/1-assess.md
+++ b/context/skills/feature-flags/references/1-assess.md
@@ -1,0 +1,60 @@
+---
+next_step: 2-configure.md
+title: Assess the app and choose a use case
+description: Confirm the existing PostHog integration and plan one safe feature-flagged behavior
+---
+
+# Step 1 - Assess the app and choose a use case
+
+## Status
+
+Emit:
+
+```text
+[STATUS] Inspecting the app and existing PostHog integration
+```
+
+## Inspect
+
+Read the project manifest, package or dependency lockfile, PostHog initialization, environment variable examples, and the smallest set of source files needed to understand the relevant user flow. Search for existing flag keys and flag evaluation calls before choosing a new key.
+
+The PostHog project token is a public client-side key, not a secret, but this workflow does not need its raw value. Do not open or print value-bearing environment files such as `.env` or `.env.local`. Check only whether expected variable names are present. Prefer the Wizard `check_env_keys` tool when it is available; otherwise use output that discards or redacts values. Do not repeat the project token in status output, the assessment, or the final report.
+
+Never expose a personal API key, OAuth token, or other secret to the model. This workflow does not need to request or move one. If a future extension must move a secret, use the host's opaque secret-reference flow, such as the Wizard's `wizard_ask` with `sensitive: true` and `set_env_values` with the returned `secretRef`.
+
+First enumerate existing environment filenames without their contents. Run the key-presence check against every existing environment file the framework can load for the current mode; do not assume `.env.local` is the only valid file. A key missing from one file is not globally missing when another supported file contains it.
+
+Record which required configuration names are already present and which are missing across all checked files. Do not call a configuration-writing tool, or recommend adding or moving a variable, until every existing supported environment file has been checked and the variable is still missing.
+
+Read `COMMANDMENTS.md`, the framework-specific reference listed in `SKILL.md`, `adding-feature-flag-code.md`, and `best-practices.md`. Treat these bundled references as the source of truth for SDK methods and framework patterns. If an older framework example conflicts with an API marked as preferred or deprecated in `adding-feature-flag-code.md`, follow the newer API guidance.
+
+Confirm all of the following:
+
+- The generated skill matches the application's language and framework.
+- A PostHog SDK is installed and initialized.
+- The application has a real project token and host configured using the framework's supported pattern, without an empty or placeholder token.
+- The control behavior can continue working when the flag is false, unavailable, or still loading.
+
+## Stop conditions
+
+If the PostHog SDK is missing or has no initialization path, do not install it in this workflow. Emit:
+
+```text
+[ABORT] A working PostHog SDK integration is required. Run the default PostHog Wizard, then rerun the feature-flags command.
+```
+
+If this skill does not match the detected framework, emit:
+
+```text
+[ABORT] The selected feature flag skill does not match this application. Rerun the command with the detected framework skill.
+```
+
+## Choose the use case
+
+Use a behavior named by the user when one exists. Otherwise, select one small, reversible user-facing enhancement supported by the code you inspected, and announce the choice before editing.
+
+Avoid authentication, authorization, billing, data deletion, privacy controls, and other behavior where a failed flag evaluation could create a security or data-integrity problem. A feature flag may control product behavior, but it must never be the security boundary.
+
+Choose a descriptive lowercase, hyphenated flag key that follows any existing project convention. Prefer a boolean flag. Use variants or payloads only when the behavior requires them.
+
+Write down the proposed flag key, control behavior, flagged behavior, evaluation location, safe default, configuration variable names without their values, and the files likely to change. Do not edit source code in this step.

--- a/context/skills/feature-flags/references/1-assess.md
+++ b/context/skills/feature-flags/references/1-assess.md
@@ -18,6 +18,8 @@ Emit:
 
 Read the project manifest, package or dependency lockfile, PostHog initialization, environment variable examples, and the smallest set of source files needed to understand the relevant user flow. Search for existing flag keys and flag evaluation calls before choosing a new key.
 
+Inspect the current working tree before proposing new product work. Read the repository status, the scoped diff for user-authored changes, and the surrounding code needed to understand any changed user-facing behavior. Do not assume every existing change belongs to this workflow, and never modify or revert unrelated work.
+
 The PostHog project token is a public client-side key, not a secret, but this workflow does not need its raw value. Do not open or print value-bearing environment files such as `.env` or `.env.local`. Check only whether expected variable names are present. Prefer the Wizard `check_env_keys` tool when it is available; otherwise use output that discards or redacts values. Do not repeat the project token in status output, the assessment, or the final report.
 
 Never expose a personal API key, OAuth token, or other secret to the model. This workflow does not need to request or move one. If a future extension must move a secret, use the host's opaque secret-reference flow, such as the Wizard's `wizard_ask` with `sensitive: true` and `set_env_values` with the returned `secretRef`.
@@ -51,7 +53,21 @@ If this skill does not match the detected framework, emit:
 
 ## Choose the use case
 
-Use a behavior named by the user when one exists. Otherwise, select one small, reversible user-facing enhancement supported by the code you inspected, and announce the choice before editing.
+Use a behavior named by the user when one exists. Otherwise, look first for one clear, reversible user-facing change in the current working tree that would benefit from a controlled release.
+
+Before calling a PostHog write tool or editing application code, present one recommended proposal containing:
+
+- The behavior to place behind the flag and why it is a good candidate.
+- The control and flagged experiences.
+- The proposed flag key and evaluation location.
+- The safe initial rollout: zero percent, or inactive when the API represents "off" that way.
+- The application files likely to change.
+
+Ask for confirmation in one interaction. If the host provides an interactive ask tool, use it. The user must be able to accept the proposal, describe a different behavior, or choose another candidate when more than one existing change is suitable.
+
+If the user has not named a behavior and the working tree contains no suitable change, offer up to three small, reversible user-facing enhancements supported by the code you inspected. Explain the control and flagged experiences for each, then wait for the user to choose. Do not invent and implement a demonstration feature without confirmation.
+
+Do not continue to Step 2 until the user has confirmed the behavior, control experience, flagged experience, and safe initial rollout. When no interactive user is available and no specific behavior was supplied, stop and report the proposed candidates instead of choosing one silently.
 
 Avoid authentication, authorization, billing, data deletion, privacy controls, and other behavior where a failed flag evaluation could create a security or data-integrity problem. A feature flag may control product behavior, but it must never be the security boundary.
 
@@ -59,4 +75,4 @@ Choose a descriptive lowercase, hyphenated flag key that follows any existing pr
 
 Record the selected skill ID and its version from the installed `SKILL.md` metadata for the final report. If the invoking program exposes whether the skill came from a local or published Context Mill menu, record that source; otherwise mark the source as unavailable instead of inferring it.
 
-Write down the proposed flag key, control behavior, flagged behavior, evaluation location, safe default, configuration variable names without their values, and the files likely to change. Do not edit source code in this step.
+Write down the confirmed flag key, control behavior, flagged behavior, evaluation location, safe default, safe initial rollout, configuration variable names without their values, and the files likely to change. Do not edit source code in this step.

--- a/context/skills/feature-flags/references/1-assess.md
+++ b/context/skills/feature-flags/references/1-assess.md
@@ -57,4 +57,6 @@ Avoid authentication, authorization, billing, data deletion, privacy controls, a
 
 Choose a descriptive lowercase, hyphenated flag key that follows any existing project convention. Prefer a boolean flag. Use variants or payloads only when the behavior requires them.
 
+Record the selected skill ID and its version from the installed `SKILL.md` metadata for the final report. If the invoking program exposes whether the skill came from a local or published Context Mill menu, record that source; otherwise mark the source as unavailable instead of inferring it.
+
 Write down the proposed flag key, control behavior, flagged behavior, evaluation location, safe default, configuration variable names without their values, and the files likely to change. Do not edit source code in this step.

--- a/context/skills/feature-flags/references/1-assess.md
+++ b/context/skills/feature-flags/references/1-assess.md
@@ -63,6 +63,30 @@ Before calling a PostHog write tool or editing application code, present one rec
 - The safe initial rollout: zero percent, or inactive when the API represents "off" that way.
 - The application files likely to change.
 
+When using an interactive ask tool, format the proposal as plain terminal text,
+not Markdown. Keep it short and scan-friendly: start with one sentence, then use
+one labeled line each for `Proposal`, `Why`, `Control`, `Flagged`, `Flag key`,
+`Evaluation`, `Rollout`, and `Files`. End with one direct confirmation question.
+Do not include Markdown headings, bold markers, backticks, nested bullets, or
+long prose paragraphs in the prompt.
+
+Use this shape:
+
+```text
+I found a developer-owned change that is a good fit for a feature flag.
+
+Proposal: <short name>
+Why: <one sentence>
+Control: <behavior when the flag is false>
+Flagged: <behavior when the flag is true>
+Flag key: <lowercase-hyphenated-key>
+Evaluation: <client or server location>
+Rollout: 0%
+Files: <comma-separated paths>
+
+Create this flag in PostHog at 0% rollout?
+```
+
 Ask for confirmation in one interaction. If the host provides an interactive ask tool, use it. The user must be able to accept the proposal, describe a different behavior, or choose another candidate when more than one existing change is suitable.
 
 If the user has not named a behavior and the working tree contains no suitable change, offer up to three small, reversible user-facing enhancements supported by the code you inspected. Explain the control and flagged experiences for each, then wait for the user to choose. Do not invent and implement a demonstration feature without confirmation.

--- a/context/skills/feature-flags/references/2-configure.md
+++ b/context/skills/feature-flags/references/2-configure.md
@@ -28,15 +28,19 @@ Discover the available feature flag tools, inspect their schemas, and list or se
 
 - If the exact key exists and its type is compatible, reuse it.
 - If the exact key exists with incompatible variants, payloads, or evaluation context, explain the conflict and ask before changing either the plan or the flag.
-- If the key does not exist, create one boolean flag with a useful description and an evaluation context that matches where the code will evaluate it.
+- If the key does not exist, create one boolean flag with a useful description, an evaluation context that matches where the code will evaluate it, and an explicit zero-percent rollout. When the API represents "off" only through active state, create it inactive instead.
 
 Do not silently modify an existing flag's conditions, rollout percentage, active state, variants, payload, or evaluation context.
 
 ## Use conservative release conditions
 
-For a new flag, preserve the control experience by default. Prefer an inactive flag, a zero-percent rollout, or a verified developer-only condition until the user has chosen a rollout audience. Do not create a broad rollout merely to simplify testing.
+For a new flag, preserve the control experience by default. Pass an explicit zero-percent rollout in the creation call; never omit release conditions or rely on the tool's default. For PostHog API-shaped tools, set a release condition under `filters.groups` with `rollout_percentage: 0`. If a wrapper uses a different shape, inspect its schema and set the equivalent explicit field. Use an inactive flag only when that is how the API represents a fully off flag. Do not create a broad or developer-targeted rollout merely to simplify testing.
 
-If the available tool cannot create the flag with safe conditions, ask the user before using its defaults.
+If the available tool cannot create the flag at zero percent or inactive, do not call it with unsafe defaults. Give the user the proposed flag configuration to create manually and wait for confirmation.
+
+Read every newly created flag back immediately. Confirm that it is inactive or has a zero-percent rollout with no condition that can match a user. If the read-back is broader than requested, return it to zero percent or inactive before changing application code, then read it back again. If the safe state cannot be restored and confirmed, stop.
+
+When reusing an existing flag that already reaches users, explain that adding new behavior behind it could expose that behavior immediately. Continue only after the user confirms that existing audience, or choose a new flag key with a zero-percent rollout. Never change an existing flag's rollout to make it fit the implementation.
 
 ## MCP fallback
 
@@ -48,4 +52,4 @@ When running without an interactive user, emit:
 [ABORT] PostHog feature flag access is required. Connect PostHog MCP or create the proposed flag in PostHog, then rerun the command.
 ```
 
-After creating or reusing a flag through MCP, read it back and confirm the exact key, type, project, active state, evaluation context, and release conditions. Keep this evidence for the final report.
+After creating or reusing a flag through MCP, read it back and confirm the exact key, type, project, active state, evaluation context, and release conditions. Do not continue to application changes until the confirmed PostHog state matches the user's approved plan. Keep this evidence for the final report.

--- a/context/skills/feature-flags/references/2-configure.md
+++ b/context/skills/feature-flags/references/2-configure.md
@@ -1,0 +1,51 @@
+---
+next_step: 3-implement.md
+title: Find or create the PostHog feature flag
+description: Reuse an exact flag or create one with conservative release conditions
+---
+
+# Step 2 - Find or create the PostHog feature flag
+
+## Status
+
+Emit:
+
+```text
+[STATUS] Checking the feature flag in PostHog
+```
+
+{{> mcp-tool-calling}}
+
+## Select the project
+
+Use the authenticated PostHog project selected by the invoking program. Confirm that its host and region match the application's existing non-secret configuration without reading the raw project token. Do not assume a region or project. If more than one project is available and the correct one cannot be established, ask the user to choose.
+
+Never expose a personal API key, OAuth token, or other secret to the model, logs, or application source. Continue using the project's existing configuration names and values.
+
+## Find before creating
+
+Discover the available feature flag tools, inspect their schemas, and list or search flags before creating anything.
+
+- If the exact key exists and its type is compatible, reuse it.
+- If the exact key exists with incompatible variants, payloads, or evaluation context, explain the conflict and ask before changing either the plan or the flag.
+- If the key does not exist, create one boolean flag with a useful description and an evaluation context that matches where the code will evaluate it.
+
+Do not silently modify an existing flag's conditions, rollout percentage, active state, variants, payload, or evaluation context.
+
+## Use conservative release conditions
+
+For a new flag, preserve the control experience by default. Prefer an inactive flag, a zero-percent rollout, or a verified developer-only condition until the user has chosen a rollout audience. Do not create a broad rollout merely to simplify testing.
+
+If the available tool cannot create the flag with safe conditions, ask the user before using its defaults.
+
+## MCP fallback
+
+If PostHog MCP is unavailable, authentication fails, or the required feature flag scope is missing, give the user the flag key, description, type, evaluation context, and conservative rollout settings to create in the PostHog dashboard. Wait for confirmation before changing application code.
+
+When running without an interactive user, emit:
+
+```text
+[ABORT] PostHog feature flag access is required. Connect PostHog MCP or create the proposed flag in PostHog, then rerun the command.
+```
+
+After creating or reusing a flag through MCP, read it back and confirm the exact key, type, project, active state, evaluation context, and release conditions. Keep this evidence for the final report.

--- a/context/skills/feature-flags/references/3-implement.md
+++ b/context/skills/feature-flags/references/3-implement.md
@@ -1,0 +1,43 @@
+---
+next_step: 4-verify.md
+title: Implement the flagged behavior
+description: Add a minimal framework-correct flag check with a safe control path
+---
+
+# Step 3 - Implement the flagged behavior
+
+## Status
+
+Emit:
+
+```text
+[STATUS] Implementing the feature-flagged behavior
+```
+
+## Choose the evaluation location
+
+Use the framework reference and `COMMANDMENTS.md` to choose the evaluation location:
+
+- Evaluate on the server when the flag affects the initial render, uses server-owned data, or protects backend execution.
+- Evaluate on the client for interactions that only exist after the page has loaded.
+- Pass a server result to the client when this avoids flicker or hydration differences.
+
+Resolve the stable person or group identity before evaluating targeted flags. Do not invent a distinct ID. Preserve anonymous evaluation when the application has no authenticated identity.
+
+## Implement the control and flagged paths
+
+Read each file immediately before editing it. Keep the changes close to the existing behavior and avoid unrelated refactors.
+
+- Preserve the current experience as the control path unless the user requested a different default.
+- Handle the SDK's unevaluated or loading value explicitly. Do not treat `undefined`, `nil`, or an SDK error as proof that the flag is false.
+- Evaluate the flag once at the smallest useful boundary instead of scattering repeated checks through the codebase.
+- Keep the application working when PostHog configuration is absent, following `COMMANDMENTS.md`.
+- Do not add a committed test override or development backdoor.
+
+Add or update focused tests for both the control and flagged paths when the project has a suitable test setup.
+
+## Instrument meaningful behavior
+
+PostHog SDKs can emit their own feature flag evaluation event. Do not manually duplicate that event.
+
+Add a custom event only when the flagged experience contains a meaningful user action worth measuring. Capture the action in its event handler or backend operation, use the SDK's documented flag context mechanism when available, and keep event properties free of PII and user-generated content.

--- a/context/skills/feature-flags/references/3-implement.md
+++ b/context/skills/feature-flags/references/3-implement.md
@@ -33,6 +33,7 @@ Read each file immediately before editing it. Keep the changes close to the exis
 - Evaluate the flag once at the smallest useful boundary instead of scattering repeated checks through the codebase.
 - Keep the application working when PostHog configuration is absent, following `COMMANDMENTS.md`.
 - Do not add a committed test override or development backdoor.
+- When an action depends on one or more network requests, check every response or SDK result before changing local success state or capturing a success event. A rejected request, non-2xx response, or SDK error must follow the application's existing failure path.
 
 Add or update focused tests for both the control and flagged paths when the project has a suitable test setup.
 

--- a/context/skills/feature-flags/references/4-verify.md
+++ b/context/skills/feature-flags/references/4-verify.md
@@ -1,0 +1,55 @@
+---
+next_step: 5-report.md
+title: Verify code, evaluation, and ingestion
+description: Test the application and distinguish local checks from live PostHog evidence
+---
+
+# Step 4 - Verify code, evaluation, and ingestion
+
+## Status
+
+Emit:
+
+```text
+[STATUS] Verifying the feature flag implementation
+```
+
+## Verify the code
+
+Review the final diff for unrelated changes, hardcoded secrets, empty or placeholder PostHog configuration, framework-unsupported configuration patterns, duplicate flag keys, unsafe defaults, and PII in event properties.
+
+Run the repository's focused tests, type checker, linter, and standard production build when those commands exist. A type check is not a substitute for the production build. If a command cannot run, record the exact blocker rather than silently omitting it.
+
+Test both the control and flagged paths with the project's normal test doubles or an SDK-supported local override. Never commit an override. Source inspection may show that a path appears correct, but it does not count as executing that path.
+
+## Verify PostHog state
+
+Read the flag from PostHog again and confirm that its key, project, type, evaluation context, active state, and release conditions still match the plan.
+
+When the application can run locally and safe test targeting is available, perform a runtime smoke test and exercise both flag states. Do not broaden or alter a shared rollout solely for testing without the user's permission. Remove any temporary developer-only condition after testing unless the user wants to keep it. If one or both paths cannot be exercised safely, mark them as not run and state the exact manual step that remains.
+
+Trigger one real evaluation from the running application. Query PostHog for the corresponding feature flag evaluation event and any custom action event added in Step 3. Confirm the event came from the expected environment and contains no PII.
+
+A local flag value, browser console output, network request, or queued event proves only that the application attempted the operation. It does not prove server ingestion. Record live PostHog query results separately.
+
+## Classify incomplete verification
+
+Do not claim a verification layer passed when it could not run:
+
+- A pre-existing build or test failure is a project baseline failure; include the command and error.
+- Missing deployment configuration is pending deployment work, even when local evaluation passes.
+- Missing MCP access or OAuth scope is pending PostHog verification.
+- No observed live evaluation means ingestion is unverified, even when code checks pass.
+- A path inferred from source code is source-reviewed, not runtime-verified.
+
+Continue to the report with the evidence available. The report must make incomplete layers visible.
+
+## Completion gate
+
+Before continuing to the report:
+
+1. Inspect the project scripts and list the applicable verification commands.
+2. Run each applicable focused test, type check, lint, and standard production build.
+3. If a defined command cannot run, classify it as `blocked` with the command and exact reason.
+
+Do not continue to Step 5 while a defined production build is still classified as `not run`.

--- a/context/skills/feature-flags/references/4-verify.md
+++ b/context/skills/feature-flags/references/4-verify.md
@@ -26,7 +26,11 @@ Test both the control and flagged paths with the project's normal test doubles o
 
 Read the flag from PostHog again and confirm that its key, project, type, evaluation context, active state, and release conditions still match the plan.
 
-When the application can run locally and safe test targeting is available, perform a runtime smoke test and exercise both flag states. Do not broaden or alter a shared rollout solely for testing without the user's permission. Remove any temporary developer-only condition after testing unless the user wants to keep it. If one or both paths cannot be exercised safely, mark them as not run and state the exact manual step that remains.
+When the application can run locally and safe test targeting is available, perform a runtime smoke test and exercise both flag states. Prefer an SDK-supported local override or a verified developer-only condition that cannot affect other users.
+
+Before changing any PostHog-side flag state for testing, record its exact active state and release conditions and get the user's permission. After testing, restore the exact prior state, read the flag back, and retain the restoration evidence for the report. If restoration fails, stop changing the flag and report the mismatch as unresolved. Do not broaden or alter a shared rollout solely for testing without permission, and do not leave temporary conditions behind unless the user explicitly asks to keep them.
+
+If one or both paths cannot be exercised safely, mark them as not run and state the exact manual step that remains.
 
 Trigger one real evaluation from the running application. Query PostHog for the corresponding feature flag evaluation event and any custom action event added in Step 3. Confirm the event came from the expected environment and contains no PII.
 
@@ -51,5 +55,6 @@ Before continuing to the report:
 1. Inspect the project scripts and list the applicable verification commands.
 2. Run each applicable focused test, type check, lint, and standard production build.
 3. If a defined command cannot run, classify it as `blocked` with the command and exact reason.
+4. If verification changed PostHog-side flag state, restore it and confirm the restored state with a read-back.
 
-Do not continue to Step 5 while a defined production build is still classified as `not run`.
+Do not continue to Step 5 while a defined production build is still classified as `not run` or temporary flag-state restoration is unverified.

--- a/context/skills/feature-flags/references/4-verify.md
+++ b/context/skills/feature-flags/references/4-verify.md
@@ -16,7 +16,7 @@ Emit:
 
 ## Verify the code
 
-Review the final diff for unrelated changes, hardcoded secrets, empty or placeholder PostHog configuration, framework-unsupported configuration patterns, duplicate flag keys, unsafe defaults, and PII in event properties.
+Review the final diff for unrelated changes, hardcoded secrets, empty or placeholder PostHog configuration, framework-unsupported configuration patterns, duplicate flag keys, unsafe defaults, and PII in event properties. For network-backed actions, confirm that failed requests cannot update successful UI state or emit success events.
 
 Run the repository's focused tests, type checker, linter, and standard production build when those commands exist. A type check is not a substitute for the production build. If a command cannot run, record the exact blocker rather than silently omitting it.
 

--- a/context/skills/feature-flags/references/5-report.md
+++ b/context/skills/feature-flags/references/5-report.md
@@ -1,0 +1,34 @@
+---
+next_step: null
+title: Write the feature flag setup report
+description: Record the implementation, PostHog state, verification evidence, and remaining work
+---
+
+# Step 5 - Write the feature flag setup report
+
+## Status
+
+Emit:
+
+```text
+[STATUS] Writing the feature flag setup report
+```
+
+Write to the report path supplied by the invoking program. If the invoking program does not supply one, use `posthog-feature-flags-report.md` at the project root. If a report from an earlier run exists at that path, read it before replacing it. Do not create or update a second report file.
+
+Keep the report concise and include:
+
+1. A one-paragraph summary of the user experience and its control behavior.
+2. The flag key, type, PostHog project, evaluation context, active state, release conditions, and whether the flag was created or reused.
+3. A table of changed files and why each changed.
+4. Any custom event name, its non-PII properties, and where it is captured.
+5. A verification table with separate rows for source review, focused tests, type checking, linting, production build, both flag paths, PostHog flag read-back, live evaluation ingestion, and custom event ingestion. Mark each row `verified`, `failed`, `source-reviewed`, `blocked`, or `not run`, and include the evidence. Use `verified` only when that check or behavior actually ran.
+6. A "Before you merge" checklist containing only unresolved work. Do not include configuration steps already confirmed during assessment.
+
+The PostHog project token is public, but do not include it in the report because the value is unnecessary. Never include personal API keys, OAuth tokens, other secrets, full environment variable values, or personal data returned by MCP tools.
+
+After writing the report, emit:
+
+```text
+[STATUS] Created setup report: <absolute report path>
+```

--- a/context/skills/feature-flags/references/5-report.md
+++ b/context/skills/feature-flags/references/5-report.md
@@ -19,12 +19,14 @@ Write to the report path supplied by the invoking program. If the invoking progr
 Keep the report concise and include:
 
 1. A one-paragraph summary of the user experience and its control behavior.
-2. The selected skill ID and version from the installed `SKILL.md` metadata. Include whether it came from a local or published Context Mill menu when the source is available; otherwise mark the source as unavailable.
+2. The selected skill ID and version from the installed `SKILL.md` metadata. Determine the source only from explicit installation evidence, such as the `install_skill` result or its source URL. A localhost or local development URL, or a `dev` skill version, means local. A menu category does not prove the skill was published. If no source evidence is available, mark the source as unavailable instead of inferring it.
 3. The flag key, type, PostHog project, evaluation context, active state, release conditions, and whether the flag was created or reused.
 4. A table of changed files and why each changed.
 5. Any custom event name, its non-PII properties, and where it is captured.
 6. A verification table with separate rows for source review, focused tests, type checking, linting, production build, both flag paths, PostHog flag read-back, live evaluation ingestion, custom event ingestion, and temporary flag-state restoration when applicable. Mark each row `verified`, `failed`, `source-reviewed`, `blocked`, or `not run`, and include the evidence. Use `verified` only when that check or behavior actually ran.
 7. A "Before you merge" checklist containing only unresolved work. Do not include configuration steps already confirmed during assessment.
+
+Keep evidence scoped to the command or observation that produced it. A passing build does not prove that linting or a separate type check ran unless the build output explicitly names and runs that check. Never infer that a linter ran from a framework convention or from a successful build.
 
 The PostHog project token is public, but do not include it in the report because the value is unnecessary. Never include personal API keys, OAuth tokens, other secrets, full environment variable values, or personal data returned by MCP tools.
 

--- a/context/skills/feature-flags/references/5-report.md
+++ b/context/skills/feature-flags/references/5-report.md
@@ -19,11 +19,12 @@ Write to the report path supplied by the invoking program. If the invoking progr
 Keep the report concise and include:
 
 1. A one-paragraph summary of the user experience and its control behavior.
-2. The flag key, type, PostHog project, evaluation context, active state, release conditions, and whether the flag was created or reused.
-3. A table of changed files and why each changed.
-4. Any custom event name, its non-PII properties, and where it is captured.
-5. A verification table with separate rows for source review, focused tests, type checking, linting, production build, both flag paths, PostHog flag read-back, live evaluation ingestion, and custom event ingestion. Mark each row `verified`, `failed`, `source-reviewed`, `blocked`, or `not run`, and include the evidence. Use `verified` only when that check or behavior actually ran.
-6. A "Before you merge" checklist containing only unresolved work. Do not include configuration steps already confirmed during assessment.
+2. The selected skill ID and version from the installed `SKILL.md` metadata. Include whether it came from a local or published Context Mill menu when the source is available; otherwise mark the source as unavailable.
+3. The flag key, type, PostHog project, evaluation context, active state, release conditions, and whether the flag was created or reused.
+4. A table of changed files and why each changed.
+5. Any custom event name, its non-PII properties, and where it is captured.
+6. A verification table with separate rows for source review, focused tests, type checking, linting, production build, both flag paths, PostHog flag read-back, live evaluation ingestion, custom event ingestion, and temporary flag-state restoration when applicable. Mark each row `verified`, `failed`, `source-reviewed`, `blocked`, or `not run`, and include the evidence. Use `verified` only when that check or behavior actually ran.
+7. A "Before you merge" checklist containing only unresolved work. Do not include configuration steps already confirmed during assessment.
 
 The PostHog project token is public, but do not include it in the report because the value is unnecessary. Never include personal API keys, OAuth tokens, other secrets, full environment variable values, or personal data returned by MCP tools.
 

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -171,6 +171,7 @@ describe('feature-flags skill contract', () => {
         expect(firstStep).toContain('mark the source as unavailable');
         expect(firstStep).toContain('Inspect the current working tree');
         expect(firstStep).toContain('Ask for confirmation in one interaction');
+        expect(firstStep).toContain('format the proposal as plain terminal text');
         expect(firstStep).toContain('Do not invent and implement a demonstration feature without confirmation');
         expect(firstStep).toContain('Do not continue to Step 2 until the user has confirmed');
         expect(configurationStep).toContain('explicit zero-percent rollout');

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import yaml from 'js-yaml';
+
+import {
+    expandSkillGroups,
+    generateSkill,
+    loadSkillsConfig,
+} from '../skill-generator.js';
+
+const REPO_ROOT = process.cwd();
+const CONFIG_DIR = path.join(REPO_ROOT, 'context');
+const FEATURE_FLAGS_DIR = path.join(CONFIG_DIR, 'skills', 'feature-flags');
+const WORKFLOW_FILES = [
+    '1-assess.md',
+    '2-configure.md',
+    '3-implement.md',
+    '4-verify.md',
+    '5-report.md',
+];
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+function loadFeatureFlagSkills() {
+    const config = loadSkillsConfig(CONFIG_DIR);
+    return expandSkillGroups(config, CONFIG_DIR)
+        .filter((skill) => skill._group === 'feature-flags');
+}
+
+describe('feature-flags skill contract', () => {
+    it('assigns browser and server runtime rules to JavaScript variants', () => {
+        const skills = loadFeatureFlagSkills();
+        const byShortId = Object.fromEntries(
+            skills.map((skill) => [skill._shortId, skill]),
+        );
+
+        expect(byShortId.react.tags).toEqual([
+            'feature-flags',
+            'react',
+            'javascript',
+            'javascript_web',
+        ]);
+        expect(byShortId.nextjs.tags).toEqual([
+            'feature-flags',
+            'nextjs',
+            'nextjs-feature-flags',
+            'react',
+            'javascript',
+            'javascript_web',
+            'javascript_node',
+        ]);
+        expect(byShortId.web.tags).toEqual([
+            'feature-flags',
+            'javascript',
+            'javascript_web',
+        ]);
+        expect(byShortId.nodejs.tags).toEqual([
+            'feature-flags',
+            'javascript',
+            'javascript_node',
+        ]);
+    });
+
+    it('generates an ordered Next.js workflow with browser and server safety rules', async () => {
+        const nextjs = loadFeatureFlagSkills()
+            .find((skill) => skill._shortId === 'nextjs');
+        const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'feature-flags-skill-'));
+        temporaryDirectories.push(outputDir);
+
+        const commandmentsConfig = yaml.load(
+            fs.readFileSync(path.join(CONFIG_DIR, 'commandments.yaml'), 'utf8'),
+        );
+        const skillTemplate = fs.readFileSync(
+            path.join(FEATURE_FLAGS_DIR, 'description.md'),
+            'utf8',
+        );
+
+        await generateSkill({
+            skill: {
+                ...nextjs,
+                docs_urls: [],
+            },
+            version: 'test',
+            repoRoot: REPO_ROOT,
+            configDir: CONFIG_DIR,
+            outputDir,
+            skipPatterns: { global: [], examples: {} },
+            commandmentsConfig,
+            skillTemplate,
+            sharedDocs: [],
+        });
+
+        const generatedDir = path.join(outputDir, 'feature-flags-nextjs');
+        const generatedSkill = fs.readFileSync(
+            path.join(generatedDir, 'SKILL.md'),
+            'utf8',
+        );
+        const generatedRules = fs.readFileSync(
+            path.join(generatedDir, 'references', 'COMMANDMENTS.md'),
+            'utf8',
+        );
+
+        for (const [index, filename] of WORKFLOW_FILES.entries()) {
+            expect(generatedSkill).toContain(
+                `${index + 1}. \`references/${filename}\``,
+            );
+            expect(
+                fs.existsSync(path.join(generatedDir, 'references', filename)),
+            ).toBe(true);
+        }
+
+        expect(generatedSkill).toContain('1-assess.md` - Assess the app and choose a use case');
+        expect(generatedSkill).toContain('Start here');
+        expect(generatedRules).toContain('NEVER send PII in posthog.capture() event properties');
+        expect(generatedRules).toContain('posthog-node is the Node.js server-side SDK package name');
+        expect(generatedRules).toContain('call posthog-node evaluateFlags() once');
+        expect(generatedRules).not.toContain('call getAllFlags() or getFeatureFlag()');
+
+        const firstStep = fs.readFileSync(
+            path.join(generatedDir, 'references', '1-assess.md'),
+            'utf8',
+        );
+        const finalStep = fs.readFileSync(
+            path.join(generatedDir, 'references', '5-report.md'),
+            'utf8',
+        );
+        const verificationStep = fs.readFileSync(
+            path.join(generatedDir, 'references', '4-verify.md'),
+            'utf8',
+        );
+
+        expect(firstStep).toContain('Upon completion, continue with:');
+        expect(firstStep).toContain('[2-configure.md](2-configure.md)');
+        expect(firstStep).toContain('Do not open or print value-bearing environment files');
+        expect(firstStep).toContain('Prefer the Wizard `check_env_keys` tool');
+        expect(firstStep).toContain('project token is a public client-side key, not a secret');
+        expect(firstStep).toContain('Never expose a personal API key');
+        expect(firstStep).toContain('`secretRef`');
+        expect(firstStep).toContain('every existing environment file');
+        expect(firstStep).toContain('do not assume `.env.local`');
+        expect(firstStep).toContain('Do not call a configuration-writing tool');
+        expect(verificationStep).toContain('standard production build');
+        expect(verificationStep).toContain('A type check is not a substitute');
+        expect(verificationStep).toContain('framework-unsupported configuration patterns');
+        expect(verificationStep).not.toContain('hardcoded PostHog configuration');
+        expect(verificationStep).toContain('does not count as executing that path');
+        expect(verificationStep).toContain('Do not continue to Step 5');
+        expect(verificationStep).toContain('defined production build is still classified as `not run`');
+        expect(finalStep).toContain('`source-reviewed`');
+        expect(finalStep).toContain('Use `verified` only when');
+        expect(finalStep).toContain('personal data returned by MCP tools');
+        expect(finalStep).toContain('report path supplied by the invoking program');
+        expect(finalStep).toContain('Do not create or update a second report file');
+        expect(finalStep).toContain('configuration steps already confirmed');
+        expect(finalStep).not.toContain('Upon completion, continue with:');
+    });
+});

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -169,6 +169,17 @@ describe('feature-flags skill contract', () => {
         expect(firstStep).toContain('selected skill ID and its version');
         expect(firstStep).toContain('local or published Context Mill menu');
         expect(firstStep).toContain('mark the source as unavailable');
+        expect(firstStep).toContain('Inspect the current working tree');
+        expect(firstStep).toContain('Ask for confirmation in one interaction');
+        expect(firstStep).toContain('Do not invent and implement a demonstration feature without confirmation');
+        expect(firstStep).toContain('Do not continue to Step 2 until the user has confirmed');
+        expect(configurationStep).toContain('explicit zero-percent rollout');
+        expect(configurationStep).toContain("never omit release conditions or rely on the tool's default");
+        expect(configurationStep).toContain('`filters.groups` with `rollout_percentage: 0`');
+        expect(configurationStep).toContain('Read every newly created flag back immediately');
+        expect(configurationStep).toContain('If the safe state cannot be restored and confirmed, stop');
+        expect(configurationStep).toContain('When reusing an existing flag that already reaches users');
+        expect(configurationStep).toContain('Do not continue to application changes');
         expect(implementationStep).toContain('check every response or SDK result');
         expect(implementationStep).toContain('non-2xx response');
         expect(implementationStep).toContain('capturing a success event');

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -200,7 +200,11 @@ describe('feature-flags skill contract', () => {
         expect(finalStep).toContain('`source-reviewed`');
         expect(finalStep).toContain('Use `verified` only when');
         expect(finalStep).toContain('selected skill ID and version');
-        expect(finalStep).toContain('local or published Context Mill menu');
+        expect(finalStep).toContain('A localhost or local development URL');
+        expect(finalStep).toContain('A menu category does not prove the skill was published');
+        expect(finalStep).toContain('mark the source as unavailable instead of inferring it');
+        expect(finalStep).toContain('A passing build does not prove that linting');
+        expect(finalStep).toContain('Never infer that a linter ran');
         expect(finalStep).toContain('temporary flag-state restoration');
         expect(finalStep).toContain('personal data returned by MCP tools');
         expect(finalStep).toContain('report path supplied by the invoking program');

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -151,6 +151,9 @@ describe('feature-flags skill contract', () => {
         expect(firstStep).toContain('every existing environment file');
         expect(firstStep).toContain('do not assume `.env.local`');
         expect(firstStep).toContain('Do not call a configuration-writing tool');
+        expect(firstStep).toContain('selected skill ID and its version');
+        expect(firstStep).toContain('local or published Context Mill menu');
+        expect(firstStep).toContain('mark the source as unavailable');
         expect(implementationStep).toContain('check every response or SDK result');
         expect(implementationStep).toContain('non-2xx response');
         expect(implementationStep).toContain('capturing a success event');
@@ -161,10 +164,18 @@ describe('feature-flags skill contract', () => {
         expect(verificationStep).toContain('emit success events');
         expect(verificationStep).not.toContain('hardcoded PostHog configuration');
         expect(verificationStep).toContain('does not count as executing that path');
+        expect(verificationStep).toContain('record its exact active state and release conditions');
+        expect(verificationStep).toContain('restore the exact prior state');
+        expect(verificationStep).toContain('retain the restoration evidence');
+        expect(verificationStep).toContain('confirm the restored state with a read-back');
         expect(verificationStep).toContain('Do not continue to Step 5');
         expect(verificationStep).toContain('defined production build is still classified as `not run`');
+        expect(verificationStep).toContain('temporary flag-state restoration is unverified');
         expect(finalStep).toContain('`source-reviewed`');
         expect(finalStep).toContain('Use `verified` only when');
+        expect(finalStep).toContain('selected skill ID and version');
+        expect(finalStep).toContain('local or published Context Mill menu');
+        expect(finalStep).toContain('temporary flag-state restoration');
         expect(finalStep).toContain('personal data returned by MCP tools');
         expect(finalStep).toContain('report path supplied by the invoking program');
         expect(finalStep).toContain('Do not create or update a second report file');

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -140,9 +140,24 @@ describe('feature-flags skill contract', () => {
             path.join(generatedDir, 'references', '3-implement.md'),
             'utf8',
         );
+        const configurationStep = fs.readFileSync(
+            path.join(generatedDir, 'references', '2-configure.md'),
+            'utf8',
+        );
 
         expect(firstStep).toContain('Upon completion, continue with:');
         expect(firstStep).toContain('[2-configure.md](2-configure.md)');
+        // Wizard maps these reason prefixes to actionable error outros. Keep
+        // this cross-repo contract in sync with featureFlagsConfig.abortCases.
+        expect(firstStep).toContain(
+            '[ABORT] A working PostHog SDK integration is required.',
+        );
+        expect(firstStep).toContain(
+            '[ABORT] The selected feature flag skill does not match this application.',
+        );
+        expect(configurationStep).toContain(
+            '[ABORT] PostHog feature flag access is required.',
+        );
         expect(firstStep).toContain('Do not open or print value-bearing environment files');
         expect(firstStep).toContain('Prefer the Wizard `check_env_keys` tool');
         expect(firstStep).toContain('project token is a public client-side key, not a secret');

--- a/scripts/lib/tests/feature-flags-skill.test.js
+++ b/scripts/lib/tests/feature-flags-skill.test.js
@@ -136,6 +136,10 @@ describe('feature-flags skill contract', () => {
             path.join(generatedDir, 'references', '4-verify.md'),
             'utf8',
         );
+        const implementationStep = fs.readFileSync(
+            path.join(generatedDir, 'references', '3-implement.md'),
+            'utf8',
+        );
 
         expect(firstStep).toContain('Upon completion, continue with:');
         expect(firstStep).toContain('[2-configure.md](2-configure.md)');
@@ -147,9 +151,14 @@ describe('feature-flags skill contract', () => {
         expect(firstStep).toContain('every existing environment file');
         expect(firstStep).toContain('do not assume `.env.local`');
         expect(firstStep).toContain('Do not call a configuration-writing tool');
+        expect(implementationStep).toContain('check every response or SDK result');
+        expect(implementationStep).toContain('non-2xx response');
+        expect(implementationStep).toContain('capturing a success event');
         expect(verificationStep).toContain('standard production build');
         expect(verificationStep).toContain('A type check is not a substitute');
         expect(verificationStep).toContain('framework-unsupported configuration patterns');
+        expect(verificationStep).toContain('failed requests cannot update successful UI state');
+        expect(verificationStep).toContain('emit success events');
         expect(verificationStep).not.toContain('hardcoded PostHog configuration');
         expect(verificationStep).toContain('does not count as executing that path');
         expect(verificationStep).toContain('Do not continue to Step 5');


### PR DESCRIPTION
Turn the existing feature-flags skills into an ordered workflow that can assess an app, configure a safe flag, implement one use case, verify the result, and leave an evidence-based report.

## What

- Add a five-step workflow shared by the feature-flags skill variants.
- Add framework-specific browser and server rule tags for JavaScript variants.
- Update Next.js server evaluation guidance to use the current `evaluateFlags()` API.
- Separate public project tokens from personal API keys, OAuth tokens, and other secrets.
- Add conservative flag creation, rollout, verification, and reporting rules.
- Add a generation contract test for the Next.js skill.

## Why

The previous skill provided documentation and general principles, but it did not define an executable workflow or completion criteria.

Testing the generated Next.js skill with a real Wizard agent exposed gaps around environment-file detection, production-build verification, report ownership, safe rollout behavior, and credential terminology. These instructions turn those findings into reusable context rather than fixture-specific fixes.

## Verification

- `npm test` - 19 test files and 139 tests passed
- `npm run build` - all 363 skills generated
- Environment-variable naming check passed
- Generated Next.js skill inspected
- Bundle and individual skill archives remain within CI size limits
- End-to-end Wizard agent test completed against a Next.js App Router fixture and a live PostHog project
  - Production build and PostHog flag read-back passed
  - An existing inactive flag was reused without changing its rollout conditions
  - Environment configuration was checked by key presence without reading values

## Runtime coverage

The agent test covered the Next.js variant. Other feature-flags variants generated successfully but were not exercised through full runtime integrations.

Live evaluation and custom event ingestion were not run because the shared rollout was not changed solely for testing. The workflow requires these layers to remain visibly classified as `not run` rather than treating source review or local state as ingestion evidence.
