### PR TITLE
fix(docs): repoint moved PostHog docs URLs to canonical paths

### DIFF
--- a/context/skills/ai-observability/references/3-otel-setup.md
+++ b/context/skills/ai-observability/references/3-otel-setup.md
@@ -105,7 +105,7 @@ posthog.capture(
 )
 ```
 
-Refer to `/docs/ai-observability/manual-capture` for the full property list.
+Refer to https://posthog.com/docs/ai-observability/installation/manual-capture for the full property list.
 
 ## Do not
 

--- a/context/skills/llm-analytics/config.yaml
+++ b/context/skills/llm-analytics/config.yaml
@@ -4,54 +4,54 @@ template: description.md
 description: PostHog LLM analytics for {display_name}
 tags: [llm-analytics]
 shared_docs:
-  - https://posthog.com/docs/llm-analytics/basics.md
-  - https://posthog.com/docs/llm-analytics/traces.md
-  - https://posthog.com/docs/llm-analytics/calculating-costs.md
+  - https://posthog.com/docs/ai-observability/basics.md
+  - https://posthog.com/docs/ai-observability/traces.md
+  - https://posthog.com/docs/ai-observability/calculating-costs.md
 variants:
   - id: setup
     display_name: all supported providers
     tags: [python, javascript]
     docs_urls:
       # --- Model providers ---
-      - https://posthog.com/docs/llm-analytics/installation/openai.md
-      - https://posthog.com/docs/llm-analytics/installation/azure-openai.md
+      - https://posthog.com/docs/ai-observability/installation/openai.md
+      - https://posthog.com/docs/ai-observability/installation/azure-openai.md
       # --- PostHog.AI / .NET OpenAI instrumentation ---
       - https://raw.githubusercontent.com/PostHog/posthog-dotnet/main/src/PostHog.AI/README.md
-      - https://posthog.com/docs/llm-analytics/installation/anthropic.md
-      - https://posthog.com/docs/llm-analytics/installation/google.md
-      - https://posthog.com/docs/llm-analytics/installation/cohere.md
-      - https://posthog.com/docs/llm-analytics/installation/mistral.md
-      - https://posthog.com/docs/llm-analytics/installation/perplexity.md
-      - https://posthog.com/docs/llm-analytics/installation/deepseek.md
-      - https://posthog.com/docs/llm-analytics/installation/groq.md
-      - https://posthog.com/docs/llm-analytics/installation/together-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/fireworks-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/xai.md
-      - https://posthog.com/docs/llm-analytics/installation/cerebras.md
-      - https://posthog.com/docs/llm-analytics/installation/hugging-face.md
-      - https://posthog.com/docs/llm-analytics/installation/ollama.md
-      - https://posthog.com/docs/llm-analytics/installation/openrouter.md
+      - https://posthog.com/docs/ai-observability/installation/anthropic.md
+      - https://posthog.com/docs/ai-observability/installation/google.md
+      - https://posthog.com/docs/ai-observability/installation/cohere.md
+      - https://posthog.com/docs/ai-observability/installation/mistral.md
+      - https://posthog.com/docs/ai-observability/installation/perplexity.md
+      - https://posthog.com/docs/ai-observability/installation/deepseek.md
+      - https://posthog.com/docs/ai-observability/installation/groq.md
+      - https://posthog.com/docs/ai-observability/installation/together-ai.md
+      - https://posthog.com/docs/ai-observability/installation/fireworks-ai.md
+      - https://posthog.com/docs/ai-observability/installation/xai.md
+      - https://posthog.com/docs/ai-observability/installation/cerebras.md
+      - https://posthog.com/docs/ai-observability/installation/hugging-face.md
+      - https://posthog.com/docs/ai-observability/installation/ollama.md
+      - https://posthog.com/docs/ai-observability/installation/openrouter.md
       # --- AI frameworks ---
-      - https://posthog.com/docs/llm-analytics/installation/langchain.md
-      - https://posthog.com/docs/llm-analytics/installation/llamaindex.md
-      - https://posthog.com/docs/llm-analytics/installation/crewai.md
-      - https://posthog.com/docs/llm-analytics/installation/autogen.md
-      - https://posthog.com/docs/llm-analytics/installation/dspy.md
-      - https://posthog.com/docs/llm-analytics/installation/langgraph.md
-      - https://posthog.com/docs/llm-analytics/installation/pydantic-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/vercel-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/litellm.md
-      - https://posthog.com/docs/llm-analytics/installation/instructor.md
-      - https://posthog.com/docs/llm-analytics/installation/semantic-kernel.md
-      - https://posthog.com/docs/llm-analytics/installation/mirascope.md
-      - https://posthog.com/docs/llm-analytics/installation/mastra.md
-      - https://posthog.com/docs/llm-analytics/installation/smolagents.md
-      - https://posthog.com/docs/llm-analytics/installation/openai-agents.md
+      - https://posthog.com/docs/ai-observability/installation/langchain.md
+      - https://posthog.com/docs/ai-observability/installation/llamaindex.md
+      - https://posthog.com/docs/ai-observability/installation/crewai.md
+      - https://posthog.com/docs/ai-observability/installation/autogen.md
+      - https://posthog.com/docs/ai-observability/installation/dspy.md
+      - https://posthog.com/docs/ai-observability/installation/langgraph.md
+      - https://posthog.com/docs/ai-observability/installation/pydantic-ai.md
+      - https://posthog.com/docs/ai-observability/installation/vercel-ai.md
+      - https://posthog.com/docs/ai-observability/installation/litellm.md
+      - https://posthog.com/docs/ai-observability/installation/instructor.md
+      - https://posthog.com/docs/ai-observability/installation/semantic-kernel.md
+      - https://posthog.com/docs/ai-observability/installation/mirascope.md
+      - https://posthog.com/docs/ai-observability/installation/mastra.md
+      - https://posthog.com/docs/ai-observability/installation/smolagents.md
+      - https://posthog.com/docs/ai-observability/installation/openai-agents.md
       # --- Proxy / gateway providers ---
-      - https://posthog.com/docs/llm-analytics/installation/portkey.md
-      - https://posthog.com/docs/llm-analytics/installation/helicone.md
+      - https://posthog.com/docs/ai-observability/installation/portkey.md
+      - https://posthog.com/docs/ai-observability/installation/helicone.md
       # --- Manual / generic ---
-      - https://posthog.com/docs/llm-analytics/installation/manual-capture.md
+      - https://posthog.com/docs/ai-observability/installation/manual-capture.md
 
   - id: dotnet-openai
     display_name: .NET OpenAI / Azure OpenAI (PostHog.AI)
@@ -59,5 +59,5 @@ variants:
     tags: [dotnet, aspnetcore, csharp, openai, azure-openai]
     docs_urls:
       - https://raw.githubusercontent.com/PostHog/posthog-dotnet/main/src/PostHog.AI/README.md
-      - https://posthog.com/docs/llm-analytics/installation/openai.md
-      - https://posthog.com/docs/llm-analytics/installation/azure-openai.md
+      - https://posthog.com/docs/ai-observability/installation/openai.md
+      - https://posthog.com/docs/ai-observability/installation/azure-openai.md

--- a/context/skills/omnibus/instrument-llm-analytics/config.yaml
+++ b/context/skills/omnibus/instrument-llm-analytics/config.yaml
@@ -5,51 +5,51 @@ category: llm-analytics
 description: Add PostHog LLM analytics to trace AI model usage. Use after implementing LLM features or reviewing PRs to ensure all generations are captured with token counts, latency, and costs. Also handles initial PostHog SDK setup if not yet installed.
 tags: [llm-analytics]
 shared_docs:
-  - https://posthog.com/docs/llm-analytics/basics.md
-  - https://posthog.com/docs/llm-analytics/traces.md
-  - https://posthog.com/docs/llm-analytics/calculating-costs.md
+  - https://posthog.com/docs/ai-observability/basics.md
+  - https://posthog.com/docs/ai-observability/traces.md
+  - https://posthog.com/docs/ai-observability/calculating-costs.md
 variants:
   - id: all
     display_name: all supported providers
     tags: []
     docs_urls:
       # Model providers
-      - https://posthog.com/docs/llm-analytics/installation/openai.md
-      - https://posthog.com/docs/llm-analytics/installation/azure-openai.md
+      - https://posthog.com/docs/ai-observability/installation/openai.md
+      - https://posthog.com/docs/ai-observability/installation/azure-openai.md
       # PostHog.AI / .NET OpenAI instrumentation
       - https://raw.githubusercontent.com/PostHog/posthog-dotnet/main/src/PostHog.AI/README.md
-      - https://posthog.com/docs/llm-analytics/installation/anthropic.md
-      - https://posthog.com/docs/llm-analytics/installation/google.md
-      - https://posthog.com/docs/llm-analytics/installation/cohere.md
-      - https://posthog.com/docs/llm-analytics/installation/mistral.md
-      - https://posthog.com/docs/llm-analytics/installation/perplexity.md
-      - https://posthog.com/docs/llm-analytics/installation/deepseek.md
-      - https://posthog.com/docs/llm-analytics/installation/groq.md
-      - https://posthog.com/docs/llm-analytics/installation/together-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/fireworks-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/xai.md
-      - https://posthog.com/docs/llm-analytics/installation/cerebras.md
-      - https://posthog.com/docs/llm-analytics/installation/hugging-face.md
-      - https://posthog.com/docs/llm-analytics/installation/ollama.md
-      - https://posthog.com/docs/llm-analytics/installation/openrouter.md
+      - https://posthog.com/docs/ai-observability/installation/anthropic.md
+      - https://posthog.com/docs/ai-observability/installation/google.md
+      - https://posthog.com/docs/ai-observability/installation/cohere.md
+      - https://posthog.com/docs/ai-observability/installation/mistral.md
+      - https://posthog.com/docs/ai-observability/installation/perplexity.md
+      - https://posthog.com/docs/ai-observability/installation/deepseek.md
+      - https://posthog.com/docs/ai-observability/installation/groq.md
+      - https://posthog.com/docs/ai-observability/installation/together-ai.md
+      - https://posthog.com/docs/ai-observability/installation/fireworks-ai.md
+      - https://posthog.com/docs/ai-observability/installation/xai.md
+      - https://posthog.com/docs/ai-observability/installation/cerebras.md
+      - https://posthog.com/docs/ai-observability/installation/hugging-face.md
+      - https://posthog.com/docs/ai-observability/installation/ollama.md
+      - https://posthog.com/docs/ai-observability/installation/openrouter.md
       # AI frameworks
-      - https://posthog.com/docs/llm-analytics/installation/langchain.md
-      - https://posthog.com/docs/llm-analytics/installation/llamaindex.md
-      - https://posthog.com/docs/llm-analytics/installation/crewai.md
-      - https://posthog.com/docs/llm-analytics/installation/autogen.md
-      - https://posthog.com/docs/llm-analytics/installation/dspy.md
-      - https://posthog.com/docs/llm-analytics/installation/langgraph.md
-      - https://posthog.com/docs/llm-analytics/installation/pydantic-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/vercel-ai.md
-      - https://posthog.com/docs/llm-analytics/installation/litellm.md
-      - https://posthog.com/docs/llm-analytics/installation/instructor.md
-      - https://posthog.com/docs/llm-analytics/installation/semantic-kernel.md
-      - https://posthog.com/docs/llm-analytics/installation/mirascope.md
-      - https://posthog.com/docs/llm-analytics/installation/mastra.md
-      - https://posthog.com/docs/llm-analytics/installation/smolagents.md
-      - https://posthog.com/docs/llm-analytics/installation/openai-agents.md
+      - https://posthog.com/docs/ai-observability/installation/langchain.md
+      - https://posthog.com/docs/ai-observability/installation/llamaindex.md
+      - https://posthog.com/docs/ai-observability/installation/crewai.md
+      - https://posthog.com/docs/ai-observability/installation/autogen.md
+      - https://posthog.com/docs/ai-observability/installation/dspy.md
+      - https://posthog.com/docs/ai-observability/installation/langgraph.md
+      - https://posthog.com/docs/ai-observability/installation/pydantic-ai.md
+      - https://posthog.com/docs/ai-observability/installation/vercel-ai.md
+      - https://posthog.com/docs/ai-observability/installation/litellm.md
+      - https://posthog.com/docs/ai-observability/installation/instructor.md
+      - https://posthog.com/docs/ai-observability/installation/semantic-kernel.md
+      - https://posthog.com/docs/ai-observability/installation/mirascope.md
+      - https://posthog.com/docs/ai-observability/installation/mastra.md
+      - https://posthog.com/docs/ai-observability/installation/smolagents.md
+      - https://posthog.com/docs/ai-observability/installation/openai-agents.md
       # Proxy / gateway
-      - https://posthog.com/docs/llm-analytics/installation/portkey.md
-      - https://posthog.com/docs/llm-analytics/installation/helicone.md
+      - https://posthog.com/docs/ai-observability/installation/portkey.md
+      - https://posthog.com/docs/ai-observability/installation/helicone.md
       # Manual
-      - https://posthog.com/docs/llm-analytics/installation/manual-capture.md
+      - https://posthog.com/docs/ai-observability/installation/manual-capture.md

--- a/context/skills/web-analytics/references/checks.md
+++ b/context/skills/web-analytics/references/checks.md
@@ -81,7 +81,7 @@ Define `total_project_pageviews` = sum of `pageviews` across every row returned 
 
 **Evidence:** the dark host name, total project pageviews for context, and any peer authorized hosts with healthy volume.
 
-**Remediation:** https://posthog.com/docs/web-analytics/faq
+**Remediation:** https://posthog.com/docs/web-analytics/troubleshooting
 
 ---
 
@@ -157,7 +157,7 @@ LIMIT 25
 
 **Evidence:** the path, the list of hosts, combined pageview count.
 
-**Remediation:** https://posthog.com/docs/web-analytics/faq — review `$current_url` / `$host` capture, confirm reverse proxy and canonicalization across all domains.
+**Remediation:** https://posthog.com/docs/web-analytics/troubleshooting — review `$current_url` / `$host` capture, confirm reverse proxy and canonicalization across all domains.
 
 ---
 


### PR DESCRIPTION

website PR for longer term fix: https://github.com/PostHog/posthog.com/pull/19100

Mechanical URL repointing. No behaviour change, no new code.

## Why

posthog.com moved a batch of docs pages. The `.md` endpoints these skills fetch either redirect now or 404, and `fetch` follows redirects silently — so the configs had drifted with no signal at all. I swept every posthog.com docs URL in the repo against live posthog.com and found 38 that redirect.

## What changed

| File | Change |
|---|---|
| `context/skills/llm-analytics/config.yaml` | 39 URLs `/docs/llm-analytics/*` → `/docs/ai-observability/*` |
| `context/skills/omnibus/instrument-llm-analytics/config.yaml` | 37 URLs, same swap |
| `context/skills/web-analytics/references/checks.md` | `/docs/web-analytics/faq` → `/docs/web-analytics/troubleshooting` |
| `context/skills/ai-observability/references/3-otel-setup.md` | bare relative path → full URL, plus the missing `installation/` segment |

## Content is unchanged

The old llm-analytics URLs **308 to these exact targets** — the old URL literally serves the new page — so the fetched markdown is byte-identical. Every provider in llm-analytics also exists in ai-observability, so there's no coverage gap.

The `raw.githubusercontent.com` PostHog.AI README URL is deliberately left alone.

## Not in scope

**This does not retire the `llm-analytics` skill.** It's still published to the marketplace as `posthog-llm-analytics` (`context/marketplace.yaml:27`), `wizard llm-analytics` is documented in CONTRIBUTING.md, and it holds the **only** .NET LLM path (the `PostHog.AI` README) — `ai-observability` has zero dotnet variants. The docs content is identical; the skill packages are not interchangeable. Whether the two should merge is a separate call for the marketplace/wizard owners.

## Verification

- All **259** posthog.com docs URLs in the repo now return a direct 200 with **no redirect hop** (was 38 redirects)
- `npm test` — 137 passing
- `npm run build` — clean, zero fetch failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
