### PR TITLE
feat(build): survive PostHog docs moves and report URL drift

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -113,6 +113,10 @@ jobs:
         run: pnpm run build
         env:
           BUILD_VERSION: ${{ steps.version.outputs.version }}
+          # Fail the release if any docs URL redirected. PR builds only warn —
+          # posthog.com moves docs on its own schedule — but a release must not
+          # ship content fetched from a path the config no longer names.
+          DOCS_STRICT_URLS: '1'
 
       - name: Scan skills with Warlock
         env:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,37 @@
+name: PostHog Context Mill - Check Links
+permissions:
+  contents: read
+
+# Deliberately NOT on pull_request. This makes ~270 requests to posthog.com,
+# which is slow and flaky per-PR, and a docs page moving upstream would fail
+# PRs authored by people who had nothing to do with it. A failing weekly run
+# is an actionable signal about posthog.com; a failing PR check would not be.
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: lts/*
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Fails on dead or moved fetched URLs — those break the next build.
+      # Plain redirects and prose-link problems are reported but don't fail;
+      # pass --strict to gate on those too.
+      - name: Check docs links
+        run: pnpm check-links

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,31 @@ npm install        # Install dependencies
 npm test           # vitest run (parsers, expander, plugins, cli block)
 npm run build      # Full build: emits dist/skills/<id>.zip + manifests
 npm run dev        # Partial-rebuild dev server with watch
+npm run check-links # Validate every posthog.com docs URL in the repo
 ```
+
+## Docs URLs and why they break
+
+Skills fetch `.md` docs pages from posthog.com at build time (`docs_urls` /
+`shared_docs` in `config.yaml`, `urls` in `docs.yaml`). Those `.md` files are
+**generated siblings** of the HTML pages, not views of them, and posthog.com's
+redirects are matched against literal paths — so a redirect written for
+`/docs/a/b` does not cover `/docs/a/b.md`. When a docs page moves, the HTML
+redirects and the `.md` can 404.
+
+`scripts/lib/doc-fetcher.js` handles both halves of that:
+
+- **A `.md` 404 is recovered**, not fatal — it asks the extensionless HTML route
+  where the page went and refetches the resolved `.md`, warning with the exact
+  `old → new` pair to paste into the config.
+- **Silently-followed redirects are reported.** `fetch` follows them by default,
+  so a moved doc still builds; the end-of-build `Stale doc URLs` block is what
+  stops configs drifting unnoticed. Releases set `DOCS_STRICT_URLS=1` to turn
+  that into a failure.
+- **HTML served from a `.md` URL is rejected**, so a soft 404 can't be written
+  into `references/*.md` and shipped inside a skill ZIP.
+
+Recovery is a backstop, not a fix — when you see the warning, repoint the URL.
 
 ## Repository conventions
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:skills:watch": "vitest scripts/lib/tests",
     "test": "vitest run scripts/plugins/tests scripts/lib/tests",
     "security-scan": "node scripts/scan-warlock.js",
-    "security-scan:skills": "node scripts/scan-warlock.js dist/skills"
+    "security-scan:skills": "node scripts/scan-warlock.js dist/skills",
+    "check-links": "node scripts/check-links.js"
   },
   "devDependencies": {
     "archiver": "^7.0.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,6 +12,7 @@
 import fs from 'fs';
 import path from 'path';
 import { generateAllSkills, fetchDoc } from './lib/skill-generator.js';
+import { getRedirectReport } from './lib/doc-fetcher.js';
 import { buildAgents } from './lib/agent-generator.js';
 import { generateMarketplace } from './lib/marketplace-generator.js';
 import {
@@ -36,6 +37,38 @@ async function fetchDocContent(doc) {
         }
     }
     return parts.join('\n\n---\n\n');
+}
+
+/**
+ * Report docs URLs that no longer live where the config says they do.
+ *
+ * `fetch` follows redirects by default, so a moved doc still builds fine and
+ * would otherwise leave no trace — which is how 37 llm-analytics URLs went
+ * stale unnoticed. Printing them here, in copy-pasteable `old → new` form,
+ * gives the drift somewhere to show up.
+ *
+ * PR builds only warn: posthog.com moves docs on its own schedule and that
+ * shouldn't red-X an unrelated change. Releases set DOCS_STRICT_URLS=1 so a
+ * release can't ship content fetched from somewhere the config doesn't name.
+ */
+function reportStaleDocUrls() {
+    const stale = getRedirectReport();
+    if (stale.length === 0) return;
+
+    console.log(`\nStale doc URLs (${stale.length}) — update these in context/**/config.yaml:`);
+    for (const { requested, final, via } of stale) {
+        const note = via === 'md-recovery' ? ' (recovered after a 404)' : '';
+        console.log(`  ${requested}\n    → ${final}${note}`);
+        if (process.env.GITHUB_ACTIONS) {
+            console.log(`::warning::Stale doc URL: ${requested} → ${final}`);
+        }
+    }
+
+    if (process.env.DOCS_STRICT_URLS === '1') {
+        throw new Error(
+            `${stale.length} doc URL(s) redirected and DOCS_STRICT_URLS=1 — repoint them before releasing`,
+        );
+    }
 }
 
 async function main() {
@@ -143,6 +176,8 @@ async function main() {
             ...bundleFiles,
         });
         console.log(`  ✓ skills-mcp-resources.zip (${(bundleSize / 1024).toFixed(1)} KB)`);
+
+        reportStaleDocUrls();
 
         console.log('\n' + '='.repeat(50));
         console.log('Build complete!\n');

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+/**
+ * Check Links
+ *
+ * Validates every PostHog docs URL in the repo against live posthog.com.
+ *
+ * Two classes of URL, deliberately treated differently:
+ *
+ * - **Fetched** — `docs_urls` / `shared_docs` in skill configs, and `urls` in
+ *   docs.yaml. These are pulled into skill ZIPs at build time, so a dead one is
+ *   a broken release. Failures here are blocking.
+ * - **Prose** — links in reference markdown and example-app READMEs. Nothing
+ *   fetches them, but they are what an agent reading a skill will follow, so a
+ *   dead one is still wrong. Reported, not blocking.
+ *
+ * The fetched set is read through the same expander the build uses, so the two
+ * can't drift: `shared_docs` merging (group + variation) and the
+ * string-or-{url,title} entry shape are handled in one place, not two.
+ *
+ * Usage:
+ *   node scripts/check-links.js            # report; fail only on dead fetched URLs
+ *   node scripts/check-links.js --strict   # also fail on redirects and dead prose links
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { loadDocsConfig } from './lib/build-phases.js';
+import { loadAndExpandSkills } from './lib/skill-generator.js';
+import { resolveRedirect, recoverMdUrl } from './lib/doc-fetcher.js';
+
+const CONCURRENCY = 6;
+
+// Directories worth scanning for prose links. example-apps READMEs point users
+// at library docs; context/ holds the skill prose agents actually read.
+const PROSE_ROOTS = ['context', 'example-apps', 'basics'];
+const PROSE_ROOT_FILES = ['README.md', 'CONTRIBUTING.md', 'AGENTS.md'];
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.docs-cache', '.git']);
+
+const URL_PATTERN = /https:\/\/posthog\.com\/docs[^\s"'`)\]<>]*/g;
+
+/**
+ * Collect the URLs the build actually fetches.
+ */
+function collectFetchedUrls(configDir) {
+    const urls = new Map(); // url → Set of sources
+
+    const add = (entry, source) => {
+        const url = typeof entry === 'string' ? entry : entry?.url;
+        if (!url) return;
+        if (!urls.has(url)) urls.set(url, new Set());
+        urls.get(url).add(source);
+    };
+
+    for (const doc of loadDocsConfig(configDir)) {
+        for (const url of doc.urls || []) add(url, `docs.yaml (${doc.id})`);
+    }
+
+    const { skills } = loadAndExpandSkills({ configDir });
+    for (const skill of skills) {
+        for (const entry of skill.docs_urls || []) add(entry, `${skill.id} docs_urls`);
+        for (const entry of skill._sharedDocs || []) add(entry, `${skill.id} shared_docs`);
+    }
+
+    return urls;
+}
+
+function* walkMarkdown(dir) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    for (const entry of entries) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            yield* walkMarkdown(full);
+        } else if (entry.name.endsWith('.md')) {
+            yield full;
+        }
+    }
+}
+
+/**
+ * Pull posthog.com docs URLs out of markdown, skipping fenced code blocks —
+ * a URL inside a snippet is illustrative, not a link to validate.
+ */
+function extractProseUrls(content) {
+    const found = [];
+    let inFence = false;
+    for (const line of content.split('\n')) {
+        if (/^\s*(```|~~~)/.test(line)) {
+            inFence = !inFence;
+            continue;
+        }
+        if (inFence) continue;
+        for (const match of line.matchAll(URL_PATTERN)) {
+            // Markdown sentences leave punctuation glued to the URL.
+            found.push(match[0].replace(/[.,;:!?]+$/, ''));
+        }
+    }
+    return found;
+}
+
+function collectProseUrls(repoRoot) {
+    const urls = new Map();
+    const add = (url, source) => {
+        if (!urls.has(url)) urls.set(url, new Set());
+        urls.get(url).add(source);
+    };
+
+    const files = [
+        ...PROSE_ROOTS.flatMap((root) => [...walkMarkdown(path.join(repoRoot, root))]),
+        ...PROSE_ROOT_FILES.map((f) => path.join(repoRoot, f)).filter((f) => fs.existsSync(f)),
+    ];
+
+    for (const file of files) {
+        const rel = path.relative(repoRoot, file);
+        for (const url of extractProseUrls(fs.readFileSync(file, 'utf8'))) {
+            add(url, rel);
+        }
+    }
+    return urls;
+}
+
+/**
+ * Classify one URL.
+ *
+ * MOVED-MD is the interesting verdict: the `.md` is a hard 404, but its HTML
+ * sibling redirects and reveals where the page went. That's a build break
+ * waiting to happen, and the report names the replacement URL.
+ */
+async function classify(url) {
+    // Fragments aren't part of the path posthog.com routes on.
+    const target = url.split('#')[0];
+    try {
+        const { finalUrl, status } = await resolveRedirect(target);
+        if (status === 404) {
+            const recovery = await recoverMdUrl(target).catch(() => null);
+            if (recovery) return { verdict: 'MOVED-MD', url, suggestion: recovery.candidate };
+            return { verdict: 'BROKEN', url };
+        }
+        if (status >= 400) return { verdict: 'BROKEN', url, status };
+        if (finalUrl !== target) return { verdict: 'REDIRECT', url, suggestion: finalUrl };
+        return { verdict: 'OK', url };
+    } catch (error) {
+        return { verdict: 'BROKEN', url, error: error.message };
+    }
+}
+
+/**
+ * Run `worker` over `items` with a bounded number in flight. Hand-rolled
+ * because this is the only place in the repo that needs it and the dependency
+ * list is deliberately short.
+ */
+async function pool(items, limit, worker) {
+    const results = [];
+    let cursor = 0;
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (cursor < items.length) {
+            const index = cursor++;
+            results[index] = await worker(items[index]);
+        }
+    });
+    await Promise.all(runners);
+    return results;
+}
+
+function printGroup(label, results, sources) {
+    const byVerdict = (v) => results.filter((r) => r.verdict === v);
+    const broken = byVerdict('BROKEN');
+    const moved = byVerdict('MOVED-MD');
+    const redirected = byVerdict('REDIRECT');
+
+    console.log(`\n${label}: ${results.length} URL(s) — ${byVerdict('OK').length} OK, ${redirected.length} redirect, ${moved.length} moved, ${broken.length} broken`);
+
+    const show = (title, list) => {
+        if (list.length === 0) return;
+        console.log(`\n  ${title}`);
+        for (const r of list) {
+            console.log(`    ${r.url}`);
+            if (r.suggestion) console.log(`      → ${r.suggestion}`);
+            if (r.error) console.log(`      (${r.error})`);
+            const from = [...(sources.get(r.url) ?? [])].slice(0, 3);
+            if (from.length) console.log(`      in: ${from.join(', ')}`);
+        }
+    };
+
+    show('MOVED — .md is 404 but the page redirected; repoint to:', moved);
+    show('BROKEN — no live page found:', broken);
+    show('REDIRECT — still works, but the config is stale:', redirected);
+
+    return { broken, moved, redirected };
+}
+
+async function main() {
+    const strict = process.argv.includes('--strict');
+    const repoRoot = path.join(import.meta.dirname, '..');
+    const configDir = path.join(repoRoot, 'context');
+
+    const fetched = collectFetchedUrls(configDir);
+    const proseAll = collectProseUrls(repoRoot);
+    // A URL the build fetches is already covered; don't check it twice.
+    for (const url of fetched.keys()) proseAll.delete(url);
+
+    console.log(`Checking ${fetched.size} fetched URL(s) and ${proseAll.size} prose URL(s) against posthog.com...`);
+
+    const fetchedResults = await pool([...fetched.keys()], CONCURRENCY, classify);
+    const proseResults = await pool([...proseAll.keys()], CONCURRENCY, classify);
+
+    const f = printGroup('Fetched (blocking)', fetchedResults, fetched);
+    const p = printGroup('Prose (informational)', proseResults, proseAll);
+
+    const blocking = f.broken.length + f.moved.length;
+    const strictExtra = strict
+        ? f.redirected.length + p.broken.length + p.moved.length + p.redirected.length
+        : 0;
+
+    console.log('');
+    if (blocking + strictExtra === 0) {
+        console.log('✓ All links resolve.');
+        return;
+    }
+    if (blocking > 0) {
+        console.error(`✗ ${blocking} fetched URL(s) will break the build.`);
+    }
+    if (strictExtra > 0) {
+        console.error(`✗ ${strictExtra} additional issue(s) under --strict.`);
+    }
+    process.exitCode = 1;
+}
+
+// Only run when invoked as a script — the tests import the pure helpers below,
+// and without this guard that import would kick off a few hundred live requests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(`[FATAL] check-links failed: ${error.message}`);
+        process.exitCode = 1;
+    });
+}
+
+export { extractProseUrls, classify, pool };

--- a/scripts/lib/doc-fetcher.js
+++ b/scripts/lib/doc-fetcher.js
@@ -1,0 +1,406 @@
+/**
+ * Doc Fetcher
+ *
+ * Fetches PostHog docs `.md` pages for the skill build, with an on-disk cache,
+ * retries, and recovery when a page moves.
+ *
+ * Split out of skill-generator.js so `check-links.js` can reuse the redirect
+ * resolution without loading the YAML/template machinery.
+ *
+ * ## Why the recovery path exists
+ *
+ * posthog.com serves each docs page twice: the HTML route, and a `.md` sibling
+ * generated at build time from the built HTML. They are separate files, and
+ * redirects in vercel.json are matched against literal paths — so a redirect
+ * written for `/docs/a/b` does not match `/docs/a/b.md`. When a page moves, the
+ * HTML redirects and the `.md` 404s, which used to fail the whole build.
+ *
+ * Splat-style redirects (`/docs/x/:path*`) do match the `.md` form, so some
+ * moves are followed silently by `fetch`'s default `redirect: 'follow'`. Those
+ * are recorded in the redirect report rather than warned about individually, so
+ * configs can be repointed instead of drifting indefinitely.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+// On-disk doc cache. posthog.com serves the .md docs slowly and drops
+// connections under the build's ~50-fetch burst, which used to kill the
+// whole build (and the dev server with it) on a single transient failure.
+// Entries live for DOCS_CACHE_TTL_MS (default 24h, 0 disables); an expired
+// entry is still kept as a stale fallback when every retry fails.
+const DOC_CACHE_DIR = process.env.DOCS_CACHE_DIR
+    ?? path.join(import.meta.dirname, '..', '..', '.docs-cache');
+const DOC_CACHE_TTL_MS = process.env.DOCS_CACHE_TTL_MS !== undefined
+    ? Number(process.env.DOCS_CACHE_TTL_MS)
+    : 24 * 60 * 60 * 1000;
+const FETCH_RETRIES = 3;
+const FETCH_BACKOFF_MS = [1_000, 4_000];
+
+// Bumped when the cache entry shape changes; older entries are ignored.
+const CACHE_VERSION = 2;
+
+const RECOVERABLE_HOSTS = new Set(['posthog.com', 'www.posthog.com']);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Convert a string to sentence case, preserving proper nouns
+ */
+function toSentenceCase(str) {
+    if (!str) return str;
+
+    // Proper nouns to preserve
+    const properNouns = [
+        'PostHog', 'Next.js', 'React', 'JavaScript', 'TypeScript',
+        'Node.js', 'API', 'SDK', 'SSR', 'SPA', 'URL', 'HTML', 'CSS',
+    ];
+
+    // Lowercase everything first
+    let result = str.toLowerCase();
+
+    // Capitalize first letter
+    result = result.charAt(0).toUpperCase() + result.slice(1);
+
+    // Restore proper nouns
+    for (const noun of properNouns) {
+        const regex = new RegExp(noun, 'gi');
+        result = result.replace(regex, noun);
+    }
+
+    return result;
+}
+
+/**
+ * Extract title from markdown content (first # heading)
+ */
+function extractTitle(content) {
+    const match = content.match(/^#\s+(.+)$/m);
+    return match ? toSentenceCase(match[1].trim()) : null;
+}
+
+/**
+ * Infer a description from URL path
+ * e.g., /docs/libraries/next-js → "PostHog integration documentation for Next.js"
+ */
+function inferDescription(url) {
+    try {
+        const parsed = new URL(url);
+        const pathParts = parsed.pathname.split('/').filter(Boolean);
+
+        // Remove .md extension from last part
+        const lastPart = pathParts[pathParts.length - 1]?.replace('.md', '') || '';
+
+        // Convert kebab-case to readable
+        const readable = lastPart.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+        if (pathParts.includes('libraries') || pathParts.includes('docs')) {
+            return `PostHog documentation for ${readable}`;
+        }
+
+        return `PostHog documentation: ${readable}`;
+    } catch (e) {
+        return 'PostHog documentation';
+    }
+}
+
+/**
+ * Strip the `.md` suffix to get the HTML route posthog.com redirects are
+ * written against. Returns null when the URL is not a `.md` page.
+ */
+function mdToHtmlUrl(url) {
+    try {
+        const parsed = new URL(url);
+        if (!parsed.pathname.endsWith('.md')) return null;
+        parsed.pathname = parsed.pathname.slice(0, -3);
+        return parsed.toString();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Append `.md` to an HTML route. Returns null when it already has one.
+ */
+function htmlToMdUrl(url) {
+    try {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith('.md')) return null;
+        // Trailing slashes come back from some redirect targets; the generated
+        // markdown file has no slash before its extension.
+        parsed.pathname = `${parsed.pathname.replace(/\/$/, '')}.md`;
+        return parsed.toString();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Recovery only makes sense for posthog.com, where the `.md` files are
+ * generated siblings of HTML pages. A `.md` on any other host (a GitHub raw
+ * README, say) has no extensionless twin, so probing would just waste a
+ * request on a 404 page.
+ */
+function isRecoverableHost(url) {
+    try {
+        return RECOVERABLE_HOSTS.has(new URL(url).hostname);
+    } catch {
+        return false;
+    }
+}
+
+// Redirects observed during this process, so the build can report which
+// configured URLs have drifted from where the docs actually live.
+let redirectReport = [];
+
+function recordRedirect(entry) {
+    if (entry.requested === entry.final) return;
+    if (redirectReport.some((r) => r.requested === entry.requested)) return;
+    redirectReport.push(entry);
+}
+
+function getRedirectReport() {
+    return [...redirectReport];
+}
+
+function resetRedirectReport() {
+    redirectReport = [];
+}
+
+function docCachePath(url) {
+    const key = crypto.createHash('sha256').update(url).digest('hex');
+    return path.join(DOC_CACHE_DIR, `${key}.json`);
+}
+
+function readDocCache(url) {
+    if (DOC_CACHE_TTL_MS <= 0) return null;
+    try {
+        const entry = JSON.parse(fs.readFileSync(docCachePath(url), 'utf8'));
+        if (entry?.v !== CACHE_VERSION) return null;
+        if (entry?.url !== url || typeof entry?.content !== 'string') return null;
+        return { ...entry, fresh: Date.now() - entry.fetchedAt < DOC_CACHE_TTL_MS };
+    } catch {
+        return null;
+    }
+}
+
+function writeDocCache(url, { content, title, finalUrl, via }) {
+    if (DOC_CACHE_TTL_MS <= 0) return;
+    try {
+        fs.mkdirSync(DOC_CACHE_DIR, { recursive: true });
+        fs.writeFileSync(docCachePath(url), JSON.stringify({
+            v: CACHE_VERSION,
+            url,
+            title,
+            content,
+            finalUrl: finalUrl ?? url,
+            via: via ?? 'direct',
+            fetchedAt: Date.now(),
+        }));
+    } catch {
+        // Cache writes are best-effort; the fetch result is still returned.
+    }
+}
+
+/**
+ * A `.md` URL that returns an HTML page means posthog.com served a soft 404 (or
+ * an error shell) with a 200. Writing that into references/<name>.md would ship
+ * a full HTML document inside the skill ZIP, silently — so treat it as a hard
+ * failure rather than content.
+ */
+function assertMarkdown(url, contentType, content) {
+    if (!url.endsWith('.md')) return;
+    const looksHtml = /^\s*(<!doctype html|<html)/i.test(content)
+        || (contentType ?? '').toLowerCase().startsWith('text/html');
+    if (!looksHtml) return;
+    const error = new Error(`Expected markdown from ${url} but got HTML — the page has probably moved or was deleted`);
+    error.retryable = false;
+    throw error;
+}
+
+/**
+ * Walk a redirect chain by hand, reading `Location` headers.
+ *
+ * Node exposes `Location` under `redirect: 'manual'` (browsers do not), which
+ * is what lets us discover where a moved page went instead of just landing on
+ * it. Response bodies are cancelled on every hop — undici holds the socket open
+ * otherwise, and the build issues these in bursts.
+ */
+async function resolveRedirect(url, { maxHops = 5, method = 'HEAD', fetchImpl } = {}) {
+    const doFetch = fetchImpl ?? globalThis.fetch;
+    const hops = [];
+    const seen = new Set([url]);
+    let current = url;
+
+    for (let hop = 0; hop <= maxHops; hop++) {
+        let response = await doFetch(current, { method, redirect: 'manual' });
+        // Some CDNs reject HEAD outright; fall back to GET for this hop.
+        if (response.status === 405 && method === 'HEAD') {
+            response.body?.cancel?.();
+            response = await doFetch(current, { method: 'GET', redirect: 'manual' });
+        }
+        response.body?.cancel?.();
+
+        if (!REDIRECT_STATUSES.has(response.status)) {
+            return { finalUrl: current, status: response.status, hops };
+        }
+
+        const location = response.headers?.get?.('location');
+        if (!location) {
+            return { finalUrl: current, status: response.status, hops };
+        }
+
+        const next = new URL(location, current).toString();
+        hops.push({ from: current, to: next, status: response.status });
+
+        if (seen.has(next)) {
+            throw new Error(`Redirect loop resolving ${url} (revisited ${next})`);
+        }
+        seen.add(next);
+        current = next;
+    }
+
+    throw new Error(`Too many redirects resolving ${url} (over ${maxHops} hops)`);
+}
+
+/**
+ * Given a `.md` URL that 404s, ask its HTML sibling where the page went and
+ * translate the answer back into a `.md` URL.
+ *
+ * Returns null when there is nothing to recover — the page is genuinely gone,
+ * the host has no HTML twin, or the redirect points back at the original.
+ */
+async function recoverMdUrl(url, { fetchImpl } = {}) {
+    if (!isRecoverableHost(url)) return null;
+    const htmlUrl = mdToHtmlUrl(url);
+    if (!htmlUrl) return null;
+
+    const { finalUrl, hops } = await resolveRedirect(htmlUrl, { fetchImpl });
+    if (finalUrl === htmlUrl) return null;
+
+    const candidate = htmlToMdUrl(finalUrl);
+    if (!candidate || candidate === url) return null;
+
+    return { candidate, hops };
+}
+
+async function readDoc(response, url) {
+    const content = await response.text();
+    assertMarkdown(url, response.headers?.get?.('content-type'), content);
+    return { content, title: extractTitle(content) || inferDescription(url) };
+}
+
+async function fetchDocOnce(url, { fetchImpl } = {}) {
+    const doFetch = fetchImpl ?? globalThis.fetch;
+    const response = await doFetch(url);
+
+    if (response.ok) {
+        const doc = await readDoc(response, url);
+        const finalUrl = response.url || url;
+        if (finalUrl !== url) {
+            recordRedirect({ requested: url, final: finalUrl, via: 'redirect' });
+        }
+        return { ...doc, requestedUrl: url, finalUrl, via: finalUrl === url ? 'direct' : 'redirect' };
+    }
+
+    if (response.status !== 404) {
+        const error = new Error(`Failed to fetch ${url}: HTTP ${response.status} ${response.statusText}`);
+        // Deterministic client errors won't change on retry.
+        error.retryable = response.status === 429 || response.status >= 500;
+        throw error;
+    }
+
+    // A 404 on a .md may just mean the page moved and only the HTML route got a
+    // redirect. Ask the HTML sibling before giving up.
+    let recovery = null;
+    try {
+        recovery = await recoverMdUrl(url, { fetchImpl });
+    } catch (probeError) {
+        // A network blip while probing shouldn't permanently convert a
+        // recoverable move into a hard build failure — let the retry loop try
+        // the whole recovery again.
+        const error = new Error(`Failed to fetch ${url}: HTTP 404; probing for a redirect failed: ${probeError.message}`);
+        error.retryable = true;
+        throw error;
+    }
+
+    if (recovery) {
+        const recovered = await doFetch(recovery.candidate);
+        if (recovered.ok) {
+            const doc = await readDoc(recovered, recovery.candidate);
+            recordRedirect({ requested: url, final: recovery.candidate, via: 'md-recovery' });
+            console.warn(`    WARN: doc moved, update this URL in config: ${url} → ${recovery.candidate}`);
+            return {
+                ...doc,
+                requestedUrl: url,
+                finalUrl: recovery.candidate,
+                via: 'md-recovery',
+            };
+        }
+        recovered.body?.cancel?.();
+    }
+
+    const detail = recovery
+        ? `; its HTML route redirects, but ${recovery.candidate} is not available either`
+        : '';
+    const error = new Error(`Failed to fetch ${url}: HTTP 404 ${response.statusText}${detail}`);
+    error.retryable = false;
+    throw error;
+}
+
+/**
+ * Fetch markdown content from a URL, with an on-disk cache and retries.
+ * Returns both content and inferred metadata. Logs `Fetching doc:` only
+ * on a real network fetch — cache hits are silent.
+ */
+async function fetchDoc(url, { fetchImpl, backoff = FETCH_BACKOFF_MS } = {}) {
+    const cached = readDocCache(url);
+    if (cached?.fresh) {
+        // Re-record on every hit, otherwise a URL that drifted would only be
+        // reported on the one build per day that missed the cache.
+        if (cached.finalUrl && cached.finalUrl !== url) {
+            recordRedirect({ requested: url, final: cached.finalUrl, via: cached.via ?? 'redirect' });
+        }
+        return { content: cached.content, title: cached.title, url, finalUrl: cached.finalUrl ?? url, via: cached.via ?? 'direct' };
+    }
+
+    console.log(`  Fetching doc: ${url}`);
+    let lastError;
+    for (let attempt = 1; attempt <= FETCH_RETRIES; attempt++) {
+        try {
+            const result = await fetchDocOnce(url, { fetchImpl });
+            writeDocCache(url, result);
+            return { ...result, url };
+        } catch (error) {
+            lastError = error;
+            // Network-level failures (undici "fetch failed") have no
+            // `retryable` flag — treat them as retryable.
+            if (error.retryable === false || attempt === FETCH_RETRIES) break;
+            const delay = backoff[attempt - 1] ?? backoff.at(-1) ?? 0;
+            console.log(`    retrying in ${delay / 1000}s (${error.message ?? error})`);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+    }
+
+    if (cached) {
+        const ageMinutes = Math.round((Date.now() - cached.fetchedAt) / 60_000);
+        console.warn(`    WARN: using stale cached copy (${ageMinutes}m old) after fetch failure: ${url}`);
+        return { content: cached.content, title: cached.title, url, finalUrl: cached.finalUrl ?? url, via: cached.via ?? 'direct' };
+    }
+    throw lastError;
+}
+
+export {
+    fetchDoc,
+    fetchDocOnce,
+    resolveRedirect,
+    recoverMdUrl,
+    mdToHtmlUrl,
+    htmlToMdUrl,
+    isRecoverableHost,
+    getRedirectReport,
+    resetRedirectReport,
+    extractTitle,
+    inferDescription,
+    toSentenceCase,
+};

--- a/scripts/lib/skill-generator.js
+++ b/scripts/lib/skill-generator.js
@@ -38,11 +38,11 @@
 
 import fs from 'fs';
 import path from 'path';
-import crypto from 'crypto';
 import yaml from 'js-yaml';
 import matter from 'gray-matter';
 import { processExample, loadSkipPatterns, mergeSkipPatterns, defaultPlugins } from './example-processor.js';
 import { CLI_ROLES, validateCommandName } from './cli-block-validation.js';
+import { fetchDoc } from './doc-fetcher.js';
 
 /**
  * Load YAML config file
@@ -364,154 +364,6 @@ function urlToFilename(url) {
     } catch (e) {
         return 'doc.md';
     }
-}
-
-/**
- * Convert a string to sentence case, preserving proper nouns
- */
-function toSentenceCase(str) {
-    if (!str) return str;
-
-    // Proper nouns to preserve
-    const properNouns = [
-        'PostHog', 'Next.js', 'React', 'JavaScript', 'TypeScript',
-        'Node.js', 'API', 'SDK', 'SSR', 'SPA', 'URL', 'HTML', 'CSS',
-    ];
-
-    // Lowercase everything first
-    let result = str.toLowerCase();
-
-    // Capitalize first letter
-    result = result.charAt(0).toUpperCase() + result.slice(1);
-
-    // Restore proper nouns
-    for (const noun of properNouns) {
-        const regex = new RegExp(noun, 'gi');
-        result = result.replace(regex, noun);
-    }
-
-    return result;
-}
-
-/**
- * Extract title from markdown content (first # heading)
- */
-function extractTitle(content) {
-    const match = content.match(/^#\s+(.+)$/m);
-    return match ? toSentenceCase(match[1].trim()) : null;
-}
-
-/**
- * Infer a description from URL path
- * e.g., /docs/libraries/next-js → "PostHog integration documentation for Next.js"
- */
-function inferDescription(url) {
-    try {
-        const parsed = new URL(url);
-        const pathParts = parsed.pathname.split('/').filter(Boolean);
-
-        // Remove .md extension from last part
-        const lastPart = pathParts[pathParts.length - 1]?.replace('.md', '') || '';
-
-        // Convert kebab-case to readable
-        const readable = lastPart.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-
-        if (pathParts.includes('libraries') || pathParts.includes('docs')) {
-            return `PostHog documentation for ${readable}`;
-        }
-
-        return `PostHog documentation: ${readable}`;
-    } catch (e) {
-        return 'PostHog documentation';
-    }
-}
-
-// On-disk doc cache. posthog.com serves the .md docs slowly and drops
-// connections under the build's ~50-fetch burst, which used to kill the
-// whole build (and the dev server with it) on a single transient failure.
-// Entries live for DOCS_CACHE_TTL_MS (default 24h, 0 disables); an expired
-// entry is still kept as a stale fallback when every retry fails.
-const DOC_CACHE_DIR = path.join(import.meta.dirname, '..', '..', '.docs-cache');
-const DOC_CACHE_TTL_MS = process.env.DOCS_CACHE_TTL_MS !== undefined
-    ? Number(process.env.DOCS_CACHE_TTL_MS)
-    : 24 * 60 * 60 * 1000;
-const FETCH_RETRIES = 3;
-const FETCH_BACKOFF_MS = [1_000, 4_000];
-
-function docCachePath(url) {
-    const key = crypto.createHash('sha256').update(url).digest('hex');
-    return path.join(DOC_CACHE_DIR, `${key}.json`);
-}
-
-function readDocCache(url) {
-    if (DOC_CACHE_TTL_MS <= 0) return null;
-    try {
-        const entry = JSON.parse(fs.readFileSync(docCachePath(url), 'utf8'));
-        if (entry?.url !== url || typeof entry?.content !== 'string') return null;
-        return { ...entry, fresh: Date.now() - entry.fetchedAt < DOC_CACHE_TTL_MS };
-    } catch {
-        return null;
-    }
-}
-
-function writeDocCache(url, { content, title }) {
-    if (DOC_CACHE_TTL_MS <= 0) return;
-    try {
-        fs.mkdirSync(DOC_CACHE_DIR, { recursive: true });
-        fs.writeFileSync(docCachePath(url), JSON.stringify({ url, title, content, fetchedAt: Date.now() }));
-    } catch {
-        // Cache writes are best-effort; the fetch result is still returned.
-    }
-}
-
-async function fetchDocOnce(url) {
-    const response = await fetch(url);
-    if (!response.ok) {
-        const error = new Error(`Failed to fetch ${url}: HTTP ${response.status} ${response.statusText}`);
-        // Deterministic client errors (404 etc.) won't change on retry.
-        error.retryable = response.status === 429 || response.status >= 500;
-        throw error;
-    }
-    const content = await response.text();
-    const title = extractTitle(content) || inferDescription(url);
-    return { content, title };
-}
-
-/**
- * Fetch markdown content from a URL, with an on-disk cache and retries.
- * Returns both content and inferred metadata. Logs `Fetching doc:` only
- * on a real network fetch — cache hits are silent.
- */
-async function fetchDoc(url) {
-    const cached = readDocCache(url);
-    if (cached?.fresh) {
-        return { content: cached.content, title: cached.title };
-    }
-
-    console.log(`  Fetching doc: ${url}`);
-    let lastError;
-    for (let attempt = 1; attempt <= FETCH_RETRIES; attempt++) {
-        try {
-            const result = await fetchDocOnce(url);
-            writeDocCache(url, result);
-            return result;
-        } catch (error) {
-            lastError = error;
-            // Network-level failures (undici "fetch failed") have no
-            // `retryable` flag — treat them as retryable.
-            if (error.retryable === false || attempt === FETCH_RETRIES) break;
-            const delay = FETCH_BACKOFF_MS[attempt - 1] ?? FETCH_BACKOFF_MS.at(-1);
-            console.log(`    retrying in ${delay / 1000}s (${error.message ?? error})`);
-            await new Promise((resolve) => setTimeout(resolve, delay));
-        }
-    }
-
-    if (cached) {
-        const ageMinutes = Math.round((Date.now() - cached.fetchedAt) / 60_000);
-        console.warn(`    WARN: using stale cached copy (${ageMinutes}m old) after fetch failure: ${url}`);
-        return { content: cached.content, title: cached.title };
-    }
-    throw lastError;
 }
 
 /**

--- a/scripts/lib/tests/check-links.test.js
+++ b/scripts/lib/tests/check-links.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { extractProseUrls, pool } from '../../check-links.js';
+
+describe('extractProseUrls', () => {
+    it('finds bare and markdown-linked URLs', () => {
+        const md = [
+            'See https://posthog.com/docs/libraries/next-js for setup.',
+            'Or read [the guide](https://posthog.com/docs/product-analytics/autocapture).',
+        ].join('\n');
+
+        expect(extractProseUrls(md)).toEqual([
+            'https://posthog.com/docs/libraries/next-js',
+            'https://posthog.com/docs/product-analytics/autocapture',
+        ]);
+    });
+
+    it('strips trailing sentence punctuation but keeps anchors', () => {
+        const md = 'Read https://posthog.com/docs/libraries/react-native#autocapture, then stop.';
+        expect(extractProseUrls(md)).toEqual([
+            'https://posthog.com/docs/libraries/react-native#autocapture',
+        ]);
+    });
+
+    it('ignores URLs inside fenced code blocks', () => {
+        // A URL in a snippet is something the agent writes into the user's
+        // code, not a link we are asserting is live.
+        const md = [
+            'Real link: https://posthog.com/docs/a',
+            '```bash',
+            'curl https://posthog.com/docs/not-a-real-link',
+            '```',
+            'Another: https://posthog.com/docs/b',
+        ].join('\n');
+
+        expect(extractProseUrls(md)).toEqual([
+            'https://posthog.com/docs/a',
+            'https://posthog.com/docs/b',
+        ]);
+    });
+
+    it('handles tilde fences and unclosed fences', () => {
+        const md = [
+            '~~~js',
+            'const u = "https://posthog.com/docs/inside"',
+            '~~~',
+            'https://posthog.com/docs/outside',
+        ].join('\n');
+
+        expect(extractProseUrls(md)).toEqual(['https://posthog.com/docs/outside']);
+    });
+
+    it('ignores non-posthog docs URLs', () => {
+        const md = 'See https://nextjs.org/docs/app and https://posthog.com/docs/a';
+        expect(extractProseUrls(md)).toEqual(['https://posthog.com/docs/a']);
+    });
+
+    it('returns nothing for markdown with no docs links', () => {
+        expect(extractProseUrls('# Title\n\nJust prose.')).toEqual([]);
+    });
+});
+
+describe('pool', () => {
+    it('preserves input order regardless of completion order', async () => {
+        const delays = [30, 0, 15, 5];
+        const results = await pool(delays, 2, async (ms) => {
+            await new Promise((r) => setTimeout(r, ms));
+            return ms;
+        });
+        expect(results).toEqual(delays);
+    });
+
+    it('never exceeds the concurrency limit', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        await pool([...Array(20).keys()], 3, async (n) => {
+            inFlight++;
+            peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 1));
+            inFlight--;
+            return n;
+        });
+        expect(peak).toBeLessThanOrEqual(3);
+    });
+
+    it('handles an empty input list', async () => {
+        expect(await pool([], 4, async (x) => x)).toEqual([]);
+    });
+});

--- a/scripts/lib/tests/doc-fetcher.test.js
+++ b/scripts/lib/tests/doc-fetcher.test.js
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import crypto from 'crypto';
+
+// doc-fetcher reads DOCS_CACHE_DIR / DOCS_CACHE_TTL_MS at module load, so the
+// module is imported fresh per test with the env already pointed at a temp dir.
+// Without this the suite would read and write the real .docs-cache/.
+let tmpCache;
+let fetcher;
+
+async function loadFetcher({ ttlMs = 60_000 } = {}) {
+    process.env.DOCS_CACHE_DIR = tmpCache;
+    process.env.DOCS_CACHE_TTL_MS = String(ttlMs);
+    vi.resetModules();
+    return import('../doc-fetcher.js');
+}
+
+/** Minimal stand-in for a fetch Response. */
+function res({ status = 200, body = '', headers = {}, url } = {}) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: '',
+        url,
+        headers: new Headers(headers),
+        body: { cancel: () => {} },
+        text: async () => body,
+    };
+}
+
+const MD = '# Some doc\n\nBody text.';
+
+/** Route table fake. Values may be a response or a fn(url, opts). */
+function fakeFetch(routes) {
+    return vi.fn(async (url, opts) => {
+        const route = routes[url];
+        if (!route) return res({ status: 404, url });
+        return typeof route === 'function' ? route(url, opts) : route;
+    });
+}
+
+function cacheFileFor(url) {
+    return join(tmpCache, `${crypto.createHash('sha256').update(url).digest('hex')}.json`);
+}
+
+beforeEach(async () => {
+    tmpCache = mkdtempSync(join(tmpdir(), 'doc-cache-'));
+    fetcher = await loadFetcher();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    rmSync(tmpCache, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.DOCS_CACHE_DIR;
+    delete process.env.DOCS_CACHE_TTL_MS;
+});
+
+describe('url helpers', () => {
+    it('converts between .md and html forms', () => {
+        const { mdToHtmlUrl, htmlToMdUrl } = fetcher;
+        expect(mdToHtmlUrl('https://posthog.com/docs/a/b.md')).toBe('https://posthog.com/docs/a/b');
+        expect(mdToHtmlUrl('https://posthog.com/docs/a/b')).toBeNull();
+        expect(htmlToMdUrl('https://posthog.com/docs/a/b')).toBe('https://posthog.com/docs/a/b.md');
+        expect(htmlToMdUrl('https://posthog.com/docs/a/b.md')).toBeNull();
+    });
+
+    it('appends .md after stripping a trailing slash', () => {
+        // Redirect targets often come back with a trailing slash; the generated
+        // markdown file has no slash before its extension.
+        expect(fetcher.htmlToMdUrl('https://posthog.com/docs/a/b/')).toBe('https://posthog.com/docs/a/b.md');
+    });
+
+    it('only treats posthog.com as recoverable', () => {
+        const { isRecoverableHost } = fetcher;
+        expect(isRecoverableHost('https://posthog.com/docs/a.md')).toBe(true);
+        expect(isRecoverableHost('https://www.posthog.com/docs/a.md')).toBe(true);
+        expect(isRecoverableHost('https://raw.githubusercontent.com/x/README.md')).toBe(false);
+    });
+});
+
+describe('fetchDoc — happy path', () => {
+    it('returns content and title, and caches under the requested URL', async () => {
+        const url = 'https://posthog.com/docs/a.md';
+        vi.stubGlobal('fetch', fakeFetch({ [url]: res({ body: MD, url }) }));
+
+        const result = await fetcher.fetchDoc(url);
+
+        expect(result.content).toBe(MD);
+        expect(result.title).toBe('Some doc');
+        expect(result.via).toBe('direct');
+        expect(fetcher.getRedirectReport()).toEqual([]);
+        expect(readdirSync(tmpCache)).toHaveLength(1);
+        expect(JSON.parse(readFileSync(cacheFileFor(url), 'utf8')).url).toBe(url);
+    });
+
+    it('records a silently-followed redirect as drift', async () => {
+        // This is the llm-analytics case: fetch follows the 308 itself and the
+        // build succeeds, so without this report the config never gets fixed.
+        const url = 'https://posthog.com/docs/llm-analytics/basics.md';
+        const final = 'https://posthog.com/docs/ai-observability/basics.md';
+        vi.stubGlobal('fetch', fakeFetch({ [url]: res({ body: MD, url: final }) }));
+
+        const result = await fetcher.fetchDoc(url);
+
+        expect(result.via).toBe('redirect');
+        expect(fetcher.getRedirectReport()).toEqual([
+            { requested: url, final, via: 'redirect' },
+        ]);
+        // Cached under the requested URL, not the resolved one — the lookup
+        // side only ever knows what the config says.
+        expect(JSON.parse(readFileSync(cacheFileFor(url), 'utf8')).finalUrl).toBe(final);
+    });
+
+    it('re-reports drift on a cache hit', async () => {
+        const url = 'https://posthog.com/docs/llm-analytics/basics.md';
+        const final = 'https://posthog.com/docs/ai-observability/basics.md';
+        const fetchMock = fakeFetch({ [url]: res({ body: MD, url: final }) });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await fetcher.fetchDoc(url);
+        fetcher.resetRedirectReport();
+        await fetcher.fetchDoc(url);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetcher.getRedirectReport()).toEqual([
+            { requested: url, final, via: 'redirect' },
+        ]);
+    });
+});
+
+describe('fetchDoc — .md 404 recovery', () => {
+    it('recovers via the HTML sibling redirect', async () => {
+        // The real /docs/logs/debug-logs-mcp.md case.
+        const dead = 'https://posthog.com/docs/logs/debug-logs-mcp.md';
+        const html = 'https://posthog.com/docs/logs/debug-logs-mcp';
+        const movedHtml = 'https://posthog.com/docs/logs/surfaces/mcp';
+        const live = 'https://posthog.com/docs/logs/surfaces/mcp.md';
+
+        const fetchMock = fakeFetch({
+            [dead]: res({ status: 404, url: dead }),
+            [html]: res({ status: 301, headers: { location: movedHtml }, url: html }),
+            [movedHtml]: res({ status: 200, url: movedHtml }),
+            [live]: res({ body: MD, url: live }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await fetcher.fetchDoc(dead);
+
+        expect(result.content).toBe(MD);
+        expect(result.via).toBe('md-recovery');
+        expect(result.finalUrl).toBe(live);
+        expect(fetcher.getRedirectReport()).toEqual([
+            { requested: dead, final: live, via: 'md-recovery' },
+        ]);
+        // The probe must not follow redirects itself — reading Location is the
+        // whole point.
+        const probeCall = fetchMock.mock.calls.find(([u]) => u === html);
+        expect(probeCall[1]).toMatchObject({ redirect: 'manual' });
+    });
+
+    it('throws naming both URLs when the recovered page is also missing', async () => {
+        const dead = 'https://posthog.com/docs/a.md';
+        const html = 'https://posthog.com/docs/a';
+        const movedHtml = 'https://posthog.com/docs/b';
+
+        vi.stubGlobal('fetch', fakeFetch({
+            [dead]: res({ status: 404, url: dead }),
+            [html]: res({ status: 301, headers: { location: movedHtml }, url: html }),
+            [movedHtml]: res({ status: 200, url: movedHtml }),
+            // https://posthog.com/docs/b.md is absent → 404 from the fake
+        }));
+
+        await expect(fetcher.fetchDoc(dead)).rejects.toThrow(/docs\/b\.md is not available/);
+        expect(readdirSync(tmpCache)).toHaveLength(0);
+    });
+
+    it('gives up when the HTML sibling does not redirect', async () => {
+        const dead = 'https://posthog.com/docs/gone.md';
+        vi.stubGlobal('fetch', fakeFetch({
+            [dead]: res({ status: 404, url: dead }),
+            'https://posthog.com/docs/gone': res({ status: 404, url: 'https://posthog.com/docs/gone' }),
+        }));
+
+        await expect(fetcher.fetchDoc(dead)).rejects.toThrow(/HTTP 404/);
+    });
+
+    it('does not probe non-posthog hosts', async () => {
+        const url = 'https://raw.githubusercontent.com/PostHog/x/main/README.md';
+        const fetchMock = fakeFetch({ [url]: res({ status: 404, url }) });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetcher.fetchDoc(url)).rejects.toThrow(/HTTP 404/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries when the probe itself fails at the network level', async () => {
+        // One flaky probe must not permanently turn a recoverable move into a
+        // hard build failure.
+        const dead = 'https://posthog.com/docs/a.md';
+        const html = 'https://posthog.com/docs/a';
+        let probeAttempts = 0;
+
+        vi.stubGlobal('fetch', fakeFetch({
+            [dead]: res({ status: 404, url: dead }),
+            [html]: () => {
+                probeAttempts++;
+                if (probeAttempts === 1) throw new TypeError('fetch failed');
+                return res({ status: 301, headers: { location: 'https://posthog.com/docs/c' }, url: html });
+            },
+            'https://posthog.com/docs/c': res({ status: 200 }),
+            'https://posthog.com/docs/c.md': res({ body: MD }),
+        }));
+
+        const result = await fetcher.fetchDoc(dead, { backoff: [0, 0] });
+
+        expect(probeAttempts).toBe(2);
+        expect(result.via).toBe('md-recovery');
+    });
+});
+
+describe('resolveRedirect safety', () => {
+    it('throws on a redirect cycle', async () => {
+        const a = 'https://posthog.com/docs/a';
+        const b = 'https://posthog.com/docs/b';
+        vi.stubGlobal('fetch', fakeFetch({
+            [a]: res({ status: 301, headers: { location: b }, url: a }),
+            [b]: res({ status: 301, headers: { location: a }, url: b }),
+        }));
+
+        await expect(fetcher.resolveRedirect(a)).rejects.toThrow(/Redirect loop/);
+    });
+
+    it('throws when the chain exceeds maxHops', async () => {
+        vi.stubGlobal('fetch', vi.fn(async (url) => {
+            const n = Number(new URL(url).pathname.split('/').pop());
+            return res({ status: 301, headers: { location: `https://posthog.com/docs/${n + 1}` }, url });
+        }));
+
+        await expect(
+            fetcher.resolveRedirect('https://posthog.com/docs/0', { maxHops: 3 }),
+        ).rejects.toThrow(/Too many redirects/);
+    });
+
+    it('returns null recovery when the redirect points back at the same doc', async () => {
+        const dead = 'https://posthog.com/docs/a.md';
+        const html = 'https://posthog.com/docs/a';
+        vi.stubGlobal('fetch', fakeFetch({
+            [dead]: res({ status: 404, url: dead }),
+            // /docs/a → /docs/a/ → back to the same .md candidate
+            [html]: res({ status: 301, headers: { location: 'https://posthog.com/docs/a/' }, url: html }),
+            'https://posthog.com/docs/a/': res({ status: 200 }),
+        }));
+
+        await expect(fetcher.recoverMdUrl(dead)).resolves.toBeNull();
+    });
+});
+
+describe('content guard', () => {
+    it('rejects HTML served from a .md URL and caches nothing', async () => {
+        // A soft 404 (200 + HTML shell) would otherwise be written into
+        // references/<name>.md and shipped inside the skill ZIP.
+        const url = 'https://posthog.com/docs/a.md';
+        vi.stubGlobal('fetch', fakeFetch({
+            [url]: res({ body: '<!DOCTYPE html><html><body>Not found</body></html>', url }),
+        }));
+
+        await expect(fetcher.fetchDoc(url)).rejects.toThrow(/Expected markdown/);
+        expect(readdirSync(tmpCache)).toHaveLength(0);
+    });
+
+    it('rejects on content-type alone', async () => {
+        const url = 'https://posthog.com/docs/a.md';
+        vi.stubGlobal('fetch', fakeFetch({
+            [url]: res({ body: 'plain text', headers: { 'content-type': 'text/html; charset=utf-8' }, url }),
+        }));
+
+        await expect(fetcher.fetchDoc(url)).rejects.toThrow(/Expected markdown/);
+    });
+});
+
+describe('retries and stale-cache fallback', () => {
+    it('retries a 500 and then falls back to an expired cache entry', async () => {
+        const url = 'https://posthog.com/docs/a.md';
+        // TTL of 1ms means the entry written below is already stale.
+        fetcher = await loadFetcher({ ttlMs: 1 });
+        writeFileSync(cacheFileFor(url), JSON.stringify({
+            v: 2, url, title: 'Cached', content: '# Cached', finalUrl: url, via: 'direct',
+            fetchedAt: Date.now() - 60_000,
+        }));
+
+        const fetchMock = fakeFetch({ [url]: res({ status: 500, url }) });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await fetcher.fetchDoc(url, { backoff: [0, 0] });
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(result.content).toBe('# Cached');
+    });
+
+    it('ignores cache entries from an older schema version', async () => {
+        const url = 'https://posthog.com/docs/a.md';
+        writeFileSync(cacheFileFor(url), JSON.stringify({
+            url, title: 'Old', content: '# Old', fetchedAt: Date.now(),
+        }));
+
+        vi.stubGlobal('fetch', fakeFetch({ [url]: res({ body: MD, url }) }));
+        const result = await fetcher.fetchDoc(url);
+
+        expect(result.content).toBe(MD);
+    });
+});


### PR DESCRIPTION
**Stack 2/2** — base is #296, review that first. This PR's diff is only the second commit.

website PR for longer term fix: https://github.com/PostHog/posthog.com/pull/19100

## The problem, and the thing that isn't the problem

"context-mill doesn't follow 301s" turns out to be false — `fetchDocOnce` calls bare `fetch(url)`, and `redirect: 'follow'` is already the default. Following redirects harder fixes nothing.

posthog.com serves each docs page **twice**: the HTML route, and a `.md` sibling generated from the built HTML (`gatsby/rawMarkdownUtils.ts`). They're separate files, and redirects are matched against **literal paths** — so a redirect written for `/docs/a/b` never matches `/docs/a/b.md`.

Verified live:

| URL | Result |
|---|---|
| `/docs/logs/debug-logs-mcp.md` | **404, no redirect** |
| `/docs/logs/debug-logs-mcp` | 301 → `/docs/logs/surfaces/mcp` |
| `/docs/logs/surfaces/mcp.md` | 200 |

So when a `.md` 404s, the extensionless sibling still knows where the page went — the build just never asks. That's what broke on the Logs IA migration.

The inverse is just as bad: splat redirects (`/docs/x/:path*`) **do** match `.md`, so those resolve silently and configs drift with no signal. That's how the 37 URLs in #296 went stale unnoticed.

## What this adds

Extracts the fetcher into `scripts/lib/doc-fetcher.js` (so the link checker can reuse redirect resolution without loading the YAML/template machinery), then:

- **`.md`-404 recovery** — probes the extensionless HTML route, follows the redirect, refetches the resolved `.md`. Warns with the exact `old → new` pair. Only probes posthog.com, so the `raw.githubusercontent.com` URL is untouched. A network blip while probing stays *retryable* rather than becoming a hard failure.
- **Drift reporting** — an end-of-build `Stale doc URLs` block, re-recorded on cache hits so it doesn't disappear for 23 hours a day. Warns on PRs; `DOCS_STRICT_URLS=1` (set on release builds only) makes it fail.
- **Content guard** — HTML served from a `.md` URL now throws. Without this a soft 404 (200 + HTML shell) gets written into `references/<name>.md` and shipped inside a skill ZIP, silently. **This is the line I'd most want kept.**
- **Cache v2** — entries gain `finalUrl`/`via`, still keyed on the *requested* URL so a moved doc isn't a permanent cache miss. One cold build to reheat.
- **`npm run check-links`** — validates the 202 fetched URLs *and* the 63 prose links in reference markdown / example-app READMEs that nothing validated before. Reads the fetched set through the same expander the build uses, so the two can't drift.

## Why the link checker isn't a PR check

It makes ~270 requests to posthog.com. Per-PR that's slow and flaky, and an upstream docs move would red-X PRs authored by people who had nothing to do with it. Weekly + `workflow_dispatch` instead — a failing weekly run is an actionable signal about posthog.com.

## Verification

- **164 tests** passing (27 new, covering recovery, cycles, hop limits, cache keying, the HTML guard, non-posthog hosts, retries)
- Recovery proven against the real dead URL: injecting `debug-logs-mcp.md` warns `→ /docs/logs/surfaces/mcp.md` and the build **succeeds**
- `DOCS_STRICT_URLS=1` exits 1 with drifted URLs, 0 on a clean tree
- `npm run check-links` — 202 fetched + 63 prose, all OK

## This is a backstop, not the fix

The real fix belongs in posthog.com. I measured all 551 literal `/docs/` redirects there: **507 are currently 404 at `.md`** (92%). The 40 that work are incidentally covered by a splat. I've written that up separately for the website team — including two incidental bugs (a stale redirect pointing at a deleted page, and the `Accept: text/markdown` rewrites that have never fired because Vercel gives the filesystem precedence over rewrites).

Until that lands, this keeps builds green and makes drift visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
