### PR TITLE
fix(docs): Update PostHog MCP URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repo packages PostHog's developer content (docs, prompts, example code)
 into [Agent Skills](https://agentskills.io/specification)-compliant skill
 packages. The build pipeline emits a versioned manifest plus per-skill ZIPs,
 consumed by the PostHog [wizard](https://github.com/PostHog/wizard) and the
-PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp).
+PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp).
 
 User-facing intro: [README.md](README.md). Contributor handbook:
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We'd love your pull request!
 
 The context mill gathers up-to-date content from multiple sources, packaging PostHog developer docs, prompts, and working example code into a versioned manifest which can be shipped anywhere as a zip file. 
 
-The [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp) currently fetches the examples repo manifest and exposes it to any MCP-compatible client as resources and slash commands. This is what currently powers the PostHog [wizard](https://github.com/PostHog/wizard). 
+The [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp) currently fetches the examples repo manifest and exposes it to any MCP-compatible client as resources and slash commands. This is what currently powers the PostHog [wizard](https://github.com/PostHog/wizard). 
 
 ## Context engine 
 


### PR DESCRIPTION
Updates the URL to the PostHog MCP.

Before (bad):
<img width="2256" height="638" alt="CleanShot 2026-07-29 at 22 21 32@2x" src="https://github.com/user-attachments/assets/4044ce20-b2cf-4964-bbeb-06fd86912871" />


After (good):
<img width="2256" height="638" alt="CleanShot 2026-07-29 at 22 21 44@2x" src="https://github.com/user-attachments/assets/e0eacf7a-8254-44ef-a32b-b04018f2854c" />
