### PR TITLE
fix(wizard): Whack a mole part 8: exec-unavailable falls back to a subagent, never credentialed shell

### DIFF
--- a/context/shared/mcp-tool-calling.md
+++ b/context/shared/mcp-tool-calling.md
@@ -20,3 +20,5 @@ Running `info <tool_name>` before `call <tool_name>` is mandatory, the same way 
 Every PostHog tool goes through `exec` this way — there is no separate named tool to call directly. The inner tool names and JSON payloads below are what you pass to `call`.
 
 **Errors** carry a suggestion and similar tool names — read it before retrying. If a name isn't found it may have been renamed; run `search <pattern>` or `tools` again to find the current one.
+
+**If the exec tool is unavailable or a call is refused by the permission layer**: delegate the MCP work to a general-purpose subagent via the Agent tool (subagents have the PostHog MCP mounted), and if that also fails, skip the artifact and say so in your summary. Never fall back to the REST API from the shell — never put an API key, bearer token, or other credential into a shell command, a source file, or `.env`; the security scanner blocks these and the attempt wastes the run.


### PR DESCRIPTION
State the fallback order in the shared `mcp-tool-calling` partial (inherited by every skill that calls PostHog tools): exec unavailable → delegate to a general-purpose subagent → skip the artifact and say so. Never the REST API with a credential in shell, source, or `.env`.

```
Before: exec refused → agent improvises `curl -H "Authorization: Bearer <secret>" …`
        → warlock: exfiltration_secret_via_shell, critical, blocked ×3 in one run (7cee73c4),
          then tries hardcoding a Personal API Key (reverted)
After:  exec refused → Agent-tool subagent runs the MCP call (subagents mount the PostHog MCP);
        if that fails too, the artifact is skipped and reported — no credential ever leaves the env
```

Companion to wizard [#1038](https://github.com/PostHog/wizard/pull/1038) (whack-a-mole 7), which fixes the underlying gate so exec is reachable from the main loop in the first place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*