### PR TITLE
feat(logs): add a logs-setup skill that correlates records to people and sessions

### DIFF
--- a/context/skills/logs-setup/config.yaml
+++ b/context/skills/logs-setup/config.yaml
@@ -1,0 +1,37 @@
+# PostHog Logs setup — installs the OTLP log export and correlates each record to
+# the session replay and person that produced it.
+#
+# Distinct from the `logs` skill group, which is docs-only reference material.
+# This one is a 7 step chain that edits the project.
+#
+# Reachable via `wizard skill logs-setup-<variant>`; the wizard also registers a
+# native `wizard logs` command that drives it.
+type: skill
+template: description.md
+category: logs-setup
+description: Set up PostHog Logs in an existing codebase and correlate each log record to the session replay and person that produced it. Additive — existing logging keeps working unchanged.
+tags: [logs]
+cli:
+  role: skill
+references:
+  preamble: "**Read ONLY this file.** Do not read any other reference file until this one tells you to."
+shared_docs:
+  - https://posthog.com/docs/logs/start-here.md
+  - https://posthog.com/docs/logs/link-session-replay.md
+  - https://posthog.com/docs/logs/link-person.md
+  - https://posthog.com/docs/logs/best-practices.md
+  - https://posthog.com/docs/logs/troubleshooting.md
+  - https://posthog.com/docs/logs/search.md
+variants:
+  - id: nextjs
+    display_name: Next.js
+    default: true
+    tags: [nextjs, javascript]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/nextjs.md
+
+  - id: python
+    display_name: Python
+    tags: [python]
+    docs_urls:
+      - https://posthog.com/docs/logs/installation/python.md

--- a/context/skills/logs-setup/description.md
+++ b/context/skills/logs-setup/description.md
@@ -1,0 +1,97 @@
+# PostHog Logs — {display_name}
+
+This skill sends this project's logs to PostHog and, more importantly, correlates them. A correlated log record carries the `posthogDistinctId` and `sessionId` of the request that produced it, so a log line in PostHog links back to the person who caused it and to the session replay of them causing it.
+
+Getting logs to arrive is table stakes and the installation docs already cover it. Correlation is the part that needs to read this codebase, and it is the reason this skill exists.
+
+## Workflow
+
+The setup runs as a 7 step chain.
+
+1. Detect the runtimes, the existing logging, and the PostHog SDKs already present (`references/1-detect.md`).
+2. Install the OTLP log export alongside the existing logging (`references/2-install.md`).
+3. Decide how far correlation can go in this codebase and persist the plan to `.posthog-logs-plan.md` (`references/3-plan.md`).
+4. Establish a request scoped identity context (`references/4-context.md`).
+5. Attach the identity to every log record from one place (`references/5-attach.md`).
+6. Verify the project still builds and a correlated record actually arrives (`references/6-verify.md`).
+7. Write the report and delete the plan file (`references/7-report.md`).
+
+Each step file points to the next via `next_step` frontmatter. Read them in order, one at a time. Do not preload future steps. Do not re-read a step file once you have moved past it.
+
+## Task list
+
+**Before you do anything else**, make a single call to `TaskCreate` to seed the task pane with the seven items above (one per step, in order). Use broad, job-oriented titles like "Detect logging setup", "Install log export", "Plan correlation", etc. The user is watching the pane and shouldn't see it sit empty.
+
+Then, and only then, read `references/1-detect.md` and start the chain.
+
+It's fine if your first list is imprecise. Call `TaskCreate` again (or `TaskUpdate` to refine existing items) every time your understanding sharpens. Use `TaskUpdate` to mark items `in_progress` when you start them and `completed` when you finish. Keeping the list current matters more than getting it right on the first call.
+
+## Correlation tiers
+
+Correlation is not all or nothing. Every project lands on one of these tiers, and the honest outcome is to reach the best tier this codebase supports and then say so.
+
+- **`session`** — the record carries both `posthogDistinctId` and `sessionId`. A log line links to the person and opens the session replay. This is the goal.
+- **`person`** — the record carries `posthogDistinctId` only. Logs appear on the person's profile, but there is no replay to open. This is the correct outcome when the project has no browser client, or when session replay is off.
+- **`none`** — no identity is reachable at log time. The logs still arrive and are still searchable, they just aren't linked to anyone.
+
+A lower tier reached deliberately and reported clearly is a good outcome. Wiring that looks like `session` but silently attaches nothing is not. Never invent an identifier to reach a higher tier.
+
+## Client side logs are already correlated
+
+If this project calls `posthog.captureLog` or `posthog.logger.*` from the JavaScript web SDK or the React Native SDK, those records already carry the current distinct id and session id. The SDK attaches them. Do not add wiring for them and do not count them as work.
+
+Every step in this chain is about **server emitted** records, which is where the identity is missing.
+
+## User decision points
+
+Call `mcp__wizard-tools__wizard_ask` when a step needs the operator to choose, confirm, or supply a value. The tool surfaces a modal in the wizard UI, blocks until they answer, and returns the answers keyed by question id. Batch related questions into one call. Do not ask via plain chat.
+
+## Live activity
+
+Emit `[STATUS] <short phrase>` lines whenever you start a new sub task. The wizard reads them and updates the spinner. Use them freely, they are cheap. Each step file names the status phrases it expects.
+
+## Logs plan file
+
+The plan file lives at `.posthog-logs-plan.md` at the project root. Step 3 writes it, Steps 4 to 6 update it, Step 7 reads it for the report and deletes it. Use `Write`, `Read`, and `Edit` directly, no MCP tools, no audit ledger.
+
+The file has two sections. A phase checklist tracks each step's outcome. A surfaces table holds one row per place that emits logs, with the correlation tier that surface reached. Step 3 defines the exact format and the later steps follow it.
+
+## Outcome statuses
+
+Mark each phase and each surface row as one of these.
+
+- `pass`, the step completed cleanly.
+- `warning`, the step completed but the operator should look at it.
+- `error`, the step failed and you could not auto recover.
+
+## Reference documentation
+
+Everything you need is on disk. Do not WebFetch the logs docs.
+
+{references}
+
+## Key principles
+
+Additive, never disruptive. Existing logging keeps working exactly as it does today. You are adding an export path and enriching records, not replacing a logging library, not changing log levels, and not rewriting log messages.
+
+Attach identity in one place, not at every call site. A codebase with two hundred log statements should end this run with two hundred correlated log statements and roughly one new file. If you find yourself editing a third individual log call to add attributes by hand, stop, and go back to the shared mechanism in Step 5.
+
+Prefer the authenticated user id over the header. The `X-POSTHOG-DISTINCT-ID` header is set by the browser and is therefore client controlled. Where the server already knows who the request belongs to, that id wins. Fall back to the header only for anonymous traffic.
+
+Use the project token, not a personal API key. The log export authenticates with the `phc_` project token, the same one the PostHog SDK uses. A `phx_` personal API key is the wrong credential and will fail. Read it from an environment variable, never hardcode it.
+
+Match the region to the project. The installation docs hardcode the US ingestion host. If this project is on EU, that endpoint silently accepts nothing useful. Step 2 resolves this before writing any endpoint.
+
+Keep edits minimal. Preserve surrounding code, formatting, and unrelated imports. If a file has integration code for other tools, leave that code alone.
+
+Do not commit. The operator reviews the diff and commits when ready.
+
+## Abort statuses
+
+Emit `[ABORT] <reason>` and stop when an abort case fires. The wizard catches these and terminates the run.
+
+- `[ABORT] No supported runtime found`, when Step 1 finds no {display_name} application to instrument.
+
+## Framework guidelines
+
+{commandments}

--- a/context/skills/logs-setup/references/1-detect.md
+++ b/context/skills/logs-setup/references/1-detect.md
@@ -1,0 +1,61 @@
+---
+title: Detect the logging setup
+next_step: 2-install.md
+---
+
+# Step 1, detect what this project already does
+
+Discovery only. Do not modify project files. Do not write the plan file, Step 3 owns that.
+
+You are answering four questions. Later steps depend on all four, so be specific and remember the answers.
+
+## Status
+
+Emit each of these as you start the matching sub task.
+
+```
+[STATUS] Detecting application runtime
+[STATUS] Finding existing logging
+[STATUS] Checking for PostHog SDKs
+[STATUS] Locating request identity
+```
+
+## 1. Is there a runtime to instrument?
+
+Read the dependency manifest at the project root, `package.json` for Next.js, `pyproject.toml` / `requirements.txt` / `setup.py` for Python. Confirm the runtime this skill targets is actually present, and note the framework underneath it: App Router or Pages Router for Next.js, Django or Flask or FastAPI for Python.
+
+For Next.js, note the major version. It changes two things in Step 2: whether `instrumentation.ts` needs the `experimental.instrumentationHook` flag, and whether `after()` from `next/server` is available.
+
+If the targeted runtime is not here at all, emit `[ABORT] No supported runtime found` and stop. That is the correct outcome, not a failure to work around.
+
+## 2. How does it log today?
+
+Find the logging that already exists, because Step 2 attaches to it rather than replacing it.
+
+Look for a logging library first, `pino`, `winston`, `bunyan`, `structlog`, `loguru`, or Python's standard `logging`. Note how it is configured and where that configuration lives. If there is no library, look for bare `console.log` / `console.error` or `print`.
+
+Record roughly how many log call sites there are and which directories they cluster in. You do not need an exact count. You need to know whether this is a codebase with a logging convention or one with scattered `console.log`, because Step 5 attaches to the former and reports honestly about the latter.
+
+Note whether records are already structured. A logger that emits objects has somewhere to put correlation attributes. A logger emitting formatted strings does not, and Step 3 needs to know.
+
+## 3. Is PostHog already here?
+
+Search for `posthog-js`, `posthog-node`, `posthog` (Python), and any existing `posthog.init` or `Posthog(...)` construction. Note the host and token configuration, and where they come from.
+
+An existing PostHog host is the most reliable signal of the project's region, and Step 2 needs the region. Record the exact host value you found, and whether it came from a literal or an environment variable.
+
+Note separately whether session replay is enabled on the client, and whether `tracing_headers` is already configured on the client SDK. Step 4 needs both.
+
+## 4. Where does the server learn who the user is?
+
+This is the question the rest of the run turns on, so spend the most time here.
+
+Find the point in a request's life where the server knows the authenticated user. That is usually a session lookup, an auth middleware, a decorator, or a helper like `auth()`, `getServerSession()`, `request.user`, or `current_user`. Note the file, the function, and the exact expression that yields a stable user id.
+
+Prefer a stable unique id, the primary key from your auth system. Not an email, not a display name.
+
+If the project has no concept of a user, say so plainly and remember it. Correlation will top out at the `session` tier via the header alone, or at `none`. That is a legitimate result.
+
+Do not modify anything to make this easier. You are reading.
+
+Continue to `2-install.md`.

--- a/context/skills/logs-setup/references/2-install.md
+++ b/context/skills/logs-setup/references/2-install.md
@@ -1,0 +1,67 @@
+---
+title: Install the log export
+next_step: 3-plan.md
+---
+
+# Step 2, install the log export
+
+Add the OpenTelemetry log export and point it at PostHog. Existing logging keeps working exactly as it does now, this only adds a second destination.
+
+The installation doc for this runtime is on disk under `references/`. It is the source of truth for package names, import paths, and the shape of the provider setup. Read it now. Do not WebFetch it.
+
+## Status
+
+Emit these as you work.
+
+```
+[STATUS] Resolving ingestion region
+[STATUS] Adding OpenTelemetry packages
+[STATUS] Wiring the log exporter
+```
+
+## Resolve the region first
+
+The installation doc hardcodes the US ingestion host. Writing that into an EU project produces a setup that looks correct, fails silently, and is genuinely unpleasant to debug. Settle it before you write any endpoint.
+
+Resolve in this order.
+
+1. The PostHog host you found in Step 1. A host containing `eu.i.posthog.com` or `eu.posthog.com` means EU, `us.i.posthog.com` or `app.posthog.com` means US.
+2. A `POSTHOG_HOST` or `NEXT_PUBLIC_POSTHOG_HOST` environment variable in `.env`, `.env.local`, or `.env.example`.
+3. If neither is present, ask. Call `mcp__wizard-tools__wizard_ask` with a single question offering US and EU.
+
+The log ingestion endpoint is the region's host followed by `/i/v1/logs`.
+
+| Region | Endpoint |
+|--------|----------|
+| US | `https://us.i.posthog.com/i/v1/logs` |
+| EU | `https://eu.i.posthog.com/i/v1/logs` |
+
+Derive the endpoint from the same environment variable the project already uses for its PostHog host wherever you can, so the two cannot drift apart. Only fall back to a separate variable when the project has no host variable to build on.
+
+## Credentials
+
+The export authenticates with the project token, the `phc_` value the PostHog SDK already uses. A `phx_` personal API key is a different credential and will not work here.
+
+Reuse the environment variable the project already reads its token from. Only add a new variable if there isn't one. Never hardcode the token, and if you add a variable, add it to `.env.example` too if the project keeps one.
+
+## Wire the exporter
+
+Follow the installation doc on disk. Two details in it are load bearing and easy to skim past.
+
+**Next.js.** Create the `loggerProvider` outside `register()` and export it. Route handlers finish before the batch processor flushes, so the provider has to be reachable for a manual flush. Guard the global registration with `process.env.NEXT_RUNTIME === 'nodejs'`, the exporter does not belong on the Edge runtime. On Next.js 14 and earlier you also need `experimental.instrumentationHook` in the Next config; on 15 and later that option is deprecated and should be removed if present.
+
+**Python.** Attach `LoggingHandler` to the root logger. That is what makes this additive: every existing `logging` call flows to PostHog without a single call site changing. The logs API is still experimental upstream, so the imports live under the private `_logs` path (`opentelemetry._logs`, `opentelemetry.sdk._logs`). Use those, `opentelemetry.logs` does not exist. Put the setup where the app already does its startup configuration, and make it run once.
+
+## Rules
+
+Do not remove, replace, or reconfigure the existing logger. Do not change log levels or formats. Do not touch individual log call sites, Step 5 handles records in one place.
+
+Do not install dependencies yet. Add the package entries to the manifest and let Step 6 install once.
+
+Do not add correlation attributes here. That is Steps 4 and 5, and doing it now means doing it twice.
+
+## Carry the outcome forward
+
+The plan file does not exist yet, so this step does not record its outcome on disk. Remember the region you resolved, the endpoint you wrote, the file the provider setup landed in, and whether the wiring applied cleanly. Step 3 records all of it.
+
+Continue to `3-plan.md`.

--- a/context/skills/logs-setup/references/2-install.md
+++ b/context/skills/logs-setup/references/2-install.md
@@ -25,9 +25,14 @@ The installation doc hardcodes the US ingestion host. Writing that into an EU pr
 
 Resolve in this order.
 
-1. The PostHog host you found in Step 1. A host containing `eu.i.posthog.com` or `eu.posthog.com` means EU, `us.i.posthog.com` or `app.posthog.com` means US.
-2. A `POSTHOG_HOST` or `NEXT_PUBLIC_POSTHOG_HOST` environment variable in `.env`, `.env.local`, or `.env.example`.
-3. If neither is present, ask. Call `mcp__wizard-tools__wizard_ask` with a single question offering US and EU.
+1. **The `PostHog Host` in your prompt context.** This is the authenticated project's real host and it outranks everything else, because it comes from the account this run is authorizing against rather than from a file that may be stale, proxied, or copied from another project.
+2. The PostHog host you found in Step 1. A host containing `eu.i.posthog.com` or `eu.posthog.com` means EU, `us.i.posthog.com` or `app.posthog.com` means US.
+3. A `POSTHOG_HOST` or `NEXT_PUBLIC_POSTHOG_HOST` environment variable in `.env`, `.env.local`, or `.env.example`.
+4. If none of those resolve it, ask. Call `mcp__wizard-tools__wizard_ask` with a single question offering US and EU.
+
+Treat a reverse proxy as no signal. A project routing through `api_host: '/ingest'` tells you nothing about the region, and a `ui_host` sitting next to it is a display setting that is frequently left at its default — neither is evidence. Fall through to the prompt context.
+
+If the codebase and the prompt context disagree, the prompt context wins, and say so in the report. That mismatch usually means the project config points at a different PostHog project than the one this run is authorized against, which is worth the operator knowing about.
 
 The log ingestion endpoint is the region's host followed by `/i/v1/logs`.
 

--- a/context/skills/logs-setup/references/3-plan.md
+++ b/context/skills/logs-setup/references/3-plan.md
@@ -1,0 +1,78 @@
+---
+title: Plan the correlation
+next_step: 4-context.md
+---
+
+# Step 3, decide how far correlation can go
+
+Correlation needs two values on each record: `posthogDistinctId`, which links the log to a person, and `sessionId`, which links it to a session replay. This step works out where each of them can come from in this codebase, and commits to a tier per surface.
+
+Be honest here rather than optimistic. Steps 4 and 5 build exactly what this plan says, and Step 7 reports it. A plan that claims an identifier it cannot actually reach produces wiring that attaches `undefined` and a report that lies.
+
+## Status
+
+Emit these as you start each sub task.
+
+```
+[STATUS] Mapping log emitting surfaces
+[STATUS] Tracing identity to log call sites
+[STATUS] Choosing correlation tier
+[STATUS] Writing correlation plan
+```
+
+## Enumerate the surfaces that emit logs
+
+A surface is a coherent place logs come from, not an individual call. Route handlers, server actions, background workers, scheduled jobs, CLI entry points, and middleware are each a surface.
+
+Group them by how a request reaches them, because that determines what identity is available.
+
+- **Request scoped surfaces** run inside an HTTP request. They can see headers and the authenticated session, so they can reach the `session` tier.
+- **Detached surfaces** are background jobs, queue consumers, cron tasks, and startup code. No request, therefore no headers and usually no user. They land at `person` if the job knows whose work it is doing, and `none` otherwise. This is expected. Do not contort a worker into faking a session.
+
+## Decide where each value comes from
+
+For `posthogDistinctId`, prefer the authenticated user id you found in Step 1. Fall back to the `X-POSTHOG-DISTINCT-ID` request header for anonymous traffic. The header is set by the browser and is therefore client controlled, so it must never outrank a server known identity.
+
+For `sessionId`, use the `X-POSTHOG-SESSION-ID` request header. There is no server side alternative; the session id belongs to the browser.
+
+Before you commit to either, prove the value actually arrives. Read the code path that will really run and confirm the id is present in the shape that code sees. Frameworks routinely withhold the user id from the object a handler receives, an allow-list on a serialized model, a session callback returning only name and email. Where the id is missing, plan to expose it deliberately at its source. Never substitute an email and never plan to pass a value that can be `undefined`.
+
+If the client does not send the headers yet, that is not a blocker. Step 4 configures the client to send them.
+
+## Choose the tier per surface
+
+Assign each surface `session`, `person`, or `none`, using the definitions in `SKILL.md`. Record why. A one line reason on a `none` surface is what makes the report useful.
+
+The whole project's tier is the best tier its request scoped surfaces reach. Detached surfaces do not drag it down.
+
+## Write the plan file
+
+Write `.posthog-logs-plan.md` at the project root with two sections.
+
+A phase checklist with one line per phase, in this order: `install`, `plan`, `context`, `attach`, `verify`. Use the markdown task syntax. Tick the `install` line with the outcome you carried over from Step 2, and record the region on it. Tick the `plan` line as pass once the file is written. Leave the rest unchecked, later steps tick them.
+
+```
+- [x] install — <pass|warning|error> — region <us|eu>, provider in <file>
+- [x] plan — pass
+- [ ] context
+- [ ] attach
+- [ ] verify
+```
+
+A surfaces table with one row per surface, in this column order.
+
+```
+| surface | kind | distinct id source | session id source | tier | status | notes |
+```
+
+`kind` is `request` or `detached`. Start each row at `pending`.
+
+Record the project wide decisions underneath the table as a short list, because Steps 4 and 5 need them and should not have to re-derive them: the file that will hold the identity context, the mechanism it uses, the file where the client SDK is initialized, and the single place where attributes will be attached.
+
+If no surface can reach beyond `none`, still write the plan. The export from Step 2 is real value on its own, and Step 7 reports the gap with something concrete for the operator to do about it.
+
+## Rules
+
+Do not edit project source in this step. Only the plan file is written. No WebFetch.
+
+Continue to `4-context.md`.

--- a/context/skills/logs-setup/references/4-context.md
+++ b/context/skills/logs-setup/references/4-context.md
@@ -1,0 +1,74 @@
+---
+title: Establish the identity context
+next_step: 5-attach.md
+---
+
+# Step 4, make identity reachable at log time
+
+The problem this step solves: the code that emits a log line is usually nowhere near the code that knows who the user is. A log statement four calls deep inside a service function has no idea a request is happening.
+
+The fix is not to pass a user id down through every function signature. It is to bind identity once per request, somewhere ambient, so the log record can reach it later without anyone threading it through.
+
+Work from the project wide decisions you recorded at the bottom of `.posthog-logs-plan.md`.
+
+## Status
+
+Emit these as you work.
+
+```
+[STATUS] Configuring client to send identity headers
+[STATUS] Adding request identity context
+[STATUS] Binding identity to the request
+```
+
+## Client side, send the headers
+
+Skip this entirely if the project has no browser client, and note why on the plan.
+
+`posthog-js` can attach the identity headers to outbound requests on its own. Set `tracing_headers` in the PostHog client initialization to your backend's hostname, and the SDK adds `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` to matching `fetch` and `XMLHttpRequest` calls.
+
+Hostnames only, no protocol, no path, no port. Where the frontend and backend share an origin, that is the app's own hostname.
+
+Do not hand-roll a fetch wrapper for this, and do not thread a session id through request bodies route by route. The installation docs demonstrate passing `sessionId` in a request body because it explains the idea in one snippet, but as an implementation it means touching every call site and it misses everything that does not go through the one function you wrapped. The config option covers the whole app.
+
+If `tracing_headers` is already configured, confirm the backend hostname is in the list and leave it alone otherwise.
+
+`sessionId` requires session replay to be enabled on the client. If replay is off, the header will not carry a session and the project tops out at the `person` tier. Note that on the plan rather than trying to work around it.
+
+## Server side, bind identity to the request
+
+Create the context the plan named. One new file, one mechanism, used everywhere.
+
+The value you bind is a small object holding the distinct id and the session id. Resolve the distinct id at bind time, preferring the authenticated user id and falling back to the `X-POSTHOG-DISTINCT-ID` header. The header is client controlled, so a server known identity always wins.
+
+**Next.js, App Router.** You may not need a store at all. `headers()` from `next/headers` is readable inside route handlers, server actions, and server components, so the attachment point in Step 5 can read the headers itself at emit time. That is the simplest thing that works, and it has no setup. Two constraints come with it: `headers()` is async on Next.js 15 and later, and it throws when called outside a request scope. Handle the throw by degrading to no attributes rather than letting it propagate, because a background job must not crash on a logging call.
+
+Do not put this in `middleware.ts`. Next.js middleware runs on the Edge runtime, which is a different runtime from the one your route handlers and the OTel provider run in. Anything you store there is not visible to them.
+
+**Next.js, Pages Router or a custom server.** `headers()` is not available. Use `AsyncLocalStorage` from `node:async_hooks`. Create the store in a module of its own, enter it at the top of the request path, and read from it in Step 5.
+
+**Python.** Use a `contextvars.ContextVar` holding the identity, set from middleware. `ContextVar` is the right primitive because it is per task and per thread, so concurrent requests cannot read each other's identity. A module level global would leak identity across requests under any concurrency, which is worse than no correlation at all.
+
+Set it where the framework gives you a request hook: Django middleware placed after `AuthenticationMiddleware`, a Flask `before_request` handler, or a FastAPI middleware. Reset the token when the request ends.
+
+Django projects using the PostHog Python SDK may already have `PosthogContextMiddleware` installed, which extracts the same tracing headers for event capture. It is a good neighbour and a good model, but it feeds PostHog's event context rather than the logging pipeline. Add your context var alongside it, do not try to reach inside it.
+
+## Rules
+
+One mechanism for the whole project. Two competing context implementations is the outcome to avoid.
+
+Do not modify individual log call sites here. Step 5 is the only step that touches how a record is produced.
+
+Do not add authentication, and do not change how the project decides who a user is. You are reading an identity that already exists.
+
+## Update the plan file
+
+Edit `.posthog-logs-plan.md` and tick the `context` phase line.
+
+```
+- [x] context — <pass|warning|error> — <mechanism, and the file it lives in>
+```
+
+Use `warning` when the context exists but something limits it, replay disabled, or a client you could not configure. Use `error` only if you could not establish a context at all.
+
+Continue to `5-attach.md`.

--- a/context/skills/logs-setup/references/4-context.md
+++ b/context/skills/logs-setup/references/4-context.md
@@ -33,6 +33,8 @@ Do not hand-roll a fetch wrapper for this, and do not thread a session id throug
 
 If `tracing_headers` is already configured, confirm the backend hostname is in the list and leave it alone otherwise.
 
+`tracing_headers` is applied at runtime but is missing from the `PostHogConfig` TypeScript types in current `posthog-js` releases, so a type check will reject it as an unknown property. Cast the options object to `Partial<PostHogConfig>` at the `init` call and carry on. Do not go reading compiled files under `node_modules` to find the correct spelling, and do not conclude from the type error that the option does not exist. Note the cast on the plan so Step 7 can report it as a follow up.
+
 `sessionId` requires session replay to be enabled. If replay is off, the header will not carry a session and the project tops out at the `person` tier. Note that on the plan rather than trying to work around it.
 
 Your prompt context states whether session replay is enabled on the PostHog project. Trust it over repo-local evidence: replay can be turned on from the snippet or from another repo entirely, so the absence of replay config in this codebase does not mean the product is off.

--- a/context/skills/logs-setup/references/4-context.md
+++ b/context/skills/logs-setup/references/4-context.md
@@ -33,7 +33,9 @@ Do not hand-roll a fetch wrapper for this, and do not thread a session id throug
 
 If `tracing_headers` is already configured, confirm the backend hostname is in the list and leave it alone otherwise.
 
-`sessionId` requires session replay to be enabled on the client. If replay is off, the header will not carry a session and the project tops out at the `person` tier. Note that on the plan rather than trying to work around it.
+`sessionId` requires session replay to be enabled. If replay is off, the header will not carry a session and the project tops out at the `person` tier. Note that on the plan rather than trying to work around it.
+
+Your prompt context states whether session replay is enabled on the PostHog project. Trust it over repo-local evidence: replay can be turned on from the snippet or from another repo entirely, so the absence of replay config in this codebase does not mean the product is off.
 
 ## Server side, bind identity to the request
 

--- a/context/skills/logs-setup/references/5-attach.md
+++ b/context/skills/logs-setup/references/5-attach.md
@@ -1,0 +1,67 @@
+---
+title: Attach identity to every record
+next_step: 6-verify.md
+---
+
+# Step 5, attach the identity to every log record
+
+One change, applied once, that enriches every record the project emits. A codebase with two hundred log statements should come out of this step with two hundred correlated log statements and roughly one new file.
+
+The two attribute names are exact. PostHog reads `posthogDistinctId` to link a record to a person and `sessionId` to link it to a session replay. Both are camelCase. A misspelling produces a record that arrives, looks fine, and links to nothing.
+
+## Status
+
+Emit these as you work.
+
+```
+[STATUS] Adding correlation to the logging pipeline
+[STATUS] Checking log call sites are covered
+```
+
+## Attach in one place
+
+Use the mechanism the plan named, reading identity from the context you built in Step 4.
+
+**Python.** Add a `logging.Filter` and attach it to the OTel `LoggingHandler` from Step 2. A filter runs on every record passing through the handler, and setting an attribute on the record makes it available to the handler downstream. Read the context var, set `posthogDistinctId` and `sessionId` on the record when they are present, and always return `True` so the filter never drops a record.
+
+This is the whole reason Step 2 attached the handler to the root logger. Every `logging` call in the project already flows through it, so a filter there reaches all of them, including logs from third party libraries, without a single call site changing.
+
+**Next.js.** The OTel logger takes attributes per `emit` call, so the equivalent single point is a thin wrapper around the logger. Export a logger from one module, have it resolve identity and merge the two attributes into whatever the caller passed, then delegate to the underlying OTel logger. Callers pass their own attributes exactly as before.
+
+Merge, do not overwrite. If a caller passes attributes of their own, keep them and add to them.
+
+## Degrade quietly
+
+Identity will be absent sometimes, on a background job, on an anonymous request, during startup. That is normal and it is the `person` and `none` tiers working as designed.
+
+Omit an attribute entirely when its value is missing. Do not attach `undefined`, `null`, `"undefined"`, or an empty string. A record with no `sessionId` is a record PostHog treats as unlinked, which is correct. A record with `sessionId: "undefined"` is a record that looks linked, and is not.
+
+Attachment must never throw. A logging call that raises because identity lookup failed turns an observability improvement into an outage. Wrap the lookup so that any failure results in a record without correlation attributes, and never in a raised exception.
+
+## Cover the call sites
+
+With the shared mechanism in place, confirm it actually reaches the surfaces in the plan.
+
+Check a request scoped surface and a detached one. For each, follow the code from the log statement to the attachment point and satisfy yourself the record really passes through it.
+
+Some call sites will not be covered by the shared mechanism, most often bare `console.log` in a project that otherwise uses a logger, or a library configured with its own transport. Do not rewrite these one by one. Record them on the plan as a `warning` with the file and a one line reason, and let Step 7 report them as follow ups.
+
+If a surface's real tier turns out lower than Step 3 predicted, update the row. The plan is a working document, and the report is only as honest as the plan it comes from.
+
+## Rules
+
+Do not add new log statements to prove the mechanism works. Step 6 emits exactly one test record.
+
+Do not change log levels, messages, or formats.
+
+Do not edit more than a couple of individual call sites. If it takes more than that, the shared mechanism is in the wrong place; go back and move it.
+
+## Update the plan file
+
+Edit `.posthog-logs-plan.md`. Update each surface row's `tier`, `status`, and `notes`. Then tick the `attach` phase line with the worst outcome across the rows: error if any row errored, warning if any warned and none errored, pass otherwise.
+
+```
+- [x] attach — <pass|warning|error> — <one line summary>
+```
+
+Continue to `6-verify.md`.

--- a/context/skills/logs-setup/references/5-attach.md
+++ b/context/skills/logs-setup/references/5-attach.md
@@ -38,6 +38,12 @@ Omit an attribute entirely when its value is missing. Do not attach `undefined`,
 
 Attachment must never throw. A logging call that raises because identity lookup failed turns an observability improvement into an outage. Wrap the lookup so that any failure results in a record without correlation attributes, and never in a raised exception.
 
+## Next.js, leave the Edge surfaces alone
+
+`middleware.ts`, and any route declaring `export const runtime = 'edge'`, run on the Edge runtime rather than the Node runtime that holds the provider from Step 2. Importing the provider into one of them pulls the OTel SDK into the Edge bundle, and since the batch processor exports on a timer, the invocation ends before anything is flushed. This compiles, it reads correctly in review, and the records quietly never arrive.
+
+Do not emit log records from these surfaces. Record them on the plan as a `warning` at tier `none` with a one line reason, the same as any other call site the shared mechanism cannot reach, and let Step 7 report them.
+
 ## Cover the call sites
 
 With the shared mechanism in place, confirm it actually reaches the surfaces in the plan.

--- a/context/skills/logs-setup/references/6-verify.md
+++ b/context/skills/logs-setup/references/6-verify.md
@@ -45,7 +45,15 @@ Not allowed:
 
 - Refactoring unrelated code.
 - Fixing pre-existing build errors that have nothing to do with this setup.
-- Silencing a type error with `any` or an ignore comment to make the build pass. If a type genuinely cannot be resolved, record it as an error on the verify phase line and let the operator address it.
+- Silencing a type error with `any` or an ignore comment to make the build pass. If a type genuinely cannot be resolved, record it as an error on the verify phase line and let the operator address it. The `tracing_headers` cast from Step 4 is the one known exception, because it covers a gap in a published type definition rather than an unresolved type in the code you wrote.
+
+## When the failure is the environment, not the code
+
+A build can fail for reasons no edit will fix: a sandbox that blocks a subprocess or a port the bundler wants, an environment variable the app reads at build time, a database or API the build expects to reach. Changing flags and running it again resolves none of these, and the build is the slowest command in this run.
+
+Attempt the build once. If it fails, read the error and decide whether it is about the code you wrote or about the environment you are running in. When it is the environment, stop there, record the verify line as a `warning` naming the restriction, and let Step 7 raise it as a manual follow up for the operator to run themselves. Do not run the same build again with different flags.
+
+Pre-existing failures are the same story. A build that was already broken before this run is not yours to fix, and it is not evidence that your changes are wrong.
 
 ## Emit one test record
 

--- a/context/skills/logs-setup/references/6-verify.md
+++ b/context/skills/logs-setup/references/6-verify.md
@@ -1,0 +1,72 @@
+---
+title: Verify the setup
+next_step: 7-report.md
+---
+
+# Step 6, verify the project still builds and a record arrives
+
+Two things to prove. The project is not broken, and a log record actually reaches PostHog with its correlation attributes intact.
+
+Do not spawn subagents.
+
+## Status
+
+Emit these as you work.
+
+```
+[STATUS] Installing dependencies
+[STATUS] Linting files I edited
+[STATUS] Running type check
+[STATUS] Running build
+[STATUS] Emitting a test log record
+```
+
+## Install dependencies
+
+Step 2 added package entries without installing. Install once now, using the package manager the project already uses. Infer it from the lockfile, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `poetry.lock`, `uv.lock`, or a `requirements.txt`.
+
+## Lint, type check, build
+
+Read the project's manifest for the scripts it defines. Run the linter and formatter only on the files you edited or created in this session, not across the whole codebase. Then run the project's type check (`tsc --noEmit`, `mypy`) and build (`next build`, `python -m py_compile`, or the project's own command).
+
+Capture stdout and stderr. Truncate to the failure region if the output is long.
+
+## Fix only what this run caused
+
+Re-run after each fix until clean. Fix only failures this setup introduced, prioritizing the files you edited.
+
+Allowed:
+
+- A wrong import path or missing type on the provider setup, the context, or the attachment point.
+- A package version that does not resolve against the project's existing dependency set.
+- An `await` missing on an async `headers()` call in Next.js 15 and later.
+
+Not allowed:
+
+- Refactoring unrelated code.
+- Fixing pre-existing build errors that have nothing to do with this setup.
+- Silencing a type error with `any` or an ignore comment to make the build pass. If a type genuinely cannot be resolved, record it as an error on the verify phase line and let the operator address it.
+
+## Emit one test record
+
+Send exactly one log record through the real path, from a request scoped surface if the project has one, so it carries correlation attributes.
+
+Prefer a route the project already exposes over writing a new one. Start the dev server, make one request, then stop the server. If the project cannot be started here, say so on the verify line rather than inventing a harness for it.
+
+Then confirm the record arrived. Use the PostHog MCP tools if they are available in this session to query the logs for the record you just emitted. Check three things: the record is present, `posthogDistinctId` is set on it, and `sessionId` is set on it if the plan predicted the `session` tier.
+
+If the MCP tools are not available, do not guess and do not claim the record arrived. Record on the plan that delivery was not verified, and let the report tell the operator how to check for themselves.
+
+A record that arrives without its attributes is the most valuable failure this step can find. It usually means the attribute names are wrong or the context was empty at emit time. Fix it here, since the operator will otherwise discover it days later while trying to debug something else.
+
+## Update the plan file
+
+Edit `.posthog-logs-plan.md` and tick the `verify` phase line.
+
+```
+- [x] verify — pass — build clean, correlated record confirmed in PostHog
+- [x] verify — warning — build clean, delivery not verified (<reason>)
+- [x] verify — error — <which command failed and a short excerpt>
+```
+
+Continue to `7-report.md` regardless of the outcome. The report still needs to be written.

--- a/context/skills/logs-setup/references/6-verify.md
+++ b/context/skills/logs-setup/references/6-verify.md
@@ -3,9 +3,9 @@ title: Verify the setup
 next_step: 7-report.md
 ---
 
-# Step 6, verify the project still builds and a record arrives
+# Step 6, verify the project still builds and the logging path runs
 
-Two things to prove. The project is not broken, and a log record actually reaches PostHog with its correlation attributes intact.
+Two things to prove. The project is not broken, and the correlated logging path executes end to end without throwing. Emitting one record is the smoke test for the second; confirming it actually landed in PostHog is the operator's step, not this one.
 
 Do not spawn subagents.
 
@@ -27,7 +27,11 @@ Step 2 added package entries without installing. Install once now, using the pac
 
 ## Lint, type check, build
 
-Read the project's manifest for the scripts it defines. Run the linter and formatter only on the files you edited or created in this session, not across the whole codebase. Then run the project's type check (`tsc --noEmit`, `mypy`) and build (`next build`, `python -m py_compile`, or the project's own command).
+Read the project's manifest for the scripts it defines. Run the linter and formatter only on the files you edited or created in this session, not across the whole codebase.
+
+The type check is the gate. Run it (`tsc --noEmit`, `mypy`) and treat a clean result as the primary proof the project is not broken. It is fast and runs anywhere, including sandboxes.
+
+The build (`next build`, `python -m py_compile`, or the project's own command) is a stronger but much slower and more fragile check. Agent sandboxes routinely cannot run it: a bundler that needs to bind a port, spawn a subprocess, or reach a database at build time fails for reasons no edit fixes (see the next section). Attempt it at most once, and only after the type check is already clean. When it cannot run in this environment, that is not a setup failure — a clean type check stands as the proof for this step, and the full build becomes an operator follow-up. Do not re-run it with different flags trying to get past an environment limit.
 
 Capture stdout and stderr. Truncate to the failure region if the output is long.
 
@@ -57,23 +61,21 @@ Pre-existing failures are the same story. A build that was already broken before
 
 ## Emit one test record
 
-Send exactly one log record through the real path, from a request scoped surface if the project has one, so it carries correlation attributes.
+Send exactly one log record through the real logging path so it carries the correlation attributes. This is a smoke test that the path executes without throwing. Whether the record then shows up in PostHog is for the operator to confirm afterwards, not for you to chase here.
 
-Prefer a route the project already exposes over writing a new one. Start the dev server, make one request, then stop the server. If the project cannot be started here, say so on the verify line rather than inventing a harness for it.
+Emit it in process, not through a running server — a dev server needs a bound port that agent sandboxes routinely block. Write one small throwaway script that imports the provider and logger you created, emits a single record with `posthogDistinctId` and `sessionId` set explicitly (a request scoped surface's real values if you can reach them, otherwise clearly synthetic ones like `wizard-verify`), force-flushes the provider, and exits. Run it once with whatever runner the project already uses for its own scripts. Make one attempt: if the script cannot run cleanly here, note that on the verify line and move on — do not iterate on harness or runner problems. Delete the script when you are done.
 
-Then confirm the record arrived. Use the PostHog MCP tools if they are available in this session to query the logs for the record you just emitted. Check three things: the record is present, `posthogDistinctId` is set on it, and `sessionId` is set on it if the plan predicted the `session` tier.
+Do not confirm arrival in this session. Do not query PostHog — not with the MCP tools, not with `curl`, not with anything — and do not hunt for an API key. A record takes a moment to land and the tools to check it belong to the operator, not this run. Step 7 tells them exactly where to look. Record delivery as emitted, note that the operator confirms it, and continue. That is the expected outcome, not a failure.
 
-If the MCP tools are not available, do not guess and do not claim the record arrived. Record on the plan that delivery was not verified, and let the report tell the operator how to check for themselves.
-
-A record that arrives without its attributes is the most valuable failure this step can find. It usually means the attribute names are wrong or the context was empty at emit time. Fix it here, since the operator will otherwise discover it days later while trying to debug something else.
+The attribute names matter more than delivery here: `posthogDistinctId` and `sessionId`, spelled exactly, set at emit time. You already ensured that in Step 5, so if the smoke test runs without throwing, this step is done.
 
 ## Update the plan file
 
 Edit `.posthog-logs-plan.md` and tick the `verify` phase line.
 
 ```
-- [x] verify — pass — build clean, correlated record confirmed in PostHog
-- [x] verify — warning — build clean, delivery not verified (<reason>)
+- [x] verify — pass — type check clean, test record emitted (operator confirms delivery)
+- [x] verify — warning — type check clean, test record could not be emitted here (<reason>)
 - [x] verify — error — <which command failed and a short excerpt>
 ```
 

--- a/context/skills/logs-setup/references/7-report.md
+++ b/context/skills/logs-setup/references/7-report.md
@@ -1,0 +1,79 @@
+---
+title: Write the setup report
+next_step: null
+---
+
+# Step 7, write the report
+
+The report comes directly from `.posthog-logs-plan.md`. That file is the source of truth for everything that happened. Nothing is invented.
+
+The reader is about to open a diff they did not write. Tell them what changed, what it bought them, and what is still theirs to do.
+
+## Status
+
+```
+[STATUS] Writing logs setup report
+```
+
+## Read the plan
+
+Read `.posthog-logs-plan.md`. Pull the outcome on each phase line, every row from the surfaces table, and the project wide decisions recorded underneath it.
+
+The project's correlation tier is the best tier reached by any row whose `kind` is `request`. Detached surfaces do not lower it.
+
+## Write the report
+
+Write `posthog-logs-report.md` at the project root with the structure below. After the report is written, delete `.posthog-logs-plan.md`.
+
+<wizard-report>
+# PostHog Logs setup report — <runtime>
+
+The wizard has set up PostHog Logs for this project. [1–2 sentence summary covering where the export was wired, the correlation tier reached, and the verify outcome.]
+
+## What you can do now
+
+One short paragraph, written for the tier actually reached.
+
+At the `session` tier: a log line in PostHog now links to the person who caused it, and opens the session replay of them causing it. Point them at the logs view and tell them to use the **View recording** button on a log entry.
+
+At the `person` tier: logs are attributed to people and appear on person profiles, and say plainly what would unlock replay linking, usually enabling session replay on the client.
+
+At the `none` tier: logs are searchable in PostHog but not linked to anyone, and say concretely what would change that.
+
+## Correlation
+
+**Tier reached: `<session|person|none>`**
+
+| Surface | Kind | Distinct ID | Session ID | Tier |
+|---------|------|-------------|------------|------|
+
+One row per surface from the plan. In the two ID columns, name the real source, "authenticated user id from `getServerSession()`" rather than "yes".
+
+## What changed
+
+| File | Change |
+|------|--------|
+
+Every file created or edited, with a short description. Group by purpose in this order: log export, identity context, correlation attachment.
+
+Name the ingestion region and the environment variables the setup reads. If you added a variable, say so explicitly, since the operator needs to set it wherever they deploy.
+
+## Manual follow-ups
+
+Numbered list of every item the operator should look at next. Include every surface row whose status is `warning` or `error` with its file and notes. Include uncovered call sites found in Step 5. Include the verify outcome if it was anything other than a clean pass, with the command and a short excerpt. Include anything that would raise the correlation tier.
+
+Be specific enough to act on. "Session replay is disabled, so logs cannot link to recordings; enable it in the `posthog.init` call in `app/providers.tsx`" is useful. "Improve correlation" is not.
+
+If there are no follow ups, write `_Nothing to follow up on._`.
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+After the report is written, emit a final line so the wizard can surface the path to the user.
+
+```
+Created logs setup report: <absolute path to posthog-logs-report.md>
+```


### PR DESCRIPTION
## Problem

The `logs` skill group is docs-only. It declares twelve platform variants and points each at the relevant installation doc, but there's no step chain behind it — it's reference material, and nothing in the wizard drives it. Of the 238 `cliEntries` in a locally built `skill-menu.json`, none are logs-related.

Installation is the half those docs already cover well. The half they don't is **correlation**: attaching `posthogDistinctId` and `sessionId` to server-emitted records so a log line resolves to a person and opens their session replay. That's the reason to put logs in PostHog rather than in a standalone log vendor, and today it's left to the reader as something to implement by hand.

It's also the genuinely hard part, and a poor fit for a doc. The answer to *"where does this codebase already know who this request belongs to"* is different every time — an auth middleware here, a session callback there. A human reading docs has to work that out themselves. An agent reading the codebase can work it out and write the wiring.

## Changes

Adds `context/skills/logs-setup/`: a 7-step chain modelled on `migrate`, with `nextjs` and `python` variants.

`detect → install → plan → context → attach → verify → report`

Same conventions as `migrate` throughout: numbered `references/` with `next_step` frontmatter, one step in context at a time, state on disk between steps (`.posthog-logs-plan.md`), `[STATUS]` lines, `[ABORT]` cases, per-step `pass`/`warning`/`error`, and a `<wizard-report>` block. No commit — the operator reviews the diff.

Four decisions worth a reviewer's attention:

**Correlation attaches in exactly one place.** A `logging.Filter` on the OTel handler in Python; a logger wrapper in Next.js. The rule the skill enforces is that a codebase with two hundred log statements should come out of the run with two hundred correlated log statements and roughly one new file. Step 5 explicitly tells the agent to stop and move the shared mechanism if it finds itself editing a third call site by hand.

**The client half uses `tracing_headers`.** `posthog-js` already emits `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` from one config option, which is the convention `integration-v2/identify` and `posthog-best-practices` already document — the latter says explicitly "do not hand-roll a fetch wrapper for it". The public logs docs demonstrate threading `sessionId` through a request body instead, which means touching every route and missing anything that doesn't go through the wrapped function. The skill follows the in-repo convention and notes that these headers are client-controlled, so a server-known user id always outranks them.

**Correlation degrades in defined tiers.** `session` (both attributes), `person` (distinct id only), `none`. The report states which tier was actually reached and what would raise it. A background worker has no session and shouldn't pretend to have one. The failure mode this is written to avoid is wiring that looks correlated but attaches `undefined` — so Step 5 requires omitting an absent attribute entirely rather than passing an empty value, and requires that attachment never throws.

**The step files stay flat.** No `references/<variant-id>/` subdirectory, because `generateSkill()` filters to top-level `references/*.md` when copying into the zip. `migrate-statsig.zip` currently ships without the `references/statsig/` mapping docs its own steps point at. Happy to file that separately if it's news.

The skill also encodes three things the installation docs bury, all of which fail silently:
- the docs hardcode the **US** ingestion host, so Step 2 resolves the region from the project's existing PostHog host before writing an endpoint
- the export takes the `phc_` **project token**, not a `phx_` personal API key
- Next.js `middleware.ts` runs on the Edge runtime, a different runtime from the one the OTel provider is registered in, so request context established there is invisible to route handlers

## CLI surface

Ships as `role: skill`, reachable as `wizard skill logs-setup-<variant>`.

The companion wizard PR registers `wizard logs` as a native flat command, the same split `ai-observability` uses (`cli: role: skill` here, `nativeCommandFactory` there). Per CONTRIBUTING's promotion criteria I'd rather a maintainer decide whether this should also carry `role: command`; shipping as `skill` keeps it out of collision with the native registration in the meantime.

Companion PR: PostHog/wizard#1043.

## Test plan

- `pnpm test` — 137 passed
- `pnpm build` — builds `logs-setup-nextjs.zip` and `logs-setup-python.zip`; `skill-menu.json` goes 238 → 240 `cliEntries` with both new skills under a `logs-setup` category
- Verified the built zip is flat and complete: `SKILL.md`, all 7 steps, `COMMANDMENTS.md`, and the 8 fetched docs, with all `{display_name}` / `{references}` / `{commandments}` placeholders substituted and the `next_step` handoff footers wired 1→7
- `pnpm security-scan:skills` — zero findings in `logs-setup-*`. The scan reports 108 findings repo-wide; all are pre-existing in other skills and unchanged by this PR
- Served locally via `pnpm dev` and confirmed the wizard fetches both variants from `localhost:8765` with `--local-mcp`

## LLM context

Written with Cursor. The design came out of reading `migrate` as the structural template and `integration-v2/identify` + `posthog-best-practices` for the existing tracing-header convention, which is what redirected the client half away from the approach the public logs docs demonstrate.

Made with [Cursor](https://cursor.com)
