### PR TITLE
fix(build): skip root-level test dirs when packaging examples

### DIFF
--- a/context/skip-patterns.yaml
+++ b/context/skip-patterns.yaml
@@ -149,6 +149,11 @@ global:
   regex:
     # Skip .env files but allow .env.example
     - ^.env(?!\.example$)
+    # Skip a root-level test/ or tests/ dir. The `/test/` substring above only
+    # catches nested ones, because shouldSkip is given a path relative to the
+    # example root, so the root dir has no leading slash to match on. The
+    # separator class also covers path.relative output on Windows.
+    - ^tests?[/\\]
 
 # Example-specific overrides
 # Add patterns here to skip files only for specific examples

--- a/scripts/lib/tests/skip-patterns.test.js
+++ b/scripts/lib/tests/skip-patterns.test.js
@@ -20,6 +20,18 @@ describe('shouldSkip', () => {
         expect(shouldSkip('.env.example', patterns)).toBe(false);
     });
 
+    it('skips a root-level test dir, not only nested ones', () => {
+        const patterns = mergeSkipPatterns({
+            includes: ['/test/'],
+            regex: [new RegExp('^tests?[/\\\\]')],
+            allow: [],
+        });
+        expect(shouldSkip('app/test/helpers.py', patterns)).toBe(true);
+        expect(shouldSkip('test/test_api.py', patterns)).toBe(true);
+        expect(shouldSkip('tests/example.spec.ts', patterns)).toBe(true);
+        expect(shouldSkip('testing/settings.py', patterns)).toBe(false);
+    });
+
     it('keeps files matching no pattern', () => {
         const patterns = mergeSkipPatterns(globalPatterns);
         expect(shouldSkip('Sources/App.swift', patterns)).toBe(false);


### PR DESCRIPTION
`shouldSkip` in `scripts/lib/example-processor.js` receives a path relative to the example root (`collectFiles` computes it with `path.relative(baseDir, fullPath)`), therefore the global `/test/` pattern only matches nested directories like `app/test/`. A root-level `test/` or `tests/` has no leading slash and never matches.

Running the current patterns through the repo's own `shouldSkip`:

```
PACKAGED test/test_api.py
PACKAGED tests/test_api.py
PACKAGED tests/example.spec.ts
SKIPPED  app/test/foo.py
```

So `example-apps/next-app-router/tests` ships its Playwright specs in the skill output today, and any example that adds tests at the root would do the same.

This adds an anchored regex for the root-level case and a regression test covering nested, root-level, and the `testing/` near-miss. The separator class covers `path.relative` output on Windows.

I considered normalizing the path with leading and trailing separators before matching, which would fix the general class rather than this one case, but it changes behaviour for every existing pattern and seemed like the wrong call for an outside contribution. Happy to do it that way instead if preferred.

Please note that the suite has 6 failing test files on `main` before this change (`bundle-writer.test.js` has an assertion failure). Unrelated, and this just adds one passing test on top.