### PR TITLE
fix(marketplace): key plugin skill dirs by id, not shortId

### DIFF
--- a/scripts/lib/marketplace-generator.js
+++ b/scripts/lib/marketplace-generator.js
@@ -188,7 +188,10 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
             // Use `id`, as the mega-plugin below already does.
             if (seen.has(skill.id)) {
                 throw new Error(
-                    `Duplicate skill id "${skill.id}" — plugin skill dirs would overwrite each other`,
+                    `Duplicate skill id "${skill.id}" — two skill groups in config.yaml flatten to it. ` +
+                        `An id is the group key with "/" replaced by "-", plus the variant id ` +
+                        `(dropped when the variant is "all"), so "a/b" + variant "c" collides with ` +
+                        `"a" + variant "b-c". Rename one group or variant.`,
                 );
             }
             seen.add(skill.id);

--- a/scripts/lib/marketplace-generator.js
+++ b/scripts/lib/marketplace-generator.js
@@ -166,11 +166,14 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
     }
 
     const allSkillEntries = [];
+    // Every skill dir written below is keyed by `id`, so one id must map to one
+    // dir across the whole build — the mega-plugin pools skills from every plugin,
+    // so a per-plugin guard would miss a collision between two of them.
+    const seen = new Set();
 
     // Generate grouped plugins
     for (const [pluginName, groupSkills] of Object.entries(pluginGroups)) {
         const pluginDir = path.join(pluginsDir, pluginName);
-        const seen = new Set();
 
         for (const skill of groupSkills) {
             const srcDir = path.join(tempDir, skill.id);
@@ -181,9 +184,11 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
 
             // `shortId` is only unique within a skill group, but a plugin aggregates
             // many groups — keying dirs by it let two skills overwrite each other.
-            // Use the globally-unique `id`, as the mega-plugin below already does.
+            // Use `id`, as the mega-plugin below already does.
             if (seen.has(skill.id)) {
-                throw new Error(`Plugin "${pluginName}" has duplicate skill id "${skill.id}"`);
+                throw new Error(
+                    `Duplicate skill id "${skill.id}" — plugin skill dirs would overwrite each other`,
+                );
             }
             seen.add(skill.id);
 

--- a/scripts/lib/marketplace-generator.js
+++ b/scripts/lib/marketplace-generator.js
@@ -174,6 +174,7 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
     // Generate grouped plugins
     for (const [pluginName, groupSkills] of Object.entries(pluginGroups)) {
         const pluginDir = path.join(pluginsDir, pluginName);
+        let written = 0;
 
         for (const skill of groupSkills) {
             const srcDir = path.join(tempDir, skill.id);
@@ -194,6 +195,7 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
 
             const destDir = path.join(pluginDir, 'skills', skill.id);
             copyDirSync(srcDir, destDir);
+            written++;
 
             allSkillEntries.push({
                 dirName: skill.id,
@@ -204,7 +206,9 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
         }
 
         writePluginJson(pluginDir, pluginName, version, maps);
-        console.log(`  ✓ ${pluginName} (${groupSkills.length} skills)`);
+        // Count what was copied, not what was offered — a skipped source dir above
+        // would otherwise be reported as shipped.
+        console.log(`  ✓ ${pluginName} (${written} skills)`);
     }
 
     // Generate mega-plugin

--- a/scripts/lib/marketplace-generator.js
+++ b/scripts/lib/marketplace-generator.js
@@ -170,6 +170,7 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
     // Generate grouped plugins
     for (const [pluginName, groupSkills] of Object.entries(pluginGroups)) {
         const pluginDir = path.join(pluginsDir, pluginName);
+        const seen = new Set();
 
         for (const skill of groupSkills) {
             const srcDir = path.join(tempDir, skill.id);
@@ -178,7 +179,15 @@ function generateMarketplace({ skills, tempDir, version, outputDir, configDir })
                 continue;
             }
 
-            const destDir = path.join(pluginDir, 'skills', skill.shortId);
+            // `shortId` is only unique within a skill group, but a plugin aggregates
+            // many groups — keying dirs by it let two skills overwrite each other.
+            // Use the globally-unique `id`, as the mega-plugin below already does.
+            if (seen.has(skill.id)) {
+                throw new Error(`Plugin "${pluginName}" has duplicate skill id "${skill.id}"`);
+            }
+            seen.add(skill.id);
+
+            const destDir = path.join(pluginDir, 'skills', skill.id);
             copyDirSync(srcDir, destDir);
 
             allSkillEntries.push({

--- a/scripts/lib/tests/marketplace-generator.test.js
+++ b/scripts/lib/tests/marketplace-generator.test.js
@@ -125,28 +125,17 @@ describe('generateMarketplace', () => {
         }
     });
 
-    it('logs the number of skills copied, not the number offered', () => {
-        const logged = [];
-        const log = console.log;
-        console.log = msg => logged.push(msg);
-        try {
-            // `missing-skill` has no source dir, so it is skipped with a warning.
-            run([skill('omnibus-instrument-integration'), skill('missing-skill')]);
-        } finally {
-            console.log = log;
-        }
+    it('skips a skill with no source dir instead of writing an empty one', () => {
+        // `missing-skill` has no source dir, so it is skipped with a warning. The
+        // build's own log line counts what was copied off the back of this.
+        run([skill('omnibus-instrument-integration'), skill('missing-skill')]);
 
-        expect(logged).toContain('  ✓ posthog-integration (1 skills)');
-    });
-
-    it('throws rather than overwriting when two skills share an id', () => {
-        expect(() =>
-            run([skill('omnibus-instrument-integration'), skill('omnibus-instrument-integration')]),
-        ).toThrow(/Duplicate skill id "omnibus-instrument-integration"/);
+        expect(pluginSkills('posthog-integration')).toEqual(['omnibus-instrument-integration']);
     });
 
     // The mega-plugin pools every plugin's skills, so a collision across two
-    // plugins reaches it even though neither plugin collides on its own.
+    // plugins reaches it even though neither plugin collides on its own. This
+    // subsumes the same-plugin case: it only passes if the guard is build-scoped.
     it('throws when two skills in different plugins share an id', () => {
         expect(() =>
             run([skill('logs-setup'), skill('logs-setup', { category: 'logs' })]),

--- a/scripts/lib/tests/marketplace-generator.test.js
+++ b/scripts/lib/tests/marketplace-generator.test.js
@@ -54,10 +54,16 @@ beforeEach(() => {
             '  integration:',
             '    name: posthog-integration',
             '    destination: skills/posthog/integration',
+            // A second plugin keeps the suite honest: keyed by `shortId` for even
+            // one plugin, the assertions below fail.
+            '  logs:',
+            '    name: posthog-logs',
+            '    destination: skills/posthog/logs',
         ].join('\n'),
     );
     writeSkillSource('omnibus-instrument-integration');
     writeSkillSource('omnibus-instrument-product-analytics');
+    writeSkillSource('logs-setup');
 });
 
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -71,6 +77,7 @@ describe('generateMarketplace', () => {
         const skills = [
             skill('omnibus-instrument-integration'),
             skill('omnibus-instrument-product-analytics'),
+            skill('logs-setup', { category: 'logs' }),
         ];
 
         const result = run(skills);
@@ -81,7 +88,26 @@ describe('generateMarketplace', () => {
             'omnibus-instrument-integration',
             'omnibus-instrument-product-analytics',
         ]);
+        // Every plugin is keyed the same way — `logs-setup` would land in
+        // `skills/all` too if any plugin still used `shortId`.
+        expect(pluginSkills('posthog-logs')).toEqual(['logs-setup']);
         expect(result.skillCount).toBe(skills.length);
+    });
+
+    it('pools every skill into the mega-plugin under its own id', () => {
+        const skills = [
+            skill('omnibus-instrument-integration'),
+            skill('omnibus-instrument-product-analytics'),
+            skill('logs-setup', { category: 'logs' }),
+        ];
+
+        run(skills);
+
+        expect(pluginSkills('posthog-all').sort()).toEqual([
+            'logs-setup',
+            'omnibus-instrument-integration',
+            'omnibus-instrument-product-analytics',
+        ]);
     });
 
     it('copies each skill intact, with no files bleeding across siblings', () => {
@@ -102,6 +128,14 @@ describe('generateMarketplace', () => {
     it('throws rather than overwriting when two skills share an id', () => {
         expect(() =>
             run([skill('omnibus-instrument-integration'), skill('omnibus-instrument-integration')]),
-        ).toThrow(/duplicate skill id "omnibus-instrument-integration"/);
+        ).toThrow(/Duplicate skill id "omnibus-instrument-integration"/);
+    });
+
+    // The mega-plugin pools every plugin's skills, so a collision across two
+    // plugins reaches it even though neither plugin collides on its own.
+    it('throws when two skills in different plugins share an id', () => {
+        expect(() =>
+            run([skill('logs-setup'), skill('logs-setup', { category: 'logs' })]),
+        ).toThrow(/Duplicate skill id "logs-setup"/);
     });
 });

--- a/scripts/lib/tests/marketplace-generator.test.js
+++ b/scripts/lib/tests/marketplace-generator.test.js
@@ -5,8 +5,9 @@ import path from 'path';
 import { generateMarketplace } from '../marketplace-generator.js';
 
 // Two skills from different groups sharing one category — the real shape of the
-// collision: `omnibus/instrument-integration` and `omnibus/instrument-product-analytics`
-// both declare `category: integration` with a single variant `id: all`.
+// #309 collision: `omnibus/instrument-integration` and
+// `omnibus/instrument-product-analytics` both declare `category: integration`
+// with a single variant `id: all`.
 const skill = (id, extra = {}) => ({
     id,
     shortId: 'all',
@@ -61,6 +62,10 @@ beforeEach(() => {
 
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
+// Regression tests for #309 — `posthog-integration` published
+// `omnibus-instrument-product-analytics` under `skills/all` while the
+// integration omnibus went missing, because plugin skill dirs were keyed by the
+// group-scoped `shortId` instead of the globally-unique `id`.
 describe('generateMarketplace', () => {
     it('gives every skill in a plugin its own directory, keyed by full id', () => {
         const skills = [

--- a/scripts/lib/tests/marketplace-generator.test.js
+++ b/scripts/lib/tests/marketplace-generator.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { generateMarketplace } from '../marketplace-generator.js';
+
+// Two skills from different groups sharing one category — the real shape of the
+// collision: `omnibus/instrument-integration` and `omnibus/instrument-product-analytics`
+// both declare `category: integration` with a single variant `id: all`.
+const skill = (id, extra = {}) => ({
+    id,
+    shortId: 'all',
+    category: 'integration',
+    displayName: id,
+    description: `${id} description`,
+    ...extra,
+});
+
+let dir;
+const tempDir = () => path.join(dir, 'built');
+const configDir = () => path.join(dir, 'context');
+const outputDir = () => path.join(dir, 'dist');
+const pluginSkills = plugin =>
+    fs.readdirSync(path.join(outputDir(), 'marketplace', 'plugins', plugin, 'skills'));
+
+function writeSkillSource(id) {
+    const skillDir = path.join(tempDir(), id);
+    fs.mkdirSync(path.join(skillDir, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `name: ${id}`);
+    fs.writeFileSync(path.join(skillDir, 'references', `${id}.md`), `${id} docs`);
+}
+
+const run = skills =>
+    generateMarketplace({
+        skills,
+        tempDir: tempDir(),
+        version: 'test',
+        outputDir: outputDir(),
+        configDir: configDir(),
+    });
+
+beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'marketplace-generator-'));
+    fs.mkdirSync(configDir(), { recursive: true });
+    fs.writeFileSync(
+        path.join(configDir(), 'marketplace.yaml'),
+        [
+            'target_repo: PostHog/skills',
+            'mega_plugin:',
+            '  name: posthog-all',
+            '  destination: skills/posthog/all',
+            'plugins:',
+            '  integration:',
+            '    name: posthog-integration',
+            '    destination: skills/posthog/integration',
+        ].join('\n'),
+    );
+    writeSkillSource('omnibus-instrument-integration');
+    writeSkillSource('omnibus-instrument-product-analytics');
+});
+
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('generateMarketplace', () => {
+    it('gives every skill in a plugin its own directory, keyed by full id', () => {
+        const skills = [
+            skill('omnibus-instrument-integration'),
+            skill('omnibus-instrument-product-analytics'),
+        ];
+
+        const result = run(skills);
+
+        // Keying by `shortId` collapsed both skills into `skills/all`, so one was
+        // silently dropped and the survivor inherited the loser's leftover files.
+        expect(pluginSkills('posthog-integration').sort()).toEqual([
+            'omnibus-instrument-integration',
+            'omnibus-instrument-product-analytics',
+        ]);
+        expect(result.skillCount).toBe(skills.length);
+    });
+
+    it('copies each skill intact, with no files bleeding across siblings', () => {
+        run([
+            skill('omnibus-instrument-integration'),
+            skill('omnibus-instrument-product-analytics'),
+        ]);
+
+        const dirOf = id =>
+            path.join(outputDir(), 'marketplace', 'plugins', 'posthog-integration', 'skills', id);
+
+        for (const id of ['omnibus-instrument-integration', 'omnibus-instrument-product-analytics']) {
+            expect(fs.readFileSync(path.join(dirOf(id), 'SKILL.md'), 'utf8')).toBe(`name: ${id}`);
+            expect(fs.readdirSync(path.join(dirOf(id), 'references'))).toEqual([`${id}.md`]);
+        }
+    });
+
+    it('throws rather than overwriting when two skills share an id', () => {
+        expect(() =>
+            run([skill('omnibus-instrument-integration'), skill('omnibus-instrument-integration')]),
+        ).toThrow(/duplicate skill id "omnibus-instrument-integration"/);
+    });
+});

--- a/scripts/lib/tests/marketplace-generator.test.js
+++ b/scripts/lib/tests/marketplace-generator.test.js
@@ -125,6 +125,20 @@ describe('generateMarketplace', () => {
         }
     });
 
+    it('logs the number of skills copied, not the number offered', () => {
+        const logged = [];
+        const log = console.log;
+        console.log = msg => logged.push(msg);
+        try {
+            // `missing-skill` has no source dir, so it is skipped with a warning.
+            run([skill('omnibus-instrument-integration'), skill('missing-skill')]);
+        } finally {
+            console.log = log;
+        }
+
+        expect(logged).toContain('  ✓ posthog-integration (1 skills)');
+    });
+
     it('throws rather than overwriting when two skills share an id', () => {
         expect(() =>
             run([skill('omnibus-instrument-integration'), skill('omnibus-instrument-integration')]),


### PR DESCRIPTION
Fixes #309.

`shortId` is unique only within a skill group, but a plugin aggregates many groups — so two skills collapsed into one directory. Keyed by `id` instead, which the mega-plugin already does.

Also fixes the log line that hid it: it counted skills offered rather than copied, so the build reported 40 while writing 39.

## Blast radius

Grouped-plugin skill dirs get their full id (`all` → `omnibus-instrument-integration`, `django` → `integration-django`). Nothing reads those names:

- Skills resolve by frontmatter `name:`, which has always been the full id — `integration/skills/django/SKILL.md` reads `name: integration-django` today. No invocation name changes; this fixes a skill going *missing*.
- `plugin.json` carries no skill list, and nothing in the repo hardcodes `skills/<name>`
- `posthog-all` already ships these exact names, so the two plugins converge
- The ai-plugin sync reads `posthog-all/skills`, already keyed by `id` — untouched

```bash
pnpm build | grep 'posthog-integration'                          # 40 skills, and now 40 on disk
ls dist/marketplace/plugins/posthog-integration/skills | wc -l   # 39 before, 40 after
```

## Won't reach PostHog/skills yet

`PostHog/skills` is [stale since March](https://github.com/PostHog/skills/commits/main/skills/posthog/integration/skills/all/SKILL.md) — the release workflow's push step is skipped after `Generate skills repo token` fails ([latest run](https://github.com/PostHog/context-mill/actions/runs/30665972908)), and recent syncs came from `releaser-skills[bot]` instead.

So #309's reproduction keeps returning the wrong `name:` until that sync runs again — you'll know which path owns it.
