### PR TITLE
fix(docs): repoint example-app paths after the examples/basics move

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,47 @@ These are more like model airplanes. They're dramatically simplified to make it 
 But the leanness makes these useful for agent-driven development. Use these as context to help your agent make better integration decisions about PostHog.
 
 ```
-examples/
-├── basics/
-│   ├── next-app-router/         # Next.js 15 with App Router
-│   ├── next-pages-router/       # Next.js 15 with Pages Router
-│   ├── react-react-router/      # React with React Router
-│   ├── react-tanstack-router-file-based/   # React with TanStack Router (file-based)
-│   ├── react-tanstack-router-code-based/   # React with TanStack Router (code-based)
-│   ├── tanstack-start/          # TanStack Start
-│   └── django/                  # Django
-├── mcp-commands/                # MCP command prompts (`/command` in agents)
-└── scripts/                     # Build scripts
+example-apps/
+├── android/                                # Android (Kotlin)
+├── angular/                                # Angular
+├── astro-hybrid/                           # Astro, hybrid rendering
+├── astro-ssr/                              # Astro, server-side rendering
+├── astro-static/                           # Astro, static output
+├── astro-view-transitions/                 # Astro with View Transitions
+├── django/                                 # Django
+├── elixir/                                 # Phoenix (Elixir)
+├── expo/                                   # Expo (React Native)
+├── fastapi/                                # FastAPI
+├── flask/                                  # Flask
+├── flutter/                                # Flutter
+├── go/                                     # Go (net/http)
+├── java-spring-boot/                       # Spring Boot (Java)
+├── javascript-node/                        # Node.js (Express, server-side)
+├── javascript-web/                         # Plain JavaScript, browser
+├── laravel/                                # Laravel
+├── next-app-router/                        # Next.js 15 with App Router
+├── next-pages-router/                      # Next.js 15 with Pages Router
+├── nuxt-3-6/                               # Nuxt 3.6
+├── nuxt-4/                                 # Nuxt 4
+├── php/                                    # Plain PHP
+├── python/                                 # Plain Python
+├── react-native/                           # React Native
+├── react-react-router-6/                   # React with React Router 6
+├── react-react-router-7-data/              # React Router 7, data mode
+├── react-react-router-7-declarative/       # React Router 7, declarative mode
+├── react-react-router-7-framework/         # React Router 7, framework mode
+├── react-tanstack-router-code-based/       # TanStack Router, code-based
+├── react-tanstack-router-file-based/       # TanStack Router, file-based
+├── react-vite/                             # React with Vite
+├── ruby/                                   # Plain Ruby
+├── ruby-on-rails/                          # Ruby on Rails
+├── rust/                                   # Rust (Axum)
+├── sveltekit/                              # SvelteKit
+├── swift/                                  # Swift (iOS)
+├── swift-xcodegen/                         # Swift with XcodeGen
+├── tanstack-start/                         # TanStack Start
+├── vue-3/                                  # Vue 3
+└── wordpress/                              # WordPress
 ```
 
 ## Build outputs

--- a/example-apps/expo/README.md
+++ b/example-apps/expo/README.md
@@ -16,7 +16,7 @@ A React Native Expo app demonstrating PostHog product analytics integration with
 ## Project Structure
 
 ```
-basics/expo/
+example-apps/expo/
 ├── app/                          # Expo Router screens (file-based routing)
 │   ├── _layout.tsx               # Root layout with PostHogProvider + AuthProvider
 │   ├── index.tsx                 # Home screen (login/welcome)
@@ -68,7 +68,7 @@ Then run `source ~/.zshrc` to apply.
 
 1. Install dependencies:
    ```bash
-   cd basics/expo
+   cd example-apps/expo
    npm install
    ```
 

--- a/example-apps/fastapi/README.md
+++ b/example-apps/fastapi/README.md
@@ -108,7 +108,7 @@ The `/api/test-error` endpoint demonstrates manual exception capture. Use `?capt
 ## Project Structure
 
 ```
-basics/fastapi/
+example-apps/fastapi/
 ├── app/
 │   ├── __init__.py              # Package marker
 │   ├── config.py                # Pydantic Settings configuration

--- a/example-apps/flask/README.md
+++ b/example-apps/flask/README.md
@@ -108,7 +108,7 @@ The `/api/test-error` endpoint demonstrates manual exception capture. Use `?capt
 ## Project Structure
 
 ```
-basics/flask/
+example-apps/flask/
 ├── app/
 │   ├── __init__.py              # Application factory
 │   ├── config.py                # Configuration classes

--- a/example-apps/javascript-node/README.md
+++ b/example-apps/javascript-node/README.md
@@ -82,7 +82,7 @@ The app tracks these events in PostHog:
 ## Code structure
 
 ```
-basics/javascript-node/
+example-apps/javascript-node/
 ├── todo.js              # Express server with PostHog tracking
 ├── package.json         # Node.js dependencies
 ├── .env.example         # Environment variable template

--- a/example-apps/javascript-web/README.md
+++ b/example-apps/javascript-web/README.md
@@ -59,7 +59,7 @@ The app tracks these custom events in PostHog (in addition to autocaptured click
 ## Code Structure
 
 ```
-basics/javascript/
+example-apps/javascript-web/
 ├── index.html           # Entry HTML page
 ├── package.json         # Dependencies (posthog-js, vite)
 ├── vite.config.js       # Vite configuration

--- a/example-apps/laravel/IMPLEMENTATION.md
+++ b/example-apps/laravel/IMPLEMENTATION.md
@@ -102,7 +102,7 @@ This document summarizes the implementation of the Laravel PostHog example appli
 ## 📁 File Structure
 
 ```
-basics/laravel/
+example-apps/laravel/
 ├── app/
 │   ├── Http/
 │   │   ├── Controllers/

--- a/example-apps/laravel/README.md
+++ b/example-apps/laravel/README.md
@@ -186,7 +186,7 @@ The `/api/test-error` endpoint demonstrates manual exception capture. Use `?capt
 ## Project Structure
 
 ```
-basics/laravel/
+example-apps/laravel/
 ├── app/
 │   ├── Http/
 │   │   ├── Controllers/

--- a/example-apps/php/README.md
+++ b/example-apps/php/README.md
@@ -71,7 +71,7 @@ The app tracks these events in PostHog:
 ## Code Structure
 
 ```
-basics/php/
+example-apps/php/
 ├── todo.php             # Main CLI application
 ├── composer.json        # PHP dependencies
 ├── .env.example         # Environment variable template

--- a/example-apps/python/README.md
+++ b/example-apps/python/README.md
@@ -76,7 +76,7 @@ The app tracks these events in PostHog:
 ## Code Structure
 
 ```
-basics/python/
+example-apps/python/
 ├── todo.py              # Main CLI application
 ├── requirements.txt     # Python dependencies
 ├── .env.example        # Environment variable template

--- a/example-apps/ruby/README.md
+++ b/example-apps/ruby/README.md
@@ -74,7 +74,7 @@ The app tracks these events in PostHog:
 ## Code Structure
 
 ```
-basics/ruby/
+example-apps/ruby/
 ├── todo.rb              # Main CLI application
 ├── Gemfile              # Ruby dependencies
 ├── .env.example         # Environment variable template


### PR DESCRIPTION
The example apps moved from `examples/basics/` to `example-apps/`, but the docs
still point to the old layout.

Nine example READMEs, laravel's IMPLEMENTATION.md, and the root README print `basics/<name>/` in their structure blocks, and expo's quick start says `cd basics/expo`, which
fails. These aren't just local docs. example-processor.js reads every file in an
example directory, README first, and that markdown ships inside the skill
bundles. `.md` isn't in skip-patterns.yaml, so
`grep -rn "basics/" --include="*.md" dist` returned hits across
dist/marketplace/plugins/... before this change. After it, nothing.

The root README tree was out of date in three ways: `examples/` doesn't exist,
the `basics/` level doesn't exist, and it listed 7 examples where there are now 40.

One extra: javascript-web's README pointed at `basics/javascript/`. The
directory is `javascript-web`, so the name needed updating along with the
parent.

Two things I'm less sure about. I left `mcp-commands/` out of the tree because I
couldn't find that directory anywhere in the repo. I also left out `scripts/`,
since it sits at the repo root rather than inside the examples. Happy to add
either back.