### PR TITLE
fix(ci): sign the commits this workflow creates

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -248,15 +248,23 @@ jobs:
           repositories: skills,ai-plugin
 
       - name: Push plugins to skills repo
+        id: skills_push
         env:
           SKILLS_REPO_TOKEN: ${{ steps.skills_token.outputs.token }}
         run: |
           MANIFEST="dist/push-manifest.json"
           TARGET_REPO=$(jq -r '.target_repo' "$MANIFEST")
-          WORK_DIR=$(mktemp -d)
+          # ghcommit-action resolves its `repository` input under $GITHUB_WORKSPACE,
+          # so the clone lives there rather than in a mktemp dir.
+          WORK_DIR="$GITHUB_WORKSPACE/.skills-push"
+          rm -rf "$WORK_DIR"
 
           echo "Cloning $TARGET_REPO..."
           git clone "https://x-access-token:${SKILLS_REPO_TOKEN}@github.com/${TARGET_REPO}.git" "$WORK_DIR"
+          {
+            echo "target_repo=$TARGET_REPO"
+            echo "target_branch=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD)"
+          } >> "$GITHUB_OUTPUT"
 
           # Read each plugin entry from the push manifest and sync to the destination
           jq -c '.plugins[]' "$MANIFEST" | while read -r entry; do
@@ -276,29 +284,41 @@ jobs:
             cp -r "$SOURCE"/. "$DEST"/
           done
 
-          # Commit and push
           cd "$WORK_DIR"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to push"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "Update generated plugins from context-mill v${RELEASE_VERSION}"
-            git push
-            echo "Pushed updated plugins to $TARGET_REPO"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-          rm -rf "$WORK_DIR"
+
+      # Both target repos require signed commits, so the mirrored content is
+      # committed through the GitHub API instead of pushed with git.
+      - name: Commit plugins to skills repo
+        if: steps.skills_push.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: Update generated plugins from context-mill ${{ env.RELEASE_TAG }}
+          repo: ${{ steps.skills_push.outputs.target_repo }}
+          branch: ${{ steps.skills_push.outputs.target_branch }}
+          repository: .skills-push
+        env:
+          GITHUB_TOKEN: ${{ steps.skills_token.outputs.token }}
 
       - name: Push omnibus skills to ai-plugin repo
+        id: ai_plugin_push
         env:
           SKILLS_REPO_TOKEN: ${{ steps.skills_token.outputs.token }}
         run: |
-          WORK_DIR=$(mktemp -d)
+          # Under $GITHUB_WORKSPACE so ghcommit-action can resolve it (see above).
+          WORK_DIR="$GITHUB_WORKSPACE/.ai-plugin-push"
+          rm -rf "$WORK_DIR"
           MEGA_SKILLS="dist/marketplace/plugins/posthog-all/skills"
 
           echo "Cloning PostHog/ai-plugin..."
           git clone "https://x-access-token:${SKILLS_REPO_TOKEN}@github.com/PostHog/ai-plugin.git" "$WORK_DIR"
+          echo "target_branch=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
 
           # Sync each omnibus skill, stripping the "omnibus-" prefix to match ai-plugin's layout
           for src in "$MEGA_SKILLS"/omnibus-*; do
@@ -313,17 +333,24 @@ jobs:
           done
 
           cd "$WORK_DIR"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to push to PostHog/ai-plugin"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "Update generated skills from context-mill v${RELEASE_VERSION}"
-            git push
-            echo "Pushed updated skills to PostHog/ai-plugin"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-          rm -rf "$WORK_DIR"
+
+      - name: Commit omnibus skills to ai-plugin repo
+        if: steps.ai_plugin_push.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: Update generated skills from context-mill ${{ env.RELEASE_TAG }}
+          repo: PostHog/ai-plugin
+          branch: ${{ steps.ai_plugin_push.outputs.target_branch }}
+          repository: .ai-plugin-push
+        env:
+          GITHUB_TOKEN: ${{ steps.skills_token.outputs.token }}
 
       - name: Build Summary
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -352,6 +352,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.skills_token.outputs.token }}
 
+      # Both clones embed the App token in their remote URL and now live in the
+      # workspace rather than a mktemp dir, so drop them before any later step runs.
+      - name: Remove the mirror clones
+        if: always()
+        run: rm -rf "$GITHUB_WORKSPACE/.skills-push" "$GITHUB_WORKSPACE/.ai-plugin-push"
+
       - name: Build Summary
         run: |
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Makes the workflow that commits in this repo produce **signed** commits.

Commits created with plain `git` are unsigned. PostHog is rolling the org-wide "Require signed commits" ruleset out to every repo, and this workflow would be rejected with `GH013` once it applies here. Routing the commit through the GitHub API instead means GitHub signs it with its own key, so it lands verified.

Found while inventorying which workflows across the org still create unsigned commits. `planetscale/ghcommit-action` is the pattern already in use in `posthog-js`, `posthog-roblox`, `brand`, `charts` and the SDK release fleet.

## Changes

The two mirror pushes (`PostHog/skills`, `PostHog/ai-plugin`) now commit through the API.

## Testing

Not run end to end. The working clones moved from `mktemp -d` into `$GITHUB_WORKSPACE/.skills-push` and `.ai-plugin-push`, because `ghcommit-action` resolves its `repository` input relative to the workspace. Both target repos already enforce signing, so these pushes were failing before this change.

---

## Review follow-up (pushed)

- Both mirror clones are now removed in an `if: always()` step. They embed the App token in `.git/config`, and moving them from `mktemp -d` into `$GITHUB_WORKSPACE` meant the token stayed readable by every later step in the job.

## Known limitation worth a decision before merge

**The API commit path cannot set an executable bit.** GraphQL `FileAddition` accepts only `path` and `contents` (verified by schema introspection), so a *newly* mirrored executable file lands as `100644`. Whether an *existing* `100755` file keeps its mode when its contents change is undocumented and I could not confirm it — no PostHog repo currently has an executable file that a `ghcommit` workflow has ever written.

Blast radius today is two files under the tree this workflow mirrors into `PostHog/skills`:

- `skills/posthog/all/hooks/skill-reminder.sh`
- `skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh`

Both are currently `100755`, and both were last written by the old plain-`git` mirror. If either loses its exec bit, the hook silently stops running. Worth checking the mode on the first real mirror run after this merges.
