### PR TITLE
fix(ai-observability): keep .env.example out of .gitignore

### DIFF
--- a/context/skills/ai-observability/references/3-instrument.md
+++ b/context/skills/ai-observability/references/3-instrument.md
@@ -16,7 +16,7 @@ Keep the setup at module level, next to the existing client. Under ten lines is 
 - Do not add module globals.
 - Do not add a presence check that raises. `os.environ["POSTHOG_API_KEY"]` already fails loudly when the key is unset.
 
-Route the token and host through env vars with `set_env_values`. Reuse the names the project already uses. Add the names to `.env.example` with empty values. Never write a real key to a file.
+Route the token and host through env vars with `set_env_values`. Reuse the names the project already uses. Add the names to `.env.example` with empty values. Never write a real key to a file. `.env.example` is documentation and must stay committed — if you edit `.gitignore`, ignore only `.env`, never `.env.example`.
 
 Agent frameworks use their own tracing hook in place of a wrapper. Take it from the install doc. Do not substitute an OTel instrumentor.
 


### PR DESCRIPTION
## Problem

Wizard-workbench CI runs of `wizard ai-observability` (context-mill v1.43.0) showed the agent adding `.env.example` to `.gitignore` on 2 of 9 test apps (`openai/node-weather`, `openai-agents/python-travel-triage`), hiding the env-var documentation the skill just asked it to write. The PR evaluator flagged both as MEDIUM.

## Cause

`3-instrument.md` says to add env var names to `.env.example` but never mentions `.gitignore`, so the agent improvises an overly cautious ignore.

## Fix

One explicit sentence: `.env.example` is documentation and must stay committed — if the agent edits `.gitignore`, it ignores only `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)