### PR TITLE
fix(integration-v2): build warehouse deep links from the app host

### DIFF
--- a/context/skills/integration-v2/warehouse/description.md
+++ b/context/skills/integration-v2/warehouse/description.md
@@ -115,8 +115,15 @@ Take the sources in turn.
 ### A `deep-link` source
 
 1. `[STATUS] <label> needs browser setup`
-2. Build the URL from your project context:
-   `<host>/project/<projectId>/data-warehouse/new-source?kind=<kind>&utm_source=wizard&utm_campaign=warehouse-source`
+2. Build the URL against the PostHog **app** host — the `Base URL` the PostHog
+   MCP reports in its active-environment block (for example
+   `https://us.posthog.com`). Do **not** use the ingestion host shown as
+   `PostHog Host` in your project context (for example `https://us.i.posthog.com`):
+   that serves the API, not the app UI, so a link built from it lands the user
+   nowhere.
+
+   `<app-host>/project/<projectId>/data-warehouse/new-source?kind=<kind>&utm_source=wizard&utm_campaign=warehouse-source`
+
    Keep the `utm_*` parameters exactly as written — they attribute a source
    finished in the browser back to this run.
 3. Tell the user to open it to finish connecting `<label>`, and carry the URL


### PR DESCRIPTION
## Why

The browser deep-link is the primary recovery path whenever warehouse credentials are declined, timed out, capped, or `wizard_ask` is unavailable — so a broken link quietly loses the user at exactly the fallback moment. The skill built the link "from your project context" with a generic `<host>`, but the host injected into that context is the ingestion/API host (e.g. `us.i.posthog.com`), which doesn't serve the app UI. Agents that used the MCP's active-environment Base URL instead produced working links.

## What changed

`context/skills/integration-v2/warehouse/description.md`:

- Change the deep-link construction to use the PostHog **app** host — the `Base URL` from the PostHog MCP active-environment block — and explicitly call out the ingestion host as the one not to use.

The deeper fix belongs in the wizard (it labels the ingestion host as "PostHog Host" in the injected project context and exposes no app host there); this skill-side change is the reliable path today because the agent can read the app host from the MCP. Prose-only skill change; `npm run build` and `npm test` pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
