### PR TITLE
feat(mcp-analytics): detect and instrument MCP TypeScript SDK v2 servers

### DIFF
--- a/context/skills/mcp-analytics/config.yaml
+++ b/context/skills/mcp-analytics/config.yaml
@@ -15,6 +15,8 @@ variants:
     tags: [javascript_node, mcp]
     docs_urls:
       - https://posthog.com/docs/mcp-analytics/installation.md
+      - url: https://posthog.com/docs/mcp-analytics/sdk-v2.md
+        title: MCP TypeScript SDK v1 vs v2 — read when the project uses @modelcontextprotocol/server
       - https://posthog.com/docs/mcp-analytics/custom-servers.md
       - https://posthog.com/docs/mcp-analytics/intent.md
       - https://posthog.com/docs/mcp-analytics/identifying-users.md
@@ -26,6 +28,11 @@ variants:
     tags: [python, mcp]
     docs_urls:
       - https://posthog.com/docs/mcp-analytics/installation.md
+      # Bundled here too, even though it's a TypeScript page: description.md is
+      # shared by both variants and points at it, so omitting it would leave a
+      # dangling reference. Its own callout tells a Python reader what applies.
+      - url: https://posthog.com/docs/mcp-analytics/sdk-v2.md
+        title: MCP TypeScript SDK v1 vs v2 — read when the project uses @modelcontextprotocol/server
       - https://posthog.com/docs/mcp-analytics/custom-servers.md
       - https://posthog.com/docs/mcp-analytics/intent.md
       - https://posthog.com/docs/mcp-analytics/identifying-users.md

--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -33,13 +33,16 @@ Follow these steps IN ORDER. Each step has a **TypeScript / JavaScript** part an
 Determine the language first, then route to the matching instructions throughout:
 
 - **TypeScript / JavaScript** — there's a `package.json`. Look for MCP signals in dependencies and source:
-  - `@modelcontextprotocol/sdk` — the official SDK (most common).
+  - `@modelcontextprotocol/sdk` — the official SDK, **v1** (most common).
+  - `@modelcontextprotocol/server` / `@modelcontextprotocol/core` / `@modelcontextprotocol/client` — the official SDK, **v2**. A v2 project has no `@modelcontextprotocol/sdk` at all, so never read that one package's absence as "no MCP server here".
   - `mcp-handler` — the Next.js / Vercel adapter.
   - `@rekog/mcp-nest` — the NestJS adapter (tools defined with `@Tool()` decorators; the server is built inside `McpModule.forRoot(...)`, so there's no `new McpServer` in user code).
   - `fastmcp`, `xmcp`, or a similar TS MCP framework.
   - A custom HTTP/edge handler speaking the MCP protocol directly (JSON-RPC methods like `tools/call`, `initialize`, an `Mcp-Session-Id` header) with none of the above.
 
   Determine the package manager from the lockfile (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`).
+
+  **Note which SDK major the project is on** — STEP 3 and STEP 4 both depend on it. `sdk-v2.md` is the reference for everything v2-specific.
 
 - **Python** — there's a `pyproject.toml`, `requirements.txt`, or `setup.py`, or `.py` sources. Look for MCP signals:
   - the official `mcp` package — `from mcp.server.fastmcp import FastMCP` or `from mcp.server.lowlevel import Server`.
@@ -54,11 +57,11 @@ Then identify the file and the exact place where the server is constructed or wh
 
 ### STEP 2: Choose the instrumentation path
 
-Pick exactly one based on what STEP 1 found. When in doubt, read the bundled reference docs — `installation.md` covers the wrapping paths; `custom-servers.md` covers the custom-dispatcher paths.
+Pick exactly one based on what STEP 1 found. When in doubt, read the bundled reference docs — `installation.md` covers the wrapping paths; `custom-servers.md` covers the custom-dispatcher paths; `sdk-v2.md` covers what differs on MCP SDK v2.
 
 **TypeScript / JavaScript:**
 
-- **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)` from `@modelcontextprotocol/sdk`): wrap it with `instrument(server, posthog)`. One line.
+- **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)`, from `@modelcontextprotocol/sdk` on v1 or `@modelcontextprotocol/server` on v2): wrap it with `instrument(server, posthog)`. One line. `instrument()` detects the server's shape at runtime, so the call is the same on both majors — never branch the code you write on which major is installed.
 - **Path B — `mcp-handler`** (`createMcpHandler((server) => { ... })`): same `instrument(server, posthog)` call, inside the setup callback. Because Vercel's transport is stateless, also wire `identify` (STEP 4) and flush per invocation (STEP 6).
 - **Path C — custom dispatcher** (Hono / Express / Cloudflare Worker / edge function with no SDK server object to wrap): use the `PostHogMCP` client and call `captureToolCall` / `captureInitialize` yourself at the dispatch points.
 - **Path D — `@rekog/mcp-nest`** (NestJS): the framework builds the server, so there's no `new McpServer` for you to wrap. Instrument it through the module's `serverMutator` hook in `McpModule.forRoot(...)`. See STEP 4.
@@ -71,6 +74,8 @@ Pick exactly one based on what STEP 1 found. When in doubt, read the bundled ref
 ### STEP 3: Install the SDK
 
 - **TypeScript / JavaScript:** install `@posthog/mcp` and `posthog-node` with the project's package manager, pinning `@posthog/mcp` to its current published version (it's pre-1.0) — e.g. `pnpm add @posthog/mcp@<latest> posthog-node`. Read the installed version back from `package.json` / the lockfile rather than guessing.
+  - **Never install an MCP SDK.** Both majors are *optional* peer dependencies, and the project already has the one it uses. Adding the other pulls in a whole SDK the code never imports.
+  - **On SDK v2, `@posthog/mcp` must be `>=0.11.2`.** If the project already depends on something older, upgrade it — earlier versions rejected high-level v2 servers in a compatibility check that `instrument()` swallows, so the integration looked healthy and captured nothing at all.
 - **Python:** the SDK ships inside `posthog`, so install (or require) `posthog>=7.21` with the project's installer — e.g. `pip install "posthog>=7.21"`, `uv add posthog`, `poetry add posthog`. The MCP SDK itself (`mcp` / `fastmcp`) is a peer dependency you already have — you built the server with it — so don't add it. A custom-dispatcher (path P2) project needs nothing beyond `posthog`.
 
 ### STEP 4: Instrument the server
@@ -90,6 +95,8 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
 **Path A — official SDK server:**
 
 ```ts
+// v1: import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+// v2: import { McpServer } from "@modelcontextprotocol/server"
 import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
@@ -97,18 +104,27 @@ const analytics = instrument(server, posthog) // wrap immediately after construc
 // register tools as usual — tools added after instrument() are still captured
 ```
 
-`instrument()` is idempotent per server and returns an analytics handle (used later for custom events). It works on both the low-level `Server` and the high-level `McpServer`.
+Match the import to the major found in STEP 1; the `instrument()` line is identical either way. On v2 tools register with `registerTool()` — the deprecated `server.tool()` was removed.
+
+`instrument()` is idempotent per server and returns an analytics handle (used later for custom events). It works on both the low-level `Server` and the high-level `McpServer`. If the project already calls `instrument(server.server)` — a workaround for an old compatibility check that rejected high-level v2 servers — change it back to `instrument(server)`.
 
 **Path B — `mcp-handler`:** call `instrument(server, posthog)` as the first line of the setup callback, with the `posthog` client created at module scope (not per request). Because the transport is stateless, group calls by user with `identify`:
 
 ```ts
+import { instrument, getRequestHeaders } from "@posthog/mcp"
+
 const handler = createMcpHandler((server) => {
   instrument(server, posthog, {
-    identify: (request, extra) => ({ distinctId: getUserId(extra) }),
+    identify: async (request, extra) => {
+      const token = getRequestHeaders(extra)?.["authorization"]
+      return token ? { distinctId: await resolveUserId(token) } : null
+    },
   })
   server.registerTool("...", { /* ... */ }, async () => { /* ... */ })
 })
 ```
+
+**Always read request headers through `getRequestHeaders(extra)`** — in `identify`, `intentFallback`, `eventProperties` and `beforeSend` alike. The callback receives the MCP SDK's `extra` unchanged, and the majors shape it differently: v1 puts a plain object at `extra.requestInfo.headers`, v2 attaches a WHATWG `Request` at `extra.http.req` whose headers only answer to `.get()`. A v1-shaped read returns `undefined` on v2, so `identify()` returns `null` and every event goes out anonymous with no error anywhere. The helper handles both and returns a plain lowercase-keyed object. See `sdk-v2.md`.
 
 **Path C — custom dispatcher:** swap the existing PostHog client for `PostHogMCP` (a drop-in `posthog-node` subclass) and call the capture helpers at the dispatch points. Read `custom-servers.md` for the full field reference before editing.
 
@@ -162,6 +178,8 @@ class AppModule {}
 ```
 
 `instrumentMutator` returns the server (not `instrument()`'s handle), so it slots straight into the hook. Compose with an existing `serverMutator` if there is one, and handlers nest registers after the mutator runs are still captured. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), call `instrument()` directly inside your own mutator and keep its handle, returning the server yourself.
+
+**Sessions on an SDK v2 server.** Protocol revision is a property of each *request*, not of the server — a v2 server serves `2025-11-25` traffic too — so instrument once and never branch on the major. The `2026-07-28` revision removed the `initialize` handshake and the `Mcp-Session-Id` header, so on that traffic **every request becomes its own `$session_id`** unless `enableConversationId: true` is set. If the project targets it, offer that option and say what it buys. `sdk-v2.md` has the rest, including why `$mcp_client_name` can be absent on `2025-11-25` traffic behind `createMcpHandler`, and which `2026-07-28` features aren't instrumented yet.
 
 #### Python
 
@@ -254,7 +272,7 @@ The PostHog client batches events; the user owns the client's lifecycle.
 
 {references}
 
-`installation.md` is the source of truth for the wrapping paths (A/B and Python P1) and the full `instrument()` options table (`identify`, `context`/intent, `enableConversationId`/`enable_conversation_id`, `reportMissing`/`report_missing`, `beforeSend`/`before_send`, `eventProperties`/`event_properties`). `custom-servers.md` is the source of truth for the custom-dispatcher paths (C and P2) — `PostHogMCP`, `captureToolCall`/`capture_tool_call`, `captureInitialize`/`capture_initialize`, and the per-call field mapping. `intent.md`, `identifying-users.md`, and `conversation-id.md` cover optional enrichment; `events.md` and `custom-events.md` describe what gets captured. The event/property vocabulary is identical across both SDKs.
+`installation.md` is the source of truth for the wrapping paths (A/B and Python P1) and the full `instrument()` options table (`identify`, `context`/intent, `enableConversationId`/`enable_conversation_id`, `reportMissing`/`report_missing`, `beforeSend`/`before_send`, `eventProperties`/`event_properties`). `custom-servers.md` is the source of truth for the custom-dispatcher paths (C and P2) — `PostHogMCP`, `captureToolCall`/`capture_tool_call`, `captureInitialize`/`capture_initialize`, and the per-call field mapping. `sdk-v2.md` (TypeScript only) is the source of truth for everything that differs between MCP TypeScript SDK v1 and v2 — which package is which major, the `getRequestHeaders` migration, sessions on `2026-07-28`, and the revision features not instrumented yet. `intent.md`, `identifying-users.md`, and `conversation-id.md` cover optional enrichment; `events.md` and `custom-events.md` describe what gets captured. The event/property vocabulary is identical across both SDKs.
 
 ## Key principles
 

--- a/context/skills/mcp-analytics/description.md
+++ b/context/skills/mcp-analytics/description.md
@@ -42,7 +42,7 @@ Determine the language first, then route to the matching instructions throughout
 
   Determine the package manager from the lockfile (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`).
 
-  **Note which SDK major the project is on** — STEP 3 and STEP 4 both depend on it. `sdk-v2.md` is the reference for everything v2-specific.
+  **Record which SDK major the project is on.** STEP 2, STEP 3, and STEP 4 each contain a **For `@modelcontextprotocol/sdk` (v1)** and a **For `@modelcontextprotocol/server` (v2)** section — follow only the one matching the major found here. `sdk-v2.md` is the reference for everything v2-specific.
 
 - **Python** — there's a `pyproject.toml`, `requirements.txt`, or `setup.py`, or `.py` sources. Look for MCP signals:
   - the official `mcp` package — `from mcp.server.fastmcp import FastMCP` or `from mcp.server.lowlevel import Server`.
@@ -59,24 +59,47 @@ Then identify the file and the exact place where the server is constructed or wh
 
 Pick exactly one based on what STEP 1 found. When in doubt, read the bundled reference docs — `installation.md` covers the wrapping paths; `custom-servers.md` covers the custom-dispatcher paths; `sdk-v2.md` covers what differs on MCP SDK v2.
 
-**TypeScript / JavaScript:**
+#### TypeScript / JavaScript
 
-- **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)`, from `@modelcontextprotocol/sdk` on v1 or `@modelcontextprotocol/server` on v2): wrap it with `instrument(server, posthog)`. One line. `instrument()` detects the server's shape at runtime, so the call is the same on both majors — never branch the code you write on which major is installed.
+- **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)` from the official SDK, either major): wrap it with `instrument(server, posthog)`. One line. `instrument()` detects the server's shape at runtime, so the call is the same on both majors — never branch the code you write on which major is installed.
 - **Path B — `mcp-handler`** (`createMcpHandler((server) => { ... })`): same `instrument(server, posthog)` call, inside the setup callback. Because Vercel's transport is stateless, also wire `identify` (STEP 4) and flush per invocation (STEP 6).
 - **Path C — custom dispatcher** (Hono / Express / Cloudflare Worker / edge function with no SDK server object to wrap): use the `PostHogMCP` client and call `captureToolCall` / `captureInitialize` yourself at the dispatch points.
 - **Path D — `@rekog/mcp-nest`** (NestJS): the framework builds the server, so there's no `new McpServer` for you to wrap. Instrument it through the module's `serverMutator` hook in `McpModule.forRoot(...)`. See STEP 4.
 
-**Python:**
+On Paths A and B, the SDK major recorded in STEP 1 decides the specifics — STEP 3 and STEP 4 each have a matching section per major:
+
+##### For @modelcontextprotocol/sdk (v1)
+
+The server object comes from `@modelcontextprotocol/sdk`. Follow the **v1** sections of STEP 3 and STEP 4; `installation.md` is the reference.
+
+##### For @modelcontextprotocol/server (v2)
+
+The server object comes from `@modelcontextprotocol/server`. Follow the **v2** sections of STEP 3 and STEP 4; `sdk-v2.md` is the reference for everything v2-specific.
+
+#### Python
 
 - **Path P1 — a FastMCP or low-level Server** (the official `mcp` package's `FastMCP`/`Server`, or jlowin's `fastmcp` 2.0): wrap it with `instrument(server, posthog)`. One line — the SDK detects which framework it is.
 - **Path P2 — custom dispatcher** (FastAPI / Starlette / Flask / edge with no server object to wrap): use the `PostHogMCP` client and call `capture_tool_call` / `capture_initialize` yourself at the dispatch points.
 
 ### STEP 3: Install the SDK
 
-- **TypeScript / JavaScript:** install `@posthog/mcp` and `posthog-node` with the project's package manager, pinning `@posthog/mcp` to its current published version (it's pre-1.0) — e.g. `pnpm add @posthog/mcp@<latest> posthog-node`. Read the installed version back from `package.json` / the lockfile rather than guessing.
-  - **Never install an MCP SDK.** Both majors are *optional* peer dependencies, and the project already has the one it uses. Adding the other pulls in a whole SDK the code never imports.
-  - **On SDK v2, `@posthog/mcp` must be `>=0.11.2`.** If the project already depends on something older, upgrade it — earlier versions rejected high-level v2 servers in a compatibility check that `instrument()` swallows, so the integration looked healthy and captured nothing at all.
-- **Python:** the SDK ships inside `posthog`, so install (or require) `posthog>=7.21` with the project's installer — e.g. `pip install "posthog>=7.21"`, `uv add posthog`, `poetry add posthog`. The MCP SDK itself (`mcp` / `fastmcp`) is a peer dependency you already have — you built the server with it — so don't add it. A custom-dispatcher (path P2) project needs nothing beyond `posthog`.
+#### TypeScript / JavaScript
+
+Install `@posthog/mcp` and `posthog-node` with the project's package manager, pinning `@posthog/mcp` to its current published version (it's pre-1.0) — e.g. `pnpm add @posthog/mcp@<latest> posthog-node`. Read the installed version back from `package.json` / the lockfile rather than guessing.
+
+**Never install an MCP SDK.** Both majors are *optional* peer dependencies of `@posthog/mcp`, and the project already has the one it uses. Adding the other pulls in a whole SDK the code never imports.
+
+##### For @modelcontextprotocol/sdk (v1)
+
+No extra constraint — pinning the current published `@posthog/mcp` release is enough.
+
+##### For @modelcontextprotocol/server (v2)
+
+`@posthog/mcp` must be **`>=0.11.2`**. If the project already depends on something older, upgrade it — earlier versions rejected high-level v2 servers in a compatibility check that `instrument()` swallows, so the integration looked healthy and captured nothing at all.
+
+#### Python
+
+The SDK ships inside `posthog`, so install (or require) `posthog>=7.21` with the project's installer — e.g. `pip install "posthog>=7.21"`, `uv add posthog`, `poetry add posthog`. The MCP SDK itself (`mcp` / `fastmcp`) is a peer dependency you already have — you built the server with it — so don't add it. A custom-dispatcher (path P2) project needs nothing beyond `posthog`.
 
 ### STEP 4: Instrument the server
 
@@ -92,11 +115,12 @@ const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
 })
 ```
 
-**Path A — official SDK server:**
+**Path A — official SDK server:** wrap the server with `instrument(server, posthog)` immediately after constructing it. `instrument()` is idempotent per server and returns an analytics handle (used later for custom events). It works on both the low-level `Server` and the high-level `McpServer`, and the wrapping line is identical on both majors — only the SDK import differs. Use the section matching the major from STEP 1:
+
+##### For @modelcontextprotocol/sdk (v1)
 
 ```ts
-// v1: import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-// v2: import { McpServer } from "@modelcontextprotocol/server"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { instrument } from "@posthog/mcp"
 
 const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
@@ -104,9 +128,22 @@ const analytics = instrument(server, posthog) // wrap immediately after construc
 // register tools as usual — tools added after instrument() are still captured
 ```
 
-Match the import to the major found in STEP 1; the `instrument()` line is identical either way. On v2 tools register with `registerTool()` — the deprecated `server.tool()` was removed.
+##### For @modelcontextprotocol/server (v2)
 
-`instrument()` is idempotent per server and returns an analytics handle (used later for custom events). It works on both the low-level `Server` and the high-level `McpServer`. If the project already calls `instrument(server.server)` — a workaround for an old compatibility check that rejected high-level v2 servers — change it back to `instrument(server)`.
+```ts
+import { McpServer } from "@modelcontextprotocol/server"
+import { instrument } from "@posthog/mcp"
+
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" })
+const analytics = instrument(server, posthog) // wrap immediately after constructing the server
+// register tools with registerTool() as usual — tools added after instrument() are still captured
+```
+
+v2 reminders:
+
+- Tools register with `registerTool()` — the deprecated `server.tool()` was removed in v2.
+- `@posthog/mcp` must be `>=0.11.2` (STEP 3).
+- If the project already calls `instrument(server.server)` — a workaround for an old compatibility check that rejected high-level v2 servers — change it back to `instrument(server)`.
 
 **Path B — `mcp-handler`:** call `instrument(server, posthog)` as the first line of the setup callback, with the `posthog` client created at module scope (not per request). Because the transport is stateless, group calls by user with `identify`:
 
@@ -124,7 +161,7 @@ const handler = createMcpHandler((server) => {
 })
 ```
 
-**Always read request headers through `getRequestHeaders(extra)`** — in `identify`, `intentFallback`, `eventProperties` and `beforeSend` alike. The callback receives the MCP SDK's `extra` unchanged, and the majors shape it differently: v1 puts a plain object at `extra.requestInfo.headers`, v2 attaches a WHATWG `Request` at `extra.http.req` whose headers only answer to `.get()`. A v1-shaped read returns `undefined` on v2, so `identify()` returns `null` and every event goes out anonymous with no error anywhere. The helper handles both and returns a plain lowercase-keyed object. See `sdk-v2.md`.
+**Always read request headers through `getRequestHeaders(extra)`** — in `identify`, `intentFallback`, `eventProperties` and `beforeSend` alike, on either major. The callbacks receive the MCP SDK's `extra` unchanged, and the two majors shape its headers differently — a hand-rolled read that works on one silently returns `undefined` on the other, so `identify()` returns `null` and every event goes out anonymous with no error anywhere. The helper handles both majors and returns a plain lowercase-keyed object. `sdk-v2.md` documents the per-major shapes.
 
 **Path C — custom dispatcher:** swap the existing PostHog client for `PostHogMCP` (a drop-in `posthog-node` subclass) and call the capture helpers at the dispatch points. Read `custom-servers.md` for the full field reference before editing.
 
@@ -179,7 +216,9 @@ class AppModule {}
 
 `instrumentMutator` returns the server (not `instrument()`'s handle), so it slots straight into the hook. Compose with an existing `serverMutator` if there is one, and handlers nest registers after the mutator runs are still captured. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), call `instrument()` directly inside your own mutator and keep its handle, returning the server yourself.
 
-**Sessions on an SDK v2 server.** Protocol revision is a property of each *request*, not of the server — a v2 server serves `2025-11-25` traffic too — so instrument once and never branch on the major. The `2026-07-28` revision removed the `initialize` handshake and the `Mcp-Session-Id` header, so on that traffic **every request becomes its own `$session_id`** unless `enableConversationId: true` is set. If the project targets it, offer that option and say what it buys. `sdk-v2.md` has the rest, including why `$mcp_client_name` can be absent on `2025-11-25` traffic behind `createMcpHandler`, and which `2026-07-28` features aren't instrumented yet.
+##### For @modelcontextprotocol/server (v2), any path — sessions and protocol revisions
+
+Protocol revision is a property of each *request*, not of the server — a v2 server serves `2025-11-25` traffic too — so instrument once and never branch on the major. The `2026-07-28` revision removed the `initialize` handshake and the `Mcp-Session-Id` header, so on that traffic **every request becomes its own `$session_id`** unless `enableConversationId: true` is set. If the project targets it, offer that option and say what it buys. `sdk-v2.md` has the rest, including why `$mcp_client_name` can be absent on `2025-11-25` traffic behind `createMcpHandler`, and which `2026-07-28` features aren't instrumented yet.
 
 #### Python
 


### PR DESCRIPTION
`@posthog/mcp` has supported both MCP TypeScript SDK majors since 0.11.1, and PostHog/posthog.com#19545 just documented them. The `mcp-analytics` skill still described a v1-only world.

## The one that matters

STEP 1 listed `@modelcontextprotocol/sdk` as the only official-SDK detection signal, and its guardrail aborts with `[ABORT] no mcp server found` when nothing matches. A v2 project depends on `@modelcontextprotocol/server` and `/core` and has **no** `@modelcontextprotocol/sdk` at all — so `wizard mcp-analytics` could turn it away before opening a single reference doc.

That is why the docs PR alone could not fix v2 projects: detection gates whether the agent ever reaches the docs.

## Also corrected

| | |
|---|---|
| Path A | Named only v1's import. Now carries both, and notes v2 registers tools with `registerTool()` (`server.tool()` was removed). The `instrument()` call is unchanged — shape is detected at runtime, so emitted code must not branch on the major |
| STEP 3 | Silent on peers. Now: never install an MCP SDK (both majors are optional peers, the project has the one it uses), and `>=0.11.2` on v2 — earlier versions rejected high-level v2 servers in a check `instrument()` swallows, so the integration looked healthy and captured nothing |
| Path B `identify` | Read headers off `extra` directly — exactly the failure the docs PR targeted. v2 puts the request at `extra.http.req` as a WHATWG `Request`, so a v1-shaped read returns `undefined`, `identify()` returns `null`, and **every event goes out anonymous with no error anywhere**. Now uses the exported `getRequestHeaders` |
| Sessions | Nothing on `2026-07-28`. Now notes it removed the handshake and session header, so every request is its own `$session_id` unless `enableConversationId` is set |

## Bundling `sdk-v2.md`

`docs_urls` is a build-time allowlist, so the new page had to be added explicitly — the seven *corrected* pages come along free on the next build, since they're the same URLs.

It goes to **both** variants, not the TypeScript one alone: `description.md` is shared, so a TS-only bundle left the Python skill with five pointers to a file it doesn't ship. The page's own "Python soon, no `2026-07-28` yet" callout is useful there regardless.

Depth stays in the doc; the skill carries only what it needs to stop being wrong.

## Checked

Cold build (`rm -rf .docs-cache`) succeeds; `sdk-v2.md` is bundled and named in `{references}` in both skills; the four corrected pages fetched post-deploy copies. `npm test` 143/143.

⚠️ **Whoever cuts the release**: `DOC_CACHE_TTL_MS` defaults to 24h, so a machine that built in the last day will silently reuse pre-deploy copies of the corrected pages. Build with `DOCS_CACHE_TTL_MS=0` or after `rm -rf .docs-cache`.

No wizard release needed — skills are fetched from the context-mill release at runtime.

## Follow-up: env var mismatch — resolved in posthog.com#19598

The original note here said `sdk-v2.md` was the outlier using `POSTHOG_PROJECT_API_KEY`. Investigation showed the premise was inverted: **every** mcp-analytics docs page used `POSTHOG_PROJECT_API_KEY` (`installation.md` ×6, `start-here.md`, `custom-servers.md`, `sdk-v2.md`, plus the tutorial), while this skill's `description.md` — and the posthog.com-wide and context-mill-wide convention — is `POSTHOG_PROJECT_TOKEN`. So a `sdk-v2.md`-only fix would have left the same skill/docs mismatch via `installation.md`.

PostHog/posthog.com#19598 renames the env var to `POSTHOG_PROJECT_TOKEN` across all five mcp-analytics files. No change needed in this PR — the skill already uses the right name.

⚠️ Same cache caveat as above, one more reason to build fresh: the corrected env var only lands in the bundle if the release is built after the posthog.com PR merges and deploys, with `DOCS_CACHE_TTL_MS=0` or a cleared `.docs-cache`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

