### PR TITLE
fix(skills): scanner skeletons pin a model posthog no longer accepts

### DIFF
--- a/context/skills/replay-vision-scanner-broken-experiences/description.md
+++ b/context/skills/replay-vision-scanner-broken-experiences/description.md
@@ -20,7 +20,7 @@ Create with `vision-scanners-create`. Two blanks: the `query` and
     ]
   },
   "sampling_rate": 0.5,
-  "model": "gemini-3.6-flash"
+  "model": "gemini-3-flash-preview"
 }
 ```
 

--- a/context/skills/replay-vision-scanner-session-summaries/description.md
+++ b/context/skills/replay-vision-scanner-session-summaries/description.md
@@ -15,7 +15,7 @@ blank: `{{PRODUCT_CONTEXT}}`. Everything else is locked.
     "kind": "RecordingsQuery"
   },
   "sampling_rate": 0.1,
-  "model": "gemini-3.6-flash"
+  "model": "gemini-3-flash-preview"
 }
 ```
 

--- a/context/skills/replay-vision-scanner-user-frustration/description.md
+++ b/context/skills/replay-vision-scanner-user-frustration/description.md
@@ -17,7 +17,7 @@ is locked.
     "events": [{ "id": "$rageclick", "type": "events" }]
   },
   "sampling_rate": 1.0,
-  "model": "gemini-3.6-flash"
+  "model": "gemini-3-flash-preview"
 }
 ```
 

--- a/context/skills/self-driving/references/6c-replay-vision-scanners.md
+++ b/context/skills/self-driving/references/6c-replay-vision-scanners.md
@@ -115,7 +115,7 @@ The product visibly breaking, on the flow where breaking costs the most. This is
     ]
   },
   "sampling_rate": 0.5,
-  "model": "gemini-3.6-flash"
+  "model": "gemini-3-flash-preview"
 }
 ```
 
@@ -136,7 +136,7 @@ The user getting stuck. Gated on `$rageclick` — cheap, high-precision, and her
     "events": [{ "id": "$rageclick", "type": "events" }]
   },
   "sampling_rate": 1.0,
-  "model": "gemini-3.6-flash"
+  "model": "gemini-3-flash-preview"
 }
 ```
 


### PR DESCRIPTION
## Problem

Every scanner the `replay-vision` command (and self-driving step 6c) tries to create fails with a 400: the skeletons pin `"model": "gemini-3.6-flash"`, which posthog retired and remapped to 3.7 (migration 0076). The step-skills treat the 400 as a per-scanner follow-up, so a run "succeeds" while creating zero scanners.

## Changes

- Swap `gemini-3.6-flash` → `gemini-3-flash-preview` in the three replay-vision scanner skeletons and self-driving's 6c reference.
- `gemini-3-flash-preview` is posthog's current default flash tier (5 credits/observation vs 15 for `gemini-3.7-flash`), matching the in-product sizing skill's "start at the default" guidance - it also cuts the skeletons' projected spend to a third.

`node scripts/build.js` passes.