### PR TITLE
feat(wizard-ci): let a PR comment pin the wizard ref

### DIFF
--- a/.github/workflows/wizard-ci-trigger.yml
+++ b/.github/workflows/wizard-ci-trigger.yml
@@ -131,6 +131,11 @@ jobs:
             }
 
             bodyParts.push('');
+            bodyParts.push('**Test against a wizard branch:**');
+            bodyParts.push('- `/wizard-ci all wizard:my-branch`');
+            bodyParts.push('');
+            bodyParts.push('Add `wizard:<branch>` to any command above to pin the wizard branch. It defaults to `main`.');
+            bodyParts.push('');
             bodyParts.push('Results will be posted here when complete.');
 
             const body = bodyParts.join('\n');
@@ -185,7 +190,36 @@ jobs:
 
             const comment = context.payload.comment.body;
             const match = comment.match(/\/wizard-ci\s+(\S+)/);
-            const app = match ? match[1] : 'all';
+            const firstArg = match ? match[1] : 'all';
+
+            // A reviewer can pin the companion repo with `wizard:<ref>`.
+            // A lone pin is not an app name, so fall back to every app.
+            const app = firstArg.startsWith('wizard:') ? 'all' : firstArg;
+
+            // The ref arrives in a PR comment, so treat it as untrusted. Accept
+            // git ref characters only. Reject traversal, a leading dash and a
+            // trailing slash.
+            const isPlausibleRef = (ref) =>
+              ref.length <= 200 &&
+              /^[A-Za-z0-9._\/-]+$/.test(ref) &&
+              !ref.includes('..') &&
+              !ref.startsWith('-') &&
+              !ref.startsWith('/') &&
+              !ref.endsWith('/');
+
+            // Read the pin from the command line only, not from later prose.
+            const companion = comment
+              .split(/\r?\n/)[0]
+              .match(/(?:^|\s)wizard:(\S+)/);
+            const wizardRef = companion ? companion[1] : null;
+
+            if (wizardRef && !isPlausibleRef(wizardRef)) {
+              core.setFailed(
+                'The wizard ref is not a valid git ref. ' +
+                  'Use `/wizard-ci <app> wizard:<branch>`.'
+              );
+              return;
+            }
 
             // React with rocket to show we're processing
             await github.rest.reactions.createForIssueComment({
@@ -207,9 +241,12 @@ jobs:
                 source_pr_number: context.payload.issue.number,
                 source_pr_url: pr.data.html_url,
                 context_mill_ref: pr.data.head.ref,
+                // Omit the key when unpinned. The workbench then uses `main`.
+                ...(wizardRef ? { wizard_ref: wizardRef } : {}),
                 notify_slack: 'false',
                 notify_pr: 'true'
               }
             });
 
-            console.log(`Triggered wizard-ci for app: ${app}`);
+            const pinNote = wizardRef ? ` (wizard ref ${wizardRef})` : '';
+            console.log(`Triggered wizard-ci for app: ${app}${pinNote}`);

--- a/.github/workflows/wizard-ci-trigger.yml
+++ b/.github/workflows/wizard-ci-trigger.yml
@@ -158,6 +158,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       startsWith(github.event.comment.body, '/wizard-ci')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

The workbench `wizard-ci` workflow already accepts `wizard_ref` and `context_mill_ref` on the same dispatch channel. This trigger sent only `context_mill_ref`, and the wizard trigger sends only `wizard_ref`. So a change that spans both repos cannot be exercised before merge.

That is not hypothetical. #360 changes the warehouse skill's credential-batching instruction, and PostHog/wizard#1146 changes the runtime cap it has to match. They are one contract in two repos, and today a reviewer cannot run them together.

## Changes

`/wizard-ci <app>` accepts an optional `wizard:<ref>` suffix. The trigger validates the ref, then adds `wizard_ref` to the dispatch payload. Without the suffix the key is omitted entirely, so the workbench applies its own `main` default and existing behaviour is byte-identical.

The app regex is untouched. A lone pin such as `/wizard-ci wizard:foo` falls back to `all` rather than reading the pin as an app name.

**Ref validation matters here.** The workbench interpolates the ref straight into a JS string literal inside `github-script`, in a job that holds the App token. The allowlist is `[A-Za-z0-9._/-]`, max 200 characters, no `..`, no leading `-`, no leading or trailing `/`. That excludes every quote, backtick, backslash, `$` and `;`, so the literal cannot be broken out of. It also blocks path traversal and git option injection such as `--upload-pack=`. An invalid ref calls `core.setFailed` and dispatches nothing, rather than silently falling back to `main`.

Residual risk is unchanged from what `context_mill_ref` already allowed: a commenter can point CI at a branch that exists and burn CI minutes. No token scope is widened.

## Test plan

- `actionlint`: findings byte-identical to the pre-change baseline, all in untouched steps.
- YAML parses; both job keys intact.
- Behavioural: the `script:` block was extracted from the YAML and executed in Node against stubbed GitHub APIs, capturing the dispatch payload across every command form. Legacy forms produce identical payloads with no `wizard_ref` key; pin forms attach it; hostile refs fail with no dispatch.

Companion PR: PostHog/wizard#1153 mirrors this with a `context-mill:<ref>` suffix.
