### PR TITLE
feat: add google-adk variant to ai-observability skill

### DIFF
--- a/context/skills/ai-observability/config.yaml
+++ b/context/skills/ai-observability/config.yaml
@@ -426,6 +426,15 @@ variants:
       - https://posthog.com/docs/ai-observability/installation/mastra.md
       - https://posthog.com/docs/libraries/node.md
 
+  - id: google-adk
+    framework: google-adk
+    display_name: Google ADK
+    description: PostHog AI Observability for the Google Agent Development Kit (agent framework, Node)
+    tags: [google-adk, javascript_node, ai_observability]
+    docs_urls:
+      - https://posthog.com/docs/ai-observability/installation/google-adk.md
+      - https://posthog.com/docs/libraries/node.md
+
   - id: instructor-python
     framework: instructor
     default: true

--- a/context/skills/ai-observability/description.md
+++ b/context/skills/ai-observability/description.md
@@ -6,7 +6,7 @@ Wire up PostHog's AI Observability so calls made through {display_name} land in 
 
 This skill instruments the LLM calls the project *already makes*. It does **not** install the vendor SDK for you.
 
-Check the project's manifest for an LLM package. The catalog is far wider than the obvious providers — 68 variants covering agent frameworks (`openai-agents`, `claude-agent-sdk`, LangGraph, CrewAI, Mastra, …) and OpenAI-compatible gateways (Groq, OpenRouter, Together, Ollama, …), which an app reaches through the `openai` package plus a `baseURL` override. `1-begin.md` carries the ordered decision rules; follow them rather than matching on the first familiar package name. If no LLM SDK is present, switch to the `manual-capture` variant — it posts `$ai_generation` events directly and works standalone.
+Check the project's manifest for an LLM package. The catalog is far wider than the obvious providers — 69 variants covering agent frameworks (`openai-agents`, `claude-agent-sdk`, LangGraph, CrewAI, Mastra, …) and OpenAI-compatible gateways (Groq, OpenRouter, Together, Ollama, …), which an app reaches through the `openai` package plus a `baseURL` override. `1-begin.md` carries the ordered decision rules; follow them rather than matching on the first familiar package name. If no LLM SDK is present, switch to the `manual-capture` variant — it posts `$ai_generation` events directly and works standalone.
 
 Everything else this skill needs — PostHog credentials, instrumentation packages, env vars — the skill installs and configures itself. It does **not** require a pre-existing `posthog.init(...)`. If one is already there, reuse its env-var names in `3-instrument.md`; if not, that step sets fresh values via `set_env_values`.
 

--- a/context/skills/ai-observability/references/1-begin.md
+++ b/context/skills/ai-observability/references/1-begin.md
@@ -8,7 +8,7 @@ Pick the variant, then read the code. Do not edit anything in this step.
 
 ## Pick the variant
 
-This skill ships 68 variants. Call `load_skill_menu` with `category: "ai-observability"`. That list is the source of truth.
+This skill ships 69 variants. Call `load_skill_menu` with `category: "ai-observability"`. That list is the source of truth.
 
 Apply these rules in order. The first match wins. Frameworks wrap providers, and gateways look like OpenAI, so the order matters.
 
@@ -32,6 +32,7 @@ Apply these rules in order. The first match wins. Frameworks wrap providers, and
 | `instructor` | `instructor-{python,node}` |
 | `litellm` | `litellm` |
 | `mastra`, `@mastra/core` | `mastra` |
+| `@google/adk` | `google-adk` |
 | `convex` | `convex` |
 
 Instrument the framework, not the provider below it. A provider instrumentor keeps the model calls and loses the agent, tool, and handoff structure.


### PR DESCRIPTION
## Problem

A Node app built on Google's Agent Development Kit (`@google/adk`) asking the wizard for AI observability has nowhere to land: the framework rules never mention ADK, so the agent falls through to a provider variant and loses the agent structure. PostHog/posthog-js#4687 adds `PostHogADKPlugin`, making the plugin the supported path.

for https://github.com/PostHog/posthog-js/pull/4687

## Changes

- `@google/adk` in the manifest now routes to the new `google-adk` variant (framework table in `1-begin.md`).
- Adds the `google-adk` variant to `config.yaml`, pointing at the Google ADK install doc and the Node library doc.
- Mechanical: variant count 68 to 69 in two files.

## Testing

- All 173 skill tests pass locally with the variant present.
- Not run: `pnpm build`. Doc fetches fail behind this sandbox's TLS interception, and the variant's install doc URL only goes live with the posthog.com page.

## Release notes

Merge wants `mcp-publish` plus a semver label so the variant reaches users. The posthog onboarding PR and the posthog.com page must land first: the build fetches the install doc and fails on a 404.

## 🤖 Agent context

Written by Claude Code from PostHog/posthog-js#4687, mirroring #373 (the Go OTel variant rollout). Skills invoked: writing-pr-descriptions, writing-user-facing-copy.
