### PR TITLE
add /latest path to context mill aws cdn

### DIFF
--- a/.github/actions/mirror-to-s3/action.yml
+++ b/.github/actions/mirror-to-s3/action.yml
@@ -40,6 +40,25 @@ inputs:
       every published artifact.
     required: false
     default: "https://context-mill.posthog.com"
+  verify-origin:
+    description: >-
+      Send verification requests here instead of to base-url's host, so the
+      mirror is verifiable before base-url has a DNS record. Artifacts still bake
+      base-url and are still asserted to.
+    required: false
+    default: ""
+  flip-latest:
+    description: >-
+      Move the /latest pointer to this prefix once it verifies. The one
+      irreversible step, so only build-release.yml sets it.
+    required: false
+    default: "false"
+  kvs-arn:
+    description: >-
+      CloudFront KeyValueStore holding the `latest` key
+      (secrets.AWS_CONTEXT_MILL_RELEASES_KVS_ARN).
+    required: false
+    default: ""
 
 outputs:
   prefix:
@@ -59,6 +78,7 @@ runs:
         VERSION: ${{ inputs.version }}
         PREFIX_IN: ${{ inputs.prefix }}
         BASE_URL: ${{ inputs.base-url }}
+        VERIFY_ORIGIN: ${{ inputs.verify-origin }}
       run: |
         set -euo pipefail
         PREFIX="${PREFIX_IN:-v$VERSION}"
@@ -66,6 +86,18 @@ runs:
         # The mirrored artifacts must resolve under the prefix they are uploaded
         # to, or every download URL in them 404s.
         echo "base=${BASE_URL%/}/$PREFIX" >> "$GITHUB_OUTPUT"
+
+        # Empty expect-host means "same host as the base", verify-mirror.js's default.
+        if [ -n "$VERIFY_ORIGIN" ]; then
+          echo "verify-base=${VERIFY_ORIGIN%/}/$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "latest-base=${VERIFY_ORIGIN%/}/latest" >> "$GITHUB_OUTPUT"
+          echo "expect-host=$(printf '%s' "${BASE_URL%/}" | sed -E 's#^https?://##')" >> "$GITHUB_OUTPUT"
+          echo "Verifying via ${VERIFY_ORIGIN%/} while asserting URLs point at ${BASE_URL%/}"
+        else
+          echo "verify-base=${BASE_URL%/}/$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "latest-base=${BASE_URL%/}/latest" >> "$GITHUB_OUTPUT"
+          echo "expect-host=" >> "$GITHUB_OUTPUT"
+        fi
 
     # posthog-cloud-infra pins this same SHA; keep them in step.
     - name: Configure AWS credentials
@@ -132,3 +164,75 @@ runs:
         COUNT=$(wc -l < /tmp/mirror-local.txt | tr -d ' ')
         echo "count=$COUNT" >> "$GITHUB_OUTPUT"
         echo "Verified $COUNT objects under $PREFIX/"
+
+    # The step above proves the objects landed. This proves a consumer can fetch
+    # them: the CDN, the OAC, the bucket policy, and the baked-in URLs.
+    - name: Verify the mirror over HTTPS
+      shell: bash
+      env:
+        BASE: ${{ steps.resolve.outputs.verify-base }}
+        EXPECT_HOST: ${{ steps.resolve.outputs.expect-host }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        node scripts/verify-mirror.js "$BASE" \
+          --expect-version "$VERSION" --expect-host "$EXPECT_HOST"
+
+    # Describe and PutKey are granted by the same policy statement, so a dry run
+    # can prove the flip's permissions without moving anything.
+    - name: Check the release role can reach the key-value store
+      if: ${{ inputs.flip-latest != 'true' && inputs.kvs-arn != '' }}
+      shell: bash
+      env:
+        KVS_ARN: ${{ inputs.kvs-arn }}
+      run: |
+        set -euo pipefail
+        aws cloudfront-keyvaluestore describe-key-value-store \
+          --kvs-arn "$KVS_ARN" --query ETag --output text > /dev/null
+        echo "Key-value store reachable; PutKey rides the same policy statement"
+
+    # The publishing step. Everything above is invisible, so a failure there
+    # leaves /latest on the previous good release.
+    - name: Point /latest at this release
+      if: ${{ inputs.flip-latest == 'true' }}
+      shell: bash
+      env:
+        KVS_ARN: ${{ inputs.kvs-arn }}
+        PREFIX: ${{ steps.resolve.outputs.prefix }}
+      run: |
+        set -euo pipefail
+        if [ -z "$KVS_ARN" ]; then
+          echo "::error::flip-latest is true but kvs-arn is empty — /latest would silently not move"
+          exit 1
+        fi
+        # --if-match: two releases racing means the loser gets a 412 and fails
+        # loudly, rather than last-write-wins leaving /latest on the older one.
+        ETAG=$(aws cloudfront-keyvaluestore describe-key-value-store \
+          --kvs-arn "$KVS_ARN" --query ETag --output text)
+        aws cloudfront-keyvaluestore put-key \
+          --kvs-arn "$KVS_ARN" --key latest --value "$PREFIX" --if-match "$ETAG"
+        echo "/latest now points at $PREFIX"
+
+    - name: Verify /latest serves this release
+      if: ${{ inputs.flip-latest == 'true' }}
+      shell: bash
+      env:
+        LATEST_BASE: ${{ steps.resolve.outputs.latest-base }}
+        EXPECT_HOST: ${{ steps.resolve.outputs.expect-host }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        # The write reaches edges in seconds, so an immediate check can race it and
+        # see the old version — a skew, not a torn read. Retry rather than fail.
+        # Checksums are skipped: same objects the versioned run just hashed.
+        for attempt in 1 2 3 4 5 6; do
+          if node scripts/verify-mirror.js "$LATEST_BASE" \
+               --expect-version "$VERSION" --expect-host "$EXPECT_HOST" \
+               --checksum-sample 0; then
+            exit 0
+          fi
+          echo "attempt ${attempt}: /latest has not caught up yet, retrying in 10s"
+          sleep 10
+        done
+        echo "::error::/latest did not serve ${VERSION} within 60s of the flip"
+        exit 1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -406,10 +406,10 @@ jobs:
       # If anything release-critical failed, `publish` never ran, its conclusion
       # isn't 'success', and the mirror correctly stays skipped.
       #
-      # Nothing consumes these objects yet: the bucket is private with no CDN in
-      # front of it. That arrives in a later phase, at which point these same
-      # objects become publicly fetchable with no re-upload, because the URLs
-      # baked into them already point at the final hostname.
+      # The action uploads the versioned prefix, verifies it over HTTPS, and only
+      # then moves /latest to it. Ordering is the safety argument: the prefix is
+      # immutable and unreferenced until the pointer moves, so any failure before
+      # that leaves /latest on the previous good release.
       - name: Mirror release to S3
         id: mirror
         if: ${{ !cancelled() && steps.publish.conclusion == 'success' }}
@@ -419,6 +419,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_ROLE_ARN }}
           bucket: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_BUCKET }}
           aws-region: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_REGION }}
+          # The only caller that moves the pointer.
+          flip-latest: "true"
+          kvs-arn: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_KVS_ARN }}
+          # TEMPORARY: context-mill.posthog.com has no DNS record yet.
+          # DELETE THIS LINE once the CNAME is live.
+          verify-origin: "https://d3pmc2dxh35inl.cloudfront.net"
 
       # always(), because the S3 mirror is the only step after the release is
       # already published. If the mirror fails we still want the release summary
@@ -438,6 +444,7 @@ jobs:
           # prefix and object count are the useful parts anyway.
           if [ -n "$MIRROR_PREFIX" ]; then
             echo "- **S3 mirror:** \`$MIRROR_PREFIX/\` ($MIRROR_COUNT objects)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Mirror URL:** https://context-mill.posthog.com/latest/skill-menu.json" >> $GITHUB_STEP_SUMMARY
           else
             echo "- **S3 mirror:** :warning: did not complete — the GitHub release above is published and unaffected" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/mirror-dryrun.yml
+++ b/.github/workflows/mirror-dryrun.yml
@@ -73,6 +73,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_ROLE_ARN }}
           bucket: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_BUCKET }}
           aws-region: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_REGION }}
+          # Permissions probe only — flip-latest stays false here.
+          kvs-arn: ${{ secrets.AWS_CONTEXT_MILL_RELEASES_KVS_ARN }}
+          # TEMPORARY: remove alongside the same line in build-release.yml.
+          verify-origin: "https://d3pmc2dxh35inl.cloudfront.net"
 
       - name: Dry run summary
         env:

--- a/scripts/lib/tests/verify-mirror.test.js
+++ b/scripts/lib/tests/verify-mirror.test.js
@@ -40,11 +40,13 @@ function makeMirror({ origin = HOST, menus = {}, overrides = {}, omitFromSums = 
 
     const routes = { ...bodies, SHA256SUMS: sums + '\n', ...overrides };
     const requested = [];
+    const expectedOrigin = new URL(origin).origin;
 
     const fetchImpl = async (url, options = {}) => {
         requested.push({ url, method: options.method ?? 'GET' });
-        const { pathname } = new URL(url);
-        if (!url.startsWith(origin)) return response(404, 'wrong origin');
+        const parsed = new URL(url);
+        const { pathname } = parsed;
+        if (parsed.origin !== expectedOrigin) return response(404, 'wrong origin');
 
         // /latest is the edge function's job; model it by serving both prefixes.
         const name = pathname.replace(`/v${VERSION}/`, '').replace('/latest/', '');
@@ -212,7 +214,8 @@ describe('verifyMirror', () => {
                 expectHost: 'context-mill.posthog.com',
             });
             expect(result.failures).toEqual([]);
-            expect(requested.every(r => r.url.startsWith(CDN))).toBe(true);
+            const cdnOrigin = new URL(CDN).origin;
+            expect(requested.every(r => new URL(r.url).origin === cdnOrigin)).toBe(true);
         });
 
         // The action always passes --expect-host, empty once DNS resolves.

--- a/scripts/lib/tests/verify-mirror.test.js
+++ b/scripts/lib/tests/verify-mirror.test.js
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import { verifyMirror, parseSha256Sums, parseArgs } from '../../verify-mirror.js';
+import { REPO_URL } from '../constants.js';
+
+const VERSION = '1.50.0';
+const HOST = 'https://context-mill.posthog.com';
+const CDN = 'https://d111111abcdef8.cloudfront.net';
+const VERSIONED = `${HOST}/v${VERSION}`;
+
+const sha256 = body => crypto.createHash('sha256').update(body).digest('hex');
+
+const skillMenu = (base = VERSIONED, version = VERSION) => ({
+    version: '1.0',
+    buildVersion: version,
+    categories: {
+        audit: [{ id: 'audit-events', name: 'Audit events', downloadUrl: `${base}/audit-events.zip` }],
+    },
+    cliEntries: [],
+});
+
+const agentMenu = (base = VERSIONED, version = VERSION) => ({
+    version: '1.0',
+    buildVersion: version,
+    agents: [{ id: 'report', flow: 'integration-v2', downloadUrl: `${base}/agents-report.md` }],
+});
+
+/** An in-memory mirror over a fake fetch. `origin` is where requests must arrive. */
+function makeMirror({ origin = HOST, menus = {}, overrides = {}, omitFromSums = [] } = {}) {
+    const bodies = {
+        'skill-menu.json': JSON.stringify(menus.skill ?? skillMenu()),
+        'agent-menu.json': JSON.stringify(menus.agent ?? agentMenu()),
+        'audit-events.zip': 'ZIPBYTES',
+        'agents-report.md': '# report',
+    };
+    const sums = Object.entries(bodies)
+        .filter(([name]) => !omitFromSums.includes(name))
+        .map(([name, body]) => `${sha256(body)}  ${name}`)
+        .join('\n');
+
+    const routes = { ...bodies, SHA256SUMS: sums + '\n', ...overrides };
+    const requested = [];
+
+    const fetchImpl = async (url, options = {}) => {
+        requested.push({ url, method: options.method ?? 'GET' });
+        const { pathname } = new URL(url);
+        if (!url.startsWith(origin)) return response(404, 'wrong origin');
+
+        // /latest is the edge function's job; model it by serving both prefixes.
+        const name = pathname.replace(`/v${VERSION}/`, '').replace('/latest/', '');
+        const entry = routes[name];
+        if (entry === undefined) return response(404, 'not found');
+        if (typeof entry === 'object') return response(entry.status, entry.body ?? '');
+        return response(200, entry);
+    };
+
+    return { fetchImpl, requested };
+}
+
+function response(status, body) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => body,
+        arrayBuffer: async () => Buffer.from(body),
+    };
+}
+
+const run = (options = {}) =>
+    verifyMirror({ base: VERSIONED, checksumSample: 10, ...options });
+
+describe('verifyMirror', () => {
+    it('passes on a well-formed mirror', async () => {
+        const { fetchImpl } = makeMirror();
+        const result = await run({ fetchImpl });
+        expect(result.failures).toEqual([]);
+        expect(result.ok).toBe(true);
+        expect(result.checked).toBe(4);
+    });
+
+    it('probes every object in SHA256SUMS, not just the ones a menu references', async () => {
+        const { fetchImpl, requested } = makeMirror();
+        await run({ fetchImpl });
+        const headed = requested.filter(r => r.method === 'HEAD').map(r => r.url);
+        expect(headed).toContain(`${VERSIONED}/skill-menu.json`);
+        expect(headed).toContain(`${VERSIONED}/audit-events.zip`);
+    });
+
+    it('fails when a download URL still points at GitHub', async () => {
+        const { fetchImpl } = makeMirror({
+            menus: { skill: skillMenu(`${REPO_URL}/releases/download/v${VERSION}`) },
+        });
+        const result = await run({ fetchImpl });
+        expect(result.ok).toBe(false);
+        expect(result.failures.join(' ')).toContain('still point at GitHub');
+    });
+
+    it('fails when a menu carries a previous version’s asset URLs', async () => {
+        const { fetchImpl } = makeMirror({
+            menus: { skill: skillMenu(`${HOST}/v1.49.0`) },
+        });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain(`not under ${VERSIONED}/`);
+    });
+
+    it('fails when the served version is not the expected one', async () => {
+        const { fetchImpl } = makeMirror();
+        const result = await run({ fetchImpl, expectVersion: '1.51.0' });
+        expect(result.failures).toEqual([
+            'expected buildVersion 1.51.0, served menu says 1.50.0',
+        ]);
+    });
+
+    it('fails when the two menus disagree about the version', async () => {
+        const { fetchImpl } = makeMirror({
+            menus: { agent: agentMenu(VERSIONED, '1.49.0') },
+        });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain('menus disagree on version');
+    });
+
+    it('fails when a referenced file is absent from SHA256SUMS', async () => {
+        const { fetchImpl } = makeMirror({ omitFromSums: ['audit-events.zip'] });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain('absent from SHA256SUMS');
+    });
+
+    it('fails when an object in the inventory is unreachable', async () => {
+        const { fetchImpl } = makeMirror({ overrides: { 'audit-events.zip': { status: 404 } } });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain('unreachable');
+    });
+
+    it('fails when fetched bytes do not match their checksum', async () => {
+        const { fetchImpl } = makeMirror({
+            overrides: { 'audit-events.zip': { status: 200, body: 'TAMPERED' } },
+        });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain('checksum mismatch for audit-events.zip');
+    });
+
+    it('fails loudly when a menu is missing rather than reporting success', async () => {
+        const { fetchImpl } = makeMirror({ overrides: { 'agent-menu.json': { status: 404 } } });
+        const result = await run({ fetchImpl });
+        expect(result.ok).toBe(false);
+        expect(result.failures.join(' ')).toContain('agent-menu.json: expected 200, got 404');
+    });
+
+    it('fails when a menu is served but is not valid JSON', async () => {
+        const { fetchImpl } = makeMirror({
+            overrides: { 'skill-menu.json': { status: 200, body: '<html>nope' } },
+        });
+        const result = await run({ fetchImpl });
+        expect(result.failures.join(' ')).toContain('not valid JSON');
+    });
+
+    it('accepts a /latest base, whose menu points at the versioned prefix', async () => {
+        const { fetchImpl } = makeMirror();
+        const result = await run({
+            fetchImpl,
+            base: `${HOST}/latest`,
+            expectVersion: VERSION,
+        });
+        expect(result.failures).toEqual([]);
+        expect(result.buildVersion).toBe(VERSION);
+    });
+
+    it('verifies a dry-run prefix, where the prefix and the version differ on purpose', async () => {
+        const dryRunBase = `${HOST}/v0.0.0-dryrun-42`;
+        const { fetchImpl } = makeMirror({
+            menus: { skill: skillMenu(dryRunBase), agent: agentMenu(dryRunBase) },
+        });
+        // URLs declare the dry-run prefix while the fake serves the versioned one.
+        const result = await verifyMirror({
+            base: dryRunBase,
+            checksumSample: 0,
+            fetchImpl: async (url, options) =>
+                fetchImpl(url.replace('/v0.0.0-dryrun-42/', `/v${VERSION}/`), options),
+        });
+        expect(result.failures).toEqual([]);
+    });
+
+    it('retries once through a transient 5xx', async () => {
+        const { fetchImpl } = makeMirror();
+        let failuresLeft = 1;
+        const flaky = async (url, options) => {
+            if (url.endsWith('audit-events.zip') && failuresLeft-- > 0) return response(503, '');
+            return fetchImpl(url, options);
+        };
+        const result = await run({ fetchImpl: flaky });
+        expect(result.failures).toEqual([]);
+    });
+
+    it('does not retry a 404, which is a real failure rather than a blip', async () => {
+        const { fetchImpl, requested } = makeMirror({
+            overrides: { 'audit-events.zip': { status: 404 } },
+        });
+        await run({ fetchImpl });
+        // Scoped to HEAD: the checksum sample refetches, which is not a retry.
+        const attempts = requested.filter(
+            r => r.url.endsWith('audit-events.zip') && r.method === 'HEAD',
+        );
+        expect(attempts).toHaveLength(1);
+    });
+
+    describe('--expect-host', () => {
+        it('checks URLs against the declared host while fetching from another origin', async () => {
+            const { fetchImpl, requested } = makeMirror({ origin: CDN });
+            const result = await run({
+                fetchImpl,
+                base: `${CDN}/v${VERSION}`,
+                expectHost: 'context-mill.posthog.com',
+            });
+            expect(result.failures).toEqual([]);
+            expect(requested.every(r => r.url.startsWith(CDN))).toBe(true);
+        });
+
+        // The action always passes --expect-host, empty once DNS resolves.
+        it('treats an empty expect-host as no override', async () => {
+            const { fetchImpl } = makeMirror();
+            const result = await run({ fetchImpl, expectHost: '' });
+            expect(result.failures).toEqual([]);
+        });
+
+        it('still rejects a bad rewrite — the host assertion is not relaxed', async () => {
+            const { fetchImpl } = makeMirror({ origin: CDN, menus: { skill: skillMenu(`${CDN}/v${VERSION}`) } });
+            const result = await run({
+                fetchImpl,
+                base: `${CDN}/v${VERSION}`,
+                expectHost: 'context-mill.posthog.com',
+            });
+            expect(result.failures.join(' ')).toContain(`not under ${VERSIONED}/`);
+        });
+    });
+});
+
+describe('parseSha256Sums', () => {
+    it('reads well-formed lines and ignores anything else', () => {
+        const sums = parseSha256Sums(`${'a'.repeat(64)}  one.zip\n\ngarbage\n${'b'.repeat(64)}  two.md\n`);
+        expect([...sums.keys()]).toEqual(['one.zip', 'two.md']);
+    });
+});
+
+describe('parseArgs', () => {
+    it('accepts the positional base before or after flags', () => {
+        expect(parseArgs(['--expect-version', '1.50.0', VERSIONED]).base).toBe(VERSIONED);
+        expect(parseArgs([VERSIONED, '--expect-version', '1.50.0']).expectVersion).toBe('1.50.0');
+    });
+
+    it('accepts an empty --expect-host, which the composite action always passes', () => {
+        expect(parseArgs([VERSIONED, '--expect-host', '']).expectHost).toBe('');
+        expect(parseArgs([VERSIONED, '--expect-host', '']).base).toBe(VERSIONED);
+    });
+
+    it('lets --checksum-sample 0 switch off the content check', () => {
+        expect(parseArgs([VERSIONED, '--checksum-sample', '0']).checksumSample).toBe(0);
+    });
+
+    it('rejects a flag with no value instead of silently consuming the next flag', () => {
+        expect(() => parseArgs([VERSIONED, '--expect-version', '--concurrency', '4'])).toThrow(
+            /needs a value/,
+        );
+    });
+
+    it('requires a base', () => {
+        expect(() => parseArgs(['--expect-version', '1.50.0'])).toThrow(/usage/);
+    });
+});

--- a/scripts/mirror-dist.js
+++ b/scripts/mirror-dist.js
@@ -59,8 +59,12 @@ function rewriteUrls(text, froms, to) {
     return froms.reduce((acc, from) => acc.split(from).join(to), text);
 }
 
-/** Collect every URL-bearing field we expect to point at the mirror after a rewrite. */
-function collectDownloadUrls({ manifest, skillMenu, agentMenu }) {
+/**
+ * Collect every URL-bearing field we expect to point at the mirror after a
+ * rewrite. Exported so verify-mirror.js checks published artifacts against the
+ * same idea of where URLs live.
+ */
+export function collectDownloadUrls({ manifest, skillMenu, agentMenu }) {
     const urls = [];
     for (const resource of manifest?.resources ?? []) {
         if (resource.downloadUrl) urls.push(resource.downloadUrl);
@@ -106,8 +110,6 @@ export async function mirrorDist({ distDir, outDir, to, version }) {
         claimed.set(name, from);
         return path.join(outDir, name);
     };
-
-    const readJson = src => JSON.parse(fs.readFileSync(src, 'utf8'));
 
     /** Rewrite a JSON file's URLs and write it flat. Parses after replacing so a
      *  malformed result fails here rather than at a consumer. */

--- a/scripts/verify-mirror.js
+++ b/scripts/verify-mirror.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Verify a published mirror over HTTPS — the upload, the bucket policy, the CDN,
+ * and the /latest pointer. The release workflow runs it against the versioned
+ * prefix before the flip, and against /latest after.
+ *
+ *   node scripts/verify-mirror.js https://context-mill.posthog.com/v1.50.0
+ *   node scripts/verify-mirror.js https://context-mill.posthog.com/latest --expect-version 1.50.0
+ *
+ * --expect-host separates the host URLs must DECLARE from the origin bytes are
+ * FETCHED from, so a mirror is verifiable before its DNS record exists. The
+ * declared-host assertion is unchanged; only the transport moves.
+ */
+import path from 'path';
+import crypto from 'crypto';
+import { REPO_URL } from './lib/constants.js';
+import { collectDownloadUrls } from './mirror-dist.js';
+
+const DEFAULT_CONCURRENCY = 16;
+/** Enough to catch a systematically corrupt upload; hashing all 259 buys no more signal. */
+const DEFAULT_CHECKSUM_SAMPLE = 5;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+function splitBase(base) {
+    const url = new URL(base.replace(/\/+$/, ''));
+    return { origin: url.origin, prefix: url.pathname.replace(/\/+$/, '') };
+}
+
+/** Run `task` over `items` with at most `limit` in flight, preserving order. */
+async function pooled(items, limit, task) {
+    const results = new Array(items.length);
+    let next = 0;
+    const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++;
+            results[index] = await task(items[index], index);
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+/** One retry on 5xx or a dropped connection. Never on 4xx — that is the real failure. */
+async function request(fetchImpl, url, { method = 'GET' } = {}) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            const response = await fetchImpl(url, {
+                method,
+                redirect: 'follow',
+                signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            });
+            if (response.status >= 500 && attempt === 0) continue;
+            return { ok: response.ok, status: response.status, response };
+        } catch (error) {
+            if (attempt === 0) continue;
+            return { ok: false, status: 0, error: error.message ?? String(error) };
+        }
+    }
+    return { ok: false, status: 0, error: 'exhausted retries' };
+}
+
+/** Parse `<sha256>  <filename>` lines, ignoring anything else. */
+export function parseSha256Sums(text) {
+    const sums = new Map();
+    for (const line of text.split('\n')) {
+        const match = line.match(/^([0-9a-f]{64})\s+(.+)$/);
+        if (match) sums.set(match[2], match[1]);
+    }
+    return sums;
+}
+
+/** Collects failures rather than throwing, so one run reports every problem. */
+export async function verifyMirror({
+    base,
+    expectVersion = null,
+    expectHost = null,
+    concurrency = DEFAULT_CONCURRENCY,
+    checksumSample = DEFAULT_CHECKSUM_SAMPLE,
+    fetchImpl = fetch,
+    log = () => {},
+}) {
+    const failures = [];
+    const fail = message => failures.push(message);
+
+    const { origin, prefix } = splitBase(base);
+    // What URLs must say vs. where bytes come from. Equal unless --expect-host.
+    const declaredOrigin = expectHost ? `https://${expectHost}` : origin;
+    const toFetchable = url =>
+        declaredOrigin === origin ? url : origin + url.slice(declaredOrigin.length);
+
+    const fetchJson = async name => {
+        const url = `${origin}${prefix}/${name}`;
+        const { ok, status, response, error } = await request(fetchImpl, url);
+        if (!ok) {
+            fail(`${name}: expected 200, got ${error ? `${error}` : status} (${url})`);
+            return null;
+        }
+        try {
+            return JSON.parse(await response.text());
+        } catch (parseError) {
+            fail(`${name}: served but not valid JSON — ${parseError.message}`);
+            return null;
+        }
+    };
+
+    const [skillMenu, agentMenu] = await Promise.all([
+        fetchJson('skill-menu.json'),
+        fetchJson('agent-menu.json'),
+    ]);
+    if (!skillMenu || !agentMenu) return { ok: false, failures, checked: 0 };
+
+    // Disagreeing menus mean two builds got mixed into one prefix.
+    const buildVersion = skillMenu.buildVersion;
+    if (!buildVersion) fail('skill-menu.json has no buildVersion');
+    if (agentMenu.buildVersion !== buildVersion) {
+        fail(
+            `menus disagree on version: skill-menu.json says ${buildVersion}, ` +
+                `agent-menu.json says ${agentMenu.buildVersion}`,
+        );
+    }
+    if (expectVersion && buildVersion !== expectVersion) {
+        fail(`expected buildVersion ${expectVersion}, served menu says ${buildVersion}`);
+    }
+    if (failures.length > 0) return { ok: false, failures, checked: 0 };
+
+    // Asset URLs always name an immutable prefix, so only /latest has to derive it
+    // from the menu. Reading a prefix directly also covers dry runs, which upload
+    // to v0.0.0-dryrun-<run_id> where prefix and version differ on purpose.
+    const versionedBase =
+        prefix === '/latest' ? `${declaredOrigin}/v${buildVersion}` : `${declaredOrigin}${prefix}`;
+    log(`menu buildVersion ${buildVersion}; asset URLs must live under ${versionedBase}/`);
+
+    const urls = collectDownloadUrls({ skillMenu, agentMenu });
+    if (urls.length === 0) fail('menus contain no download URLs at all');
+
+    // A mirrored menu pointing back at GitHub rescues the menu fetch and loses
+    // every asset fetch — the exact failure this origin exists to prevent.
+    const github = urls.filter(url => url.includes(`${REPO_URL}/releases`));
+    if (github.length > 0) {
+        fail(`${github.length} download URL(s) still point at GitHub, e.g. ${github[0]}`);
+    }
+
+    const stray = urls.filter(url => !url.startsWith(`${versionedBase}/`));
+    if (stray.length > 0) {
+        fail(`${stray.length} download URL(s) are not under ${versionedBase}/, e.g. ${stray[0]}`);
+    }
+
+    // SHA256SUMS is the release's own inventory: the complete object set, and a
+    // superset of what the menus reference.
+    const sumsResponse = await request(fetchImpl, toFetchable(`${versionedBase}/SHA256SUMS`));
+    let sums = new Map();
+    if (!sumsResponse.ok) {
+        fail(`SHA256SUMS: expected 200, got ${sumsResponse.error ?? sumsResponse.status}`);
+    } else {
+        sums = parseSha256Sums(await sumsResponse.response.text());
+        if (sums.size === 0) fail('SHA256SUMS is present but contains no usable entries');
+    }
+
+    const missing = urls
+        .map(url => path.posix.basename(new URL(url).pathname))
+        .filter(name => sums.size > 0 && !sums.has(name));
+    if (missing.length > 0) {
+        fail(`${missing.length} referenced file(s) absent from SHA256SUMS, e.g. ${missing[0]}`);
+    }
+
+    const objectUrls = [...sums.keys()].map(name => `${versionedBase}/${name}`);
+    const probes = await pooled(objectUrls, concurrency, async url => {
+        const result = await request(fetchImpl, toFetchable(url), { method: 'HEAD' });
+        return { url, ...result };
+    });
+    const unreachable = probes.filter(probe => !probe.ok);
+    for (const probe of unreachable.slice(0, 5)) {
+        fail(`unreachable: ${probe.url} → ${probe.error ?? probe.status}`);
+    }
+    if (unreachable.length > 5) {
+        fail(`…and ${unreachable.length - 5} more unreachable object(s)`);
+    }
+
+    // Evenly spaced over the sorted inventory, so a failure is reproducible.
+    const names = [...sums.keys()].sort();
+    const sampleCount = Math.min(checksumSample, names.length);
+    const sample = Array.from(
+        { length: sampleCount },
+        (_, i) => names[Math.floor((i * names.length) / sampleCount)],
+    );
+    await pooled(sample, concurrency, async name => {
+        const url = toFetchable(`${versionedBase}/${name}`);
+        const result = await request(fetchImpl, url);
+        if (!result.ok) return;
+        const body = Buffer.from(await result.response.arrayBuffer());
+        const digest = crypto.createHash('sha256').update(body).digest('hex');
+        if (digest !== sums.get(name)) {
+            fail(`checksum mismatch for ${name}: SHA256SUMS says ${sums.get(name)}, got ${digest}`);
+        }
+    });
+
+    log(
+        `checked ${urls.length} menu URLs, ${objectUrls.length} objects, ` +
+            `${sample.length} checksums`,
+    );
+    return { ok: failures.length === 0, failures, checked: objectUrls.length, buildVersion };
+}
+
+const USAGE =
+    'usage: node scripts/verify-mirror.js <base> [--expect-version <v>] ' +
+    '[--expect-host <host>] [--concurrency <n>] [--checksum-sample <n>]';
+
+/** Positional base plus `--flag value` pairs, in any order. */
+export function parseArgs(argv) {
+    const flags = new Map();
+    const positional = [];
+    for (let i = 0; i < argv.length; i++) {
+        if (!argv[i].startsWith('--')) {
+            positional.push(argv[i]);
+            continue;
+        }
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith('--')) {
+            throw new Error(`${argv[i]} needs a value\n${USAGE}`);
+        }
+        flags.set(argv[i].slice(2), value);
+        i++;
+    }
+    const [base] = positional;
+    if (!base) throw new Error(USAGE);
+
+    // Absent vs. zero, so --checksum-sample 0 switches the content check off.
+    const number = (name, fallback) => {
+        if (!flags.has(name)) return fallback;
+        const parsed = Number(flags.get(name));
+        if (!Number.isInteger(parsed) || parsed < 0) {
+            throw new Error(`--${name} must be a non-negative integer`);
+        }
+        return parsed;
+    };
+    return {
+        base,
+        expectVersion: flags.get('expect-version') ?? null,
+        expectHost: flags.get('expect-host') ?? null,
+        concurrency: number('concurrency', DEFAULT_CONCURRENCY) || DEFAULT_CONCURRENCY,
+        checksumSample: number('checksum-sample', DEFAULT_CHECKSUM_SAMPLE),
+    };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+    const options = parseArgs(process.argv.slice(2));
+    const { ok, failures, checked } = await verifyMirror({
+        ...options,
+        log: message => console.log(message),
+    });
+    if (!ok) {
+        console.error(`\nMirror verification FAILED for ${options.base}:`);
+        for (const failure of failures) console.error(`  - ${failure}`);
+        process.exit(1);
+    }
+    console.log(`Mirror verified: ${options.base} (${checked} objects reachable)`);
+}


### PR DESCRIPTION
Making the latest context mill version available in AWS CDN + S3 at `{aws-cdn}/latest/*`