### PR TITLE
feat(flag-health): add PostHog flag roster alignment audit skill

### DIFF
--- a/context/skills/flag-health/config.yaml
+++ b/context/skills/flag-health/config.yaml
@@ -1,0 +1,18 @@
+type: skill
+template: description.md
+description: Audit where a PostHog integration's code and its actual flag configuration have drifted apart — ghost keys, stale rollouts, undocumented long-lived flags, unreferenced active flags, and multivariate flags misread as booleans
+tags: [best-practices]
+cli:
+  role: command
+  parentCommand: audit
+  command: flag-health
+references:
+  preamble: "**Read ONLY this file.** Do not read any other reference file until this one tells you to."
+shared_docs:
+  - https://posthog.com/docs/feature-flags/cutting-costs.md
+  - https://posthog.com/docs/feature-flags/cleaning-up-stale-flags.md
+variants:
+  - id: all
+    display_name: PostHog audit — flag roster alignment
+    tags: [best-practices]
+    docs_urls: []

--- a/context/skills/flag-health/description.md
+++ b/context/skills/flag-health/description.md
@@ -1,0 +1,80 @@
+# PostHog Audit — Flag Roster Alignment
+
+This skill finds places where a project's code and its actual PostHog flag configuration have drifted apart. **Read-only** — the only file you create is the final audit report. The audit never mutates PostHog state and never edits project source.
+
+Every check here needs **both sides at once** — the repository and PostHog's live flag roster — which is the point of this skill existing as a packaged tool rather than a one-off agent prompt: an agent pointed only at the repo can reason about code quality, but it cannot see whether a flag key it finds still exists in PostHog, what a flag's real rollout percentage is, or whether a flag is multivariate. These findings only exist because both sides were checked together:
+
+- **`ff-active-but-unreferenced`** — a flag is active in PostHog with zero references anywhere in the codebase. Still evaluated (and billed) on every request.
+- **`ff-ghost-flag-key`** — code calls a flag key that doesn't exist in PostHog's roster. The SDK silently returns a default; the branch behind it never runs, with no error.
+- **`ff-stale-full-rollout`** — a flag has been pinned at 100% or 0% for 30+ days, and the code still has a live branch on it. The decision is made; the branch is dead weight nobody can reason about.
+- **`ff-multivariate-as-boolean`** — PostHog says a flag has variants; every code call site reads it as a plain on/off. The variant information the flag was built to carry is being silently discarded.
+
+One check is the deliberate exception — it has no code side at all:
+
+- **`ff-flag-missing-metadata`** — a long-lived, fully-decided flag (the same candidate set `ff-stale-full-rollout` looks at) has no tags. (PostHog's flag API has no separate description field — `name` doubles as the description and is populated for nearly every flag at creation, so it isn't a usable "documented vs. not" signal on its own; tags are.) It's included because it's what makes `ff-stale-full-rollout`'s own exclusion logic trustworthy: that check is supposed to skip a flag tagged `keep`/`ops`/`kill-switch`, but that only works if someone tagged it. This check surfaces the flags where nobody did, so the team can decide intent before this skill (or anyone else) treats "looks abandoned" as "is abandoned."
+
+## Workflow
+
+The audit runs as a step chain. **The exact step list lives in the reference files themselves, not in this overview.** Step 1 lives at `references/1-presence.md`; each step file ends with a `next_step:` frontmatter pointer to the next, and the final step has `next_step: null`. Follow them in the order they point.
+
+The audit ledger is seeded with one pending check per rule above. **Each step gracefully handles a missing check id**: if a step's expected id is not in the ledger, it skips its `audit_resolve_checks` call for that id and continues. Use `mcp__wizard-tools__audit_resolve_checks` to patch each check as you finish it.
+
+**Start by reading the path relative to this file at `references/1-presence.md`.** Do not Glob, ls, or find the skill directory. Do not preload future steps. Do not re-read a step file once you've moved past it. Do not re-read SKILL.md.
+
+`ToolSearch` is only for loading a tool by exact name when the SDK has it deferred (e.g. `select:Grep`). Do **not** use it to browse for other tools — every tool the audit needs (`Glob`, `Grep`, `Read`, `Write`, `Bash`, the named `mcp__wizard-tools__audit_*` tools) is already named in this skill. PostHog access goes through its single `exec` tool, described in the check-dispatch reference.
+
+**Do not call `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.** The audit doesn't track its own task list — progress comes from the audit ledger plus `[STATUS]` lines.
+
+## Live activity — `[STATUS]`
+
+The "Working on …" banner reads from `[STATUS]` lines you emit in plain text. Whenever you start a new sub-step, write a line like:
+
+```
+[STATUS] Cross-referencing flag roster against code
+```
+
+The wizard intercepts these and updates the spinner. Use them freely — they are cheap.
+
+## Audit checks ledger
+
+The ledger lives at `.posthog-audit-checks.json` and is rendered live in the "Audit plan" tab. It is owned by MCP tools — **never `Write` this file directly**:
+
+- `mcp__wizard-tools__audit_resolve_checks({ updates })` — patch one or more checks by `id`. Each `update` is `{ id, status, file?, details? }`. Batch updates from the same step into a single call.
+
+All audit ledger calls are atomic and serialize internally — **concurrent calls from parallel subagents cannot lose updates**, so feel free to fan out runtime checks across `Agent` subagents when a step says so.
+
+### Check entry shape
+
+- `id` — stable kebab-case slug. Reuse the existing seeded ids exactly when calling `audit_resolve_checks`.
+- `area` — this skill seeds one area: `Flag Roster Alignment`.
+- `label` — short human name.
+- `status` — `pending` | `pass` | `error` | `warning` | `suggestion`.
+- `file` — optional `path:line` for findings tied to a location. Project-wide findings (most of these are) leave it blank.
+- `details` — optional one-line explanation.
+
+After the final step writes the report, delete `.posthog-audit-checks.json`.
+
+## Severity levels
+
+- `warning`: A confirmed drift between code and PostHog — the SDK is silently doing the wrong thing, or a dead code path ships in every build.
+- `suggestion`: A candidate that needs a human's judgment before it's actionable (unclear code impact, no owner to confirm intent), or a best-practice gap (missing metadata).
+
+This skill doesn't use `error` — nothing it finds is a crash or data-loss risk; the worst case is a silent behavior gap, which is a `warning`, not an `error`.
+
+## Key principles
+
+- **Read-only**: Do not edit project source files or PostHog flag configuration. The only file you create is the audit report.
+- **Evidence-based**: Every finding names the flag key and cites the PostHog state it's based on (rollout %, last-modified date, variant list) in `details`.
+- **Never recommend a one-step delete.** A flag that looks fully decided or ghosted still needs its code path removed and its removal confirmed before the flag itself is disabled or deleted in PostHog — deleting a flag while a live client still evaluates it flips that client to the off path, a production behavior change, not a no-op. Findings that suggest removal always recommend the staged sequence: remove the call site → deploy → confirm calls stop → then disable/delete in PostHog.
+- **A disqualified finding is not a failed check.** A flag that looks stale or ghosted but is experiment-linked, remote-config typed, referenced by another flag's release conditions, read only for its payload, or carries an exclusion tag (`keep`, `ops`, `kill-switch`) is load-bearing. Recording *why* a candidate was disqualified is as much the check's job as flagging one that wasn't.
+- **Graceful MCP fallback**: Every check here needs PostHog MCP access. When it's unavailable, auth fails, or a call errors after one retry: resolve as `suggestion` with `details: "PostHog MCP unavailable — could not read <what>"` and `mcp_skipped: true`. Do not block the audit — resolve the other checks normally.
+
+## Abort statuses
+
+Report abort states with `[ABORT]` prefixed messages. The wizard catches these and terminates the run — do not halt yourself.
+
+- No PostHog feature flag usage found (no SDK call sites matching the flag-eval API surface)
+
+## Framework guidelines
+
+{commandments}

--- a/context/skills/flag-health/references/1-presence.md
+++ b/context/skills/flag-health/references/1-presence.md
@@ -1,0 +1,31 @@
+---
+next_step: 2-roster-checks.md
+---
+
+# Step 1 — Presence detector
+
+This step decides whether the rest of the audit has anything to look at. Run it **before** any other work. Resolve zero ledger checks here — this step is gating only.
+
+## Status
+
+Emit:
+
+```
+[STATUS] Detecting PostHog feature flag usage
+```
+
+## Action
+
+Run **one `Grep` call** with `output_mode: "files_with_matches"`, scoped to source code only — exclude `node_modules`, `vendor`, build/dist output, and documentation (`*.md`, `*.mdx`, `README*`). A match inside a doc file or a code comment isn't a real call site; a match that's just a method name with no trailing `(` (e.g. inside the PostHog snippet loader's own stub method list, or an SDK config option like `preloadFeatureFlags: true`) isn't either.
+
+- Flag API surface — any of:
+  `getFeatureFlag\(|isFeatureEnabled\(|useFeatureFlag\(|onFeatureFlags\(|reloadFeatureFlags\(|getFeatureFlagPayload\(|featureFlags\.\w+\(|posthog\.feature_enabled\(|feature_enabled\(|is_feature_enabled\(|get_feature_flag\(|get_feature_flag_payload\(`
+
+## Decision
+
+- **Zero hits anywhere in the project:** emit `[ABORT] No PostHog feature flag usage found` and stop. The wizard catches `[ABORT]` and terminates the run.
+- **Hits found:** continue.
+
+Do not read any files in this step. Do not call `audit_resolve_checks`. Do not preload future steps.
+
+Continue to **`2-roster-checks.md`**.

--- a/context/skills/flag-health/references/2-roster-checks.md
+++ b/context/skills/flag-health/references/2-roster-checks.md
@@ -1,0 +1,257 @@
+---
+next_step: 3-report.md
+---
+
+# Step 2 — Roster alignment checks
+
+This step resolves five checks **in parallel**, one subagent per check. All five need PostHog MCP access; four of the five also need the repository:
+
+- `ff-active-but-unreferenced` — PostHog + repo
+- `ff-ghost-flag-key` — PostHog + repo
+- `ff-stale-full-rollout` — PostHog + repo
+- `ff-multivariate-as-boolean` — PostHog + repo
+- `ff-flag-missing-metadata` — PostHog only, no repo side. Included because it's what makes `ff-stale-full-rollout`'s exclusion-tag logic trustworthy, not because it fits the same repo-vs-roster shape as the other four. Treat it as a documented exception, not a model for future checks in this skill.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry, each task resolves independently as `suggestion` with `mcp_skipped: true` — one task's MCP failure does not block the others.
+
+{{> mcp-tool-calling}}
+
+## Status
+
+Emit before dispatching:
+
+```
+[STATUS] Cross-referencing flag roster against code
+```
+
+## Action — dispatch five subagents in one message
+
+Make **five `Agent` tool calls in a single message** so they run concurrently. Wait for all five to return, then continue to `3-report.md`. Do not run any other tools between dispatch and the next step.
+
+The bundled `cleaning-up-stale-flags.md` and `cutting-costs.md` references hold PostHog's authoritative flag-lifecycle and cost guidance. They're typically at `.claude/skills/flag-health/references/cleaning-up-stale-flags.md` and `.claude/skills/flag-health/references/cutting-costs.md`; if a path doesn't exist, discover it with `Glob` `**/skills/flag-health/references/<name>.md`. Each subagent reads the one it's told to, once, before judging.
+
+### Task A — `ff-active-but-unreferenced`
+
+`description`: `Audit ff-active-but-unreferenced`
+
+`prompt`:
+```
+You are an audit subagent. Resolve exactly one rule and return: ff-active-but-unreferenced.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, with `details` set to compact JSON `{"mcp_skipped": true, "reason": "PostHog MCP unavailable — could not list active flags"}`. Do not block the audit.
+
+Read this skill's bundled `cutting-costs.md` reference once (typically `.claude/skills/flag-health/references/cutting-costs.md`; otherwise discover with `Glob` `**/skills/flag-health/references/cutting-costs.md`). Focus on the "unused flags still incur charges" callout — active flags continue to evaluate (and bill) even with zero code references, because survey targeting and the `/flags` endpoint evaluate all active flags. The only way to stop charges is to disable, delete, or archive the flag in PostHog (removing it from code is not enough).
+
+Step 1 — list active flags from PostHog. Prefer `feature-flag-get-all` or the equivalent listing tool. If only `execute-sql` is available, fall back to:
+
+```sql
+SELECT key
+FROM feature_flags
+WHERE active = true AND deleted = false
+```
+
+Step 2 — for each active flag key, grep the codebase for the literal key (case-sensitive). Count any reference in any source-tree file (a flag is referenced even if it appears only in a config file, a test fixture, or a comment).
+
+Rule:
+- pass: every active flag has at least one reference in the codebase.
+- suggestion: 1+ active flags have zero codebase references — they are still being evaluated (and billed) on every `/flags` request, especially via survey targeting. Recommend disabling, archiving, or deleting them in PostHog.
+
+Emit one `mcp__wizard-tools__audit_resolve_checks` call with a single update for id `ff-active-but-unreferenced`, with `file` left blank (this finding is project-wide, not tied to a single code site), and `details` as compact JSON:
+
+```
+{
+  "active_flag_count": <N>,
+  "unreferenced_active_flag_count": <N>,
+  "unreferenced_keys": ["<key>", ...],
+  "mcp_skipped": false
+}
+```
+
+Return when the call completes. Do not write the audit report.
+```
+
+### Task B — `ff-ghost-flag-key`
+
+`description`: `Audit ff-ghost-flag-key`
+
+`prompt`:
+````
+You are an audit subagent. Resolve exactly one rule and return: ff-ghost-flag-key.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, with `details` set to compact JSON `{"mcp_skipped": true, "reason": "PostHog MCP unavailable — could not list the flag roster"}`. Do not block the audit.
+
+Background: a "ghost flag" is code calling a flag key that has no flag behind it in the PostHog project — soft-deleted, never created, or renamed without updating the call site. The SDK doesn't error on an unknown key; it silently returns `false` (booleans) or `undefined` (multivariate), so the branch that was meant to run never does, with no exception and no log line. This is a term PostHog's own built-in flag monitor also uses, in the same direction (code references a key that doesn't exist) — don't confuse it with `ff-active-but-unreferenced`, which is the opposite case (a flag active in PostHog with no code reference at all).
+
+Run **one** Grep: `getFeatureFlag\(|isFeatureEnabled\(|useFeatureFlag\(|getFeatureFlagPayload\(|posthog\.feature_enabled\(|feature_enabled\(|is_feature_enabled\(|get_feature_flag\(|get_feature_flag_payload\(` — every flag-eval call site, JS and snake_case SDKs (Python, Ruby) alike.
+
+Read each file that contains a hit, once. For each call site, extract the flag key argument and classify it:
+- **String literal**, or a `const`/enum that resolves to one at the call site — a resolvable key.
+- **One hop from a local static registry** — the call site passes a variable or property access (e.g. `flag.key`, `FLAGS.HINT`) that traces back to a literal string inside a `const`/static array or object literal defined in the same file (or a file it directly imports). This is a common pattern — one array of `{ key, ... }` objects iterated to register several flags — so resolve it: read the registry definition once, substitute the literal, and treat it as resolvable. Do not let this fall through to "dynamic" by default.
+- **Genuinely dynamically constructed** — built from a template string, network response, function parameter, or any value that isn't traceable to a literal within one hop as above. A grep-based cross-reference cannot resolve these. Do not treat a dynamic key as a ghost candidate under any circumstance; record it separately as `dynamic_key_sites` and move on.
+
+Step 1 — list the full flag roster from PostHog, **not filtered to active-only** (a ghost key may be soft-deleted, not just inactive). Prefer `feature-flag-get-all` or the equivalent listing tool. If only `execute-sql` is available, fall back to:
+
+```sql
+SELECT key FROM feature_flags
+```
+
+Step 2 — for each resolvable literal key found in code, check whether it appears in the roster. A key that doesn't appear is a ghost candidate.
+
+Step 3 — before concluding a ghost, apply these guards:
+- If the flag key looks like a placeholder, example, or lives only in a test fixture / comment / commented-out line — skip it, not a real call site.
+- If nothing else in the roster is a near-match (a prefix or template match to the candidate key), the missing-key conclusion is safe. If something close exists (e.g. code calls `checkout-v2` and the roster has `checkout-v3`), note the near-match in `details` as a possible rename rather than asserting deletion.
+
+Rule:
+- pass: every resolvable literal key in code appears in the roster. (Dynamic-key sites and near-match renames don't block a pass — they're reported as informational context, not findings.)
+- warning: one or more resolvable literal keys in code do not appear anywhere in the roster — the SDK is silently returning the default for that call site on every evaluation. Recommend either creating the missing flag in PostHog (if the key was meant to exist) or removing the dead call site (if the flag was intentionally retired).
+
+Emit one `mcp__wizard-tools__audit_resolve_checks` call with a single update for id `ff-ghost-flag-key`, with `file` (path:line of the first ghost call site, if any), and `details` as compact JSON:
+
+```
+{
+  "resolvable_call_site_count": <N>,
+  "dynamic_key_site_count": <N>,
+  "ghost_keys": ["<key>", ...],
+  "examples": [
+    {"file": "<path:line>", "key": "<key>", "near_match": "<key or null>"}
+  ],
+  "mcp_skipped": false
+}
+```
+
+Return when the call completes. Do not write the audit report.
+````
+
+### Task C — `ff-stale-full-rollout`
+
+`description`: `Audit ff-stale-full-rollout`
+
+`prompt`:
+````
+You are an audit subagent. Resolve exactly one rule and return: ff-stale-full-rollout.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, with `details` set to compact JSON `{"mcp_skipped": true, "reason": "PostHog MCP unavailable — could not read flag rollout state"}`. Do not block the audit.
+
+Read this skill's bundled `cleaning-up-stale-flags.md` reference once. Background: a flag pinned at 100% or 0% rollout, with no active release conditions and no edits for 30+ days, has had its decision made — the flag itself did its job. If code still branches on it, that's a dead branch nobody can reason about: it always takes the same path, but it still adds cognitive load, review overhead, and a small but real risk of a stale flag being reused for something new (PostHog's own docs cite the 2012 Knight Capital incident as the canonical example of what a reused dead flag can cost).
+
+Step 1 — list flags from PostHog with their rollout percentage, release conditions, last-modified date, tags, and (where available) linked-experiment status. Prefer `feature-flag-get-all` or the equivalent listing tool; fall back to `execute-sql` against `feature_flags` if needed. Note: PostHog's flag API has no separate description field — the `name` field doubles as the description and is populated at creation for essentially every flag, so it isn't a usable "documented vs. not" signal on its own. Tags are the only reliable signal here.
+
+Step 2 — filter to candidates: rollout is 100% or 0%, there are no partial/percentage release conditions in between, and the flag has not been modified in 30+ days.
+
+Step 3 — apply disqualifiers before treating a candidate as a finding. Exclude and record the reason for each:
+- **Experiment-linked** (non-empty linked-experiment / `experiment_set`) — deleting or flipping this breaks the experiment's results. Never a candidate.
+- **Remote-config type** — these are long-lived config values by design, not release toggles; being "at 100%" is normal for them.
+- **Referenced by another flag's release conditions** — a flag dependency exists; changing the parent changes what the dependent serves.
+- **Exclusion-tagged** — the flag's tags contain `keep`, `ops`, or `kill-switch` (case-insensitive). Kill switches and ops toggles are meant to sit at a fixed rollout indefinitely; do not infer this from a flag's `name` text — only an explicit tag counts. If a candidate has no such tag, don't guess intent either way; pass it through as a candidate needing owner input (and note that `ff-flag-missing-metadata` is the check that surfaces the "nobody tagged this" gap on its own).
+- **Newer than 7 days** — too young to be stale under any definition; exclude even if it happens to be at 100%/0%.
+
+Step 4 — for each surviving candidate, grep the codebase for the literal flag key (reuse the pattern: `getFeatureFlag\(|isFeatureEnabled\(|useFeatureFlag\(|getFeatureFlagPayload\(|posthog\.feature_enabled\(|feature_enabled\(|is_feature_enabled\(|get_feature_flag\(|get_feature_flag_payload\(`). Read each hit once and classify:
+- **Branching usage** — the result feeds an `if`/ternary/switch that takes different code paths. This is the dead-branch case worth reporting.
+- **Payload-only usage** — the call is `getFeatureFlagPayload(...)` and the surrounding code only reads a payload value, never branches on the boolean/variant itself. A flag can sit at 100% and still serve a payload every request — that's a legitimate ongoing use, not debt. Do not report these as branching findings; note them separately.
+- **No code reference at all** — already covered by `ff-active-but-unreferenced`; don't duplicate that finding here, just note the overlap in `details` (e.g. `"note": "also flagged by ff-active-but-unreferenced"`).
+
+Rule:
+- pass: no surviving candidates after disqualification, OR every surviving candidate is payload-only or has no branching code reference.
+- suggestion: a surviving candidate has no exclusion tag and unclear code impact — needs an owner's judgment before it's actionable, not a confirmed problem.
+- warning: a surviving candidate has a branching code reference — a dead conditional shipping in every build. Recommend the staged sequence, never a one-step delete: (1) remove the call site's branching and deploy, (2) confirm `$feature_flag_called` evaluations for that key stop, (3) only then disable or delete the flag in PostHog.
+
+Emit one `mcp__wizard-tools__audit_resolve_checks` call with a single update for id `ff-stale-full-rollout`, with `file` left blank unless there's one clearly representative branching site, and `details` as compact JSON:
+
+```
+{
+  "candidate_count": <N>,
+  "disqualified_count": <N>,
+  "branching_findings": ["<key>", ...],
+  "payload_only": ["<key>", ...],
+  "needs_owner_input": ["<key>", ...],
+  "overlaps_with_unreferenced": ["<key>", ...],
+  "mcp_skipped": false
+}
+```
+
+Return when the call completes. Do not write the audit report.
+````
+
+### Task D — `ff-multivariate-as-boolean`
+
+`description`: `Audit ff-multivariate-as-boolean`
+
+`prompt`:
+````
+You are an audit subagent. Resolve exactly one rule and return: ff-multivariate-as-boolean.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, with `details` set to compact JSON `{"mcp_skipped": true, "reason": "PostHog MCP unavailable — could not read flag variant definitions"}`. Do not block the audit.
+
+Background: a multivariate flag (2+ named variants, e.g. `control` / `treatment-a` / `treatment-b`) has meaningful information in *which* variant a user got, not just whether it's "on." Reading it with a boolean-style call (`isFeatureEnabled`, or a language equivalent like `is_feature_enabled` / `featureEnabled`) collapses every non-control variant into `true` — the code can no longer tell `treatment-a` from `treatment-b`, and any variant-specific logic silently defaults to whichever branch the boolean check happens to gate. This is a correctness bug, not a lifecycle one — it's grouped with this skill's other checks only because confirming it needs PostHog's flag definition, not because it's a roster-drift finding like the other three.
+
+Step 1 — list flags from PostHog with their type and variant keys. Prefer `feature-flag-get-all` or the equivalent listing tool; fall back to `execute-sql` against `feature_flags` if needed. Build a set of multivariate flag keys (2+ variants defined).
+
+Step 2 — run **two** Greps in parallel:
+- Boolean-style reads: `isFeatureEnabled\(|is_feature_enabled\(|featureEnabled\(|posthog\.feature_enabled\(|feature_enabled\(` — capture the flag key argument at each site.
+- Variant-aware reads: `getFeatureFlag\(|useFeatureFlag\(|getFeatureFlagPayload\(|get_feature_flag\(|get_feature_flag_payload\(` — capture the flag key argument at each site.
+
+Step 3 — for each multivariate flag key from Step 1, check its call sites from Step 2:
+- If **every** call site for that key uses only the boolean-style read — flag it. The variant information is fully discarded.
+- If the key has **at least one** variant-aware read anywhere in the codebase, but also has boolean-style reads elsewhere — note it as a suggestion (mixed usage is common when a flag started boolean and grew a variant later) rather than a warning; the variant information isn't lost, just inconsistently read.
+- If a multivariate key has no code reference at all, that's `ff-active-but-unreferenced`'s job, not this check's — skip it here.
+
+Rule:
+- pass: no multivariate flag is read exclusively via a boolean-style method.
+- suggestion: a multivariate flag has mixed boolean- and variant-aware reads across the codebase — inconsistent, but not silently broken anywhere.
+- warning: a multivariate flag is read exclusively via boolean-style methods — every call site collapses its variants into on/off, and any variant-specific behavior the flag was created to drive doesn't exist in the code.
+
+Emit one `mcp__wizard-tools__audit_resolve_checks` call with a single update for id `ff-multivariate-as-boolean`, including `file` (path:line of a representative boolean-style read) and `details` as compact JSON:
+
+```
+{
+  "multivariate_flag_count": <N>,
+  "exclusively_boolean_read": ["<key>", ...],
+  "mixed_read": ["<key>", ...],
+  "examples": [
+    {"file": "<path:line>", "key": "<key>", "variant_count": <N>}
+  ],
+  "mcp_skipped": false
+}
+```
+
+Return when the call completes. Do not write the audit report.
+````
+
+### Task E — `ff-flag-missing-metadata`
+
+`description`: `Audit ff-flag-missing-metadata`
+
+`prompt`:
+````
+You are an audit subagent. Resolve exactly one rule and return: ff-flag-missing-metadata.
+
+If the MCP server is unavailable, auth fails, or any call errors after one retry: resolve with `suggestion`, with `details` set to compact JSON `{"mcp_skipped": true, "reason": "PostHog MCP unavailable — could not read flag metadata"}`. Do not block the audit.
+
+This check has no code side — it reads PostHog's flag roster only. It exists to support `ff-stale-full-rollout`: that check is supposed to skip a flag tagged `keep` / `ops` / `kill-switch`, but that exclusion only works if someone actually tagged it. This check surfaces exactly the flags where nobody did, so a human can decide intent before anyone (this skill included) treats "looks abandoned" as "is abandoned."
+
+Read this skill's bundled `cleaning-up-stale-flags.md` reference once for PostHog's flag-lifecycle guidance on ownership and documentation.
+
+Step 1 — list flags from PostHog with their rollout percentage, release conditions, last-modified date, tags, and linked-experiment status. Reuse the same candidate filter as `ff-stale-full-rollout`: rollout is 100% or 0%, no partial release conditions, not modified in 30+ days, older than 7 days, not experiment-linked, not remote-config typed, not referenced by another flag's release conditions. Scope this check to that same candidate set — a freshly created or actively-rolling-out flag doesn't need an owner yet, so don't flag it here.
+
+Step 2 — for each candidate, check whether it has at least one tag. PostHog's flag API has no separate description field — the `name` field doubles as the description and is populated for essentially every flag at creation, so its presence isn't a meaningful "documented" signal; only a tag reliably indicates someone made a deliberate decision about this flag's lifecycle.
+
+Rule:
+- pass: no surviving candidates, OR every surviving candidate has at least one tag.
+- suggestion: one or more long-lived, fully-decided flags have no tags at all — recommend the team add an explicit tag (`keep`, `ops`, `kill-switch`, or similar) so future audits can tell intentional permanence from forgotten cleanup.
+
+Emit one `mcp__wizard-tools__audit_resolve_checks` call with a single update for id `ff-flag-missing-metadata`, with `file` left blank (this finding is project-wide, not tied to a code site), and `details` as compact JSON:
+
+```
+{
+  "candidate_count": <N>,
+  "undocumented_keys": ["<key>", ...],
+  "mcp_skipped": false
+}
+```
+
+Return when the call completes. Do not write the audit report.
+````
+
+## After all five checks are resolved
+
+Continue to **`3-report.md`**.

--- a/context/skills/flag-health/references/3-report.md
+++ b/context/skills/flag-health/references/3-report.md
@@ -1,0 +1,97 @@
+---
+next_step: null
+---
+
+# Step 3 — Generate the audit report
+
+The audit report is rendered **directly from `.posthog-audit-checks.json`** — that file is the source of truth. Every check the wizard seeded for this skill ends up in the report, even passes; nothing is invented.
+
+This report is deliberately short — it has one area (Flag Roster Alignment) and five checks, so it doesn't need the multi-area scaffolding a bigger audit skill does. But it should still read the way this repo's other audit reports do: a human opens it to find out what's broken and how to fix it, not to parse a data dump. **Summary** and **Recommended actions** come first and contain everything required to act — that's the whole report for someone who just wants to know what's wrong. **Full audit** and **About this audit** are reference material for someone who wants the detail behind a finding. Do not pad the summary or the actions list with restated detail from later sections.
+
+## Status
+
+Emit:
+
+```
+[STATUS] Writing flag alignment report
+```
+
+## Action
+
+`Read` the ledger once, then transform every entry into the report below. Use `label`, `status`, `file`, and `details` from each entry verbatim where the report calls for them.
+
+`Write` `posthog-flag-health-report.md` at the project root with the structure shown below. After the report is written, delete `.posthog-audit-checks.json`.
+
+## Report template
+
+<wizard-report>
+# PostHog Flag Roster Alignment Report
+
+[1–2 sentence overview: whether PostHog MCP was available for these checks, how many flags were in scope, and whether the codebase does client-side, server-side (local evaluation), or both kinds of flag evaluation.]
+
+**Counts**
+
+- **Warnings**: [N] (confirmed drift — fix these)
+- **Suggestions**: [N] (needs an owner's call, or closes a documentation gap)
+- **Passes**: [N]
+
+**Problematic items** _(only `warning` and `suggestion` — no passes)_
+
+| Severity | Check | Flag key(s) | File |
+|----------|-------|-------------|------|
+| ⚠️ warning | [label] | `[key]` | [file:line] |
+
+If there are no problematic items, write `_Nothing found — your code and PostHog's flag configuration agree._` instead of the table, and skip straight to **Full audit**.
+
+## Recommended actions
+
+Numbered list, ordered warnings first, then suggestions. Each item is **three sentences**, in this order:
+
+1. **What's wrong** — a plain-language diagnosis derived from `details`, naming the flag key(s) involved.
+2. **Why it matters** — one sentence on the concrete consequence: what the SDK actually does differently because of this (a branch that never runs, a variant that's collapsed to a bool, a flag still billed on every request).
+3. **How to fix** — one or two short imperative sentences pointing at `file:line` (or "no single code site — see PostHog flag settings" for a project-wide finding) with the concrete change to make.
+
+Format:
+
+`N. **[label]** — [what's wrong]. _Why it matters:_ [consequence]. _Fix:_ [concrete action] at `[file:line]`.`
+
+For a `ff-stale-full-rollout` warning, the fix states the staged sequence: remove the call site's branching and deploy → confirm `$feature_flag_called` evaluations for that key stop → only then disable or delete the flag in PostHog. Never suggest a one-step delete.
+
+For a `ff-ghost-flag-key` warning, phrase the fix as a fork, since there's no flag in PostHog to stage a removal against: either create the missing flag in PostHog (if the key was meant to exist), or remove the dead call site and deploy (if the flag was intentionally retired) — don't default to one branch without saying so.
+
+Do not repeat the same finding twice: if `ff-stale-full-rollout`'s `details` notes overlap with `ff-active-but-unreferenced` for the same key, report it once under whichever check found the more specific problem (a branching dead-code reference is more specific than "no reference at all") and drop a one-clause cross-reference (e.g. "— see also the unreferenced-flags finding above") rather than writing it out twice.
+
+If there are no actions, write `_Nothing to fix._`.
+
+## Full audit
+
+### Flag Roster Alignment
+
+This area covers drift between the codebase and PostHog's live flag roster: flags active in PostHog with no code reference, code calling a flag key PostHog doesn't have, flags pinned at a fixed rollout for 30+ days with a live branch still on them, multivariate flags collapsed to booleans, and long-lived decided flags with no lifecycle tag.
+
+| Check | Status | Details |
+|-------|--------|---------|
+| [label] | [glyph — ✅ pass / ⚠️ warning / 💡 suggestion] | [one-line detail from `details`, or blank for a clean pass] |
+
+### Assumptions and blind spots
+
+In ≤3 sentences: name anything a check couldn't verify from static analysis alone — e.g. a dynamically-resolved flag key that had to be traced through a local registry rather than read as a literal, a candidate excluded only because of a tag whose intent wasn't independently confirmable, or a check that resolved via `execute-sql` fallback instead of a typed listing tool. If nothing in this run required a judgment call like that, write `_No caveats — every finding above was resolved directly from PostHog's flag data and a literal code reference._`.
+
+Only add a closing callout if a check resolved with `mcp_skipped: true` — one sentence: `[N] check(s) couldn't run without PostHog access: [labels]. Re-run once MCP is connected to cover them.` If everything resolved normally, omit this callout entirely — do not manufacture caveats.
+
+## About this audit
+
+This audit ran the PostHog `flag-health` skill — a focused, read-only check of how well the codebase's feature-flag calls line up with PostHog's actual flag configuration. It never edits project source and never changes PostHog state; the only file it writes is this report.
+
+- `warning` items are a confirmed drift between code and PostHog — the SDK is silently doing the wrong thing, or a dead code path ships in every build. Fix these.
+- `suggestion` items need an owner's judgment (unclear intent, no one to confirm) or flag a documentation gap (a long-lived flag with no tag) that makes the next audit's calls more reliable.
+
+Re-run this audit after applying fixes to confirm the drift is gone.
+
+</wizard-report>
+
+After the report is written, emit a final line so the wizard can surface the path to the user:
+
+```
+Created audit report: <absolute path to posthog-flag-health-report.md>
+```


### PR DESCRIPTION
## Summary
- New `flag-health` audit skill (`wizard audit flag-health`) that cross-references a project's feature-flag call sites against PostHog's live flag roster: ghost flag keys, active-but-unreferenced flags, stale 100%/0% rollouts still branched on in code, multivariate flags read as booleans, and long-lived flags with no lifecycle tag.
- Fixes found by dogfooding the skill end-to-end (real PostHog project + several example apps, via parallel subagents running each check for real):
  - Presence-detector grep now requires call-site syntax (`\(`) and excludes docs/node_modules/vendor — it previously false-triggered a full 5-subagent audit on 13/40 example apps that had zero real flag usage (matches were the PostHog snippet loader's stub method-name list, SDK config keys, or README prose).
  - `ff-ghost-flag-key`, `ff-stale-full-rollout`, and `ff-multivariate-as-boolean`'s grep patterns now consistently cover snake_case SDKs (Python `feature_enabled`/`get_feature_flag_payload`, etc.) — previously only one of the three tasks special-cased Python, so the other two undercounted or missed call sites in non-JS codebases.
  - `ff-ghost-flag-key`'s "dynamic key → skip" guard now resolves one hop through a local static flag registry (e.g. `flag.key` from an array of `{ key, ... }` objects) before giving up — the previous wording could cause a real ghost flag to be silently skipped as "dynamic" in that common pattern.
  - Report template restyled to match this repo's other audit skills (`audit-feature-flags`): three-sentence recommended-action items (what's wrong / why it matters / how to fix), explicitly defined status glyphs, an Assumptions-and-blind-spots section, an About-this-audit closer, and fix wording that fits `ff-ghost-flag-key`'s case (there's no existing PostHog flag to stage a removal against).

## Test plan
- [x] `npm test` — 173 tests pass
- [x] `npm run build` — skill packages cleanly into `dist/skills/flag-health.zip`
- [x] Ran the skill for real (subagent-driven, PostHog MCP live) against a real app with its own PostHog project, and against a context-mill example app — all 5 checks landed on independently-verified-correct results in both runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBZpxnSyEjzrmLLUpgPVR3